### PR TITLE
Unify header styles across main and fetch pages

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -5,59 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Put It On A Map</title>
   <link rel="shortcut icon" type="image/x-icon" href="images/favicon.ico"/>
+  <link rel="stylesheet" href="/shared.css" />
   <style>
-    :root {
-      --bg: #f5f7fb;
-      --card: #ffffff;
-      --border: #d9e2ef;
-      --text: #1c2333;
-      --muted: #5a667d;
-      --accent: #2d4f8b;
-      --accent-soft: rgba(45, 79, 139, 0.12);
-    }
-    * { box-sizing: border-box; }
-    html, body {
-      height: 100%;
-      margin: 0;
-      font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
-      background: var(--bg);
-      color: var(--text);
-    }
-    a { color: inherit; text-decoration: none; }
-    .wrap { min-height: 100%; display: flex; flex-direction: column; }
-    header {
-      padding: 28px 20px;
-      border-bottom: 1px solid var(--border);
-      background: #fff;
-    }
-    .container { max-width: 1080px; margin: 0 auto; width: 100%; }
-    .header-row {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 20px;
-    }
-    .brand {
-      display: inline-flex;
-      align-items: center;
-      gap: 12px;
-      font-weight: 600;
-    }
-    .brand div {
-      font-size: 40pt;
-      position: relative;
-      top: 12pt;
-    }
-    .brand img { width: 150px; height: auto; }
-    .nav-links {
-      display: flex;
-      gap: 14px;
-      flex-wrap: wrap;
-      font-weight: 600;
-      color: var(--muted);
-    }
-    .nav-links a { padding: 6px 10px; border-radius: 999px; border: 1px solid transparent; }
-    .nav-links a:hover { border-color: var(--border); color: var(--accent); }
     main { flex: 1; padding: 48px 20px 60px; }
     .hero {
       display: grid;
@@ -104,10 +53,6 @@
       text-align: center;
       color: var(--muted);
       font-size: 0.85rem;
-    }
-    @media (max-width: 720px) {
-      .header-row { flex-direction: column; align-items: flex-start; }
-      .brand img { width: 130px; }
     }
   </style>
 </head>

--- a/site/shared.css
+++ b/site/shared.css
@@ -1,0 +1,85 @@
+:root {
+  --bg: #f5f7fb;
+  --card: #ffffff;
+  --border: #d9e2ef;
+  --text: #1c2333;
+  --muted: #5a667d;
+  --accent: #2d4f8b;
+  --accent-soft: rgba(45, 79, 139, 0.12);
+}
+* {
+  box-sizing: border-box;
+}
+html,
+body {
+  height: 100%;
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+.wrap {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+header {
+  padding: 28px 20px;
+  border-bottom: 1px solid var(--border);
+  background: #fff;
+}
+.container {
+  max-width: 1080px;
+  margin: 0 auto;
+  width: 100%;
+}
+.header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+}
+.brand div {
+  font-size: 40pt;
+  position: relative;
+  top: 12pt;
+}
+.brand img {
+  width: 150px;
+  height: auto;
+}
+.nav-links {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  font-weight: 600;
+  color: var(--muted);
+}
+.nav-links a {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+.nav-links a:hover {
+  border-color: var(--border);
+  color: var(--accent);
+}
+@media (max-width: 720px) {
+  .header-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .brand img {
+    width: 130px;
+  }
+}

--- a/util/fetch.html
+++ b/util/fetch.html
@@ -5,32 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ArcGIS to GeoParquet Loader</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='16' r='14' fill='%232d4f8b'/%3E%3Cpath d='M9 17.5l4.5 4.5 9-11' stroke='%23fff' stroke-width='3' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E">
+  <link rel="stylesheet" href="/shared.css" />
   <style>
-    :root {
-      --bg: #f5f7fb;
-      --card: #ffffff;
-      --border: #d9e2ef;
-      --text: #1c2333;
-      --muted: #5a667d;
-      --accent: #2d4f8b;
-      --accent-soft: rgba(45, 79, 139, 0.12);
-    }
-    body { font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif; margin: 0; padding: 0; background: var(--bg); color: var(--text); }
-    header { background: #fff; border-bottom: 1px solid var(--border); padding: 1.5rem 0; }
-    main { padding: 1.5rem; max-width: 980px; margin: 0 auto; }
-    .container { max-width: 980px; margin: 0 auto; padding: 0 1.5rem; }
-    .header-top { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1.25rem; }
-    .brand { display: inline-flex; align-items: center; gap: 0.85rem; font-weight: 600; }
-    .brand div {
-      font-size: 40pt;
-      position: relative;
-      top: 12pt;
-    }
-    .brand img { width: 130px; height: auto; }
-    .home-link { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.4rem 0.85rem; border-radius: 999px; border: 1px solid var(--border); background: #fff; color: var(--accent); font-size: 0.85rem; font-weight: 600; text-decoration: none; transition: border-color 0.2s ease, box-shadow 0.2s ease; }
-    .home-link:hover { border-color: var(--accent); box-shadow: 0 6px 16px rgba(45, 79, 139, 0.15); }
-    header h1 { margin: 0 0 0.35rem; font-size: 1.9rem; }
-    header p { margin: 0; color: var(--muted); }
+    main { padding: 32px 20px 60px; }
+    .fetch-main { display: flex; flex-direction: column; gap: 1.5rem; }
+    .page-intro h1 { margin: 0 0 0.35rem; font-size: 1.9rem; }
+    .page-intro p { margin: 0; color: var(--muted); max-width: 720px; }
     section { background: var(--card); border-radius: 16px; border: 1px solid var(--border); padding: 1.2rem 1.4rem; margin-bottom: 1rem; box-shadow: 0 10px 24px rgba(21, 30, 50, 0.05); }
     label { display: block; margin-bottom: 0.2rem; margin-top: 0.2rem; font-weight: 600; }
     input[type="text"] { width: 100%; padding: 0.65rem 0.75rem; border: 1px solid var(--border); border-radius: 8px; font-size: 1rem; }
@@ -81,26 +61,29 @@
     .panel-close { background: transparent; color: var(--accent); border: none; font-size: 1.2rem; cursor: pointer; padding: 0.2rem 0.5rem; border-radius: 6px; line-height: 1; }
     .panel-close:hover { background: var(--accent-soft); }
     @media (max-width: 700px) {
-      .header-top { flex-direction: column; align-items: flex-start; }
-      header h1 { font-size: 1.6rem; }
+      .page-intro h1 { font-size: 1.6rem; }
     }
   </style>
 </head>
 <body>
   <header>
-    <div class="container">
-      <div class="header-top">
-        <a class="brand" href="/" aria-label="Put It On A Map home">
-          <img src="/images/logo.svg" alt="putitonamap logo">
-          <div>PutItOnAMap.com</div>
-        </a>
-        <a class="home-link" href="/" aria-label="Return to home">← Home</a>
-      </div>
+    <div class="container header-row">
+      <a class="brand" href="/" aria-label="Put It On A Map home">
+        <img src="/images/logo.svg" alt="putitonamap logo">
+        <div>PutItOnAMap.com</div>
+      </a>
+      <nav class="nav-links" aria-label="Primary">
+        <a href="/viz">3D Viz</a>
+        <a href="/util/fetch.html">Data Fetcher</a>
+        <a href="https://github.com/larsiusprime/geovizwiz">Source Code</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container fetch-main">
+    <div class="page-intro">
       <h1>ArcGIS Layer to GeoParquet</h1>
       <p>Load an ArcGIS endpoint, browse layers, and export a single layer as GeoParquet entirely in your browser.</p>
     </div>
-  </header>
-  <main>
     <nav class="breadcrumbs" id="breadcrumbNav" aria-label="Workflow steps">
       <button class="breadcrumb current" type="button" data-step="1">Step 1: Endpoint</button>
       <button class="breadcrumb" type="button" data-step="2" disabled>Step 2: Layers</button>


### PR DESCRIPTION
### Motivation

- Reduce duplicated CSS and header markup between the main landing page and the data fetcher to keep styling consistent.
- Provide a single shared stylesheet for base layout, brand, and primary navigation to simplify maintenance.
- Make the fetch page header match the main site header so navigation and branding are identical across pages.

### Description

- Add `site/shared.css` containing shared root variables, header, branding, and navigation styles.
- Update `site/index.html` to include the shared stylesheet via `<link rel="stylesheet" href="/shared.css" />` and remove the duplicated header CSS.
- Update `util/fetch.html` to include the shared stylesheet, replace the previous header markup with the consistent `header`/`.container.header-row` and `.nav-links` markup, and move the page title/description into the main content area using `fetch-main`/`page-intro` classes.
- Minor adjustments to inline CSS in `util/fetch.html` to rely on shared styles while keeping page-specific layout rules.

### Testing

- Launched a local HTTP server and opened `http://127.0.0.1:4173/util/fetch.html` with Playwright and captured a screenshot `artifacts/fetch-header.png`, which completed successfully.
- Changes were staged and committed successfully with the message `Unify header styles across pages`.
- No build steps for `viz` were run as part of this change.
- No automated unit tests were added or run for these layout changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695827f774888326a79eb8004dd92656)