### PR TITLE
Add GeoPackage (.gpkg) support to converter

### DIFF
--- a/util/convert.html
+++ b/util/convert.html
@@ -136,6 +136,7 @@
         <h3>Supported input formats</h3>
         <ul class="tree">
           <li>ESRI Shapefile (must be supplied as a zip file containing .shp + .dbf + .shx)</li>
+          <li>GeoPackage (.gpkg)</li>
         </ul>
       </div>
       <div id="dropZone" class="drop-zone" role="button" tabindex="0" aria-label="File upload drop zone">

--- a/util/src/apps/converterApp.js
+++ b/util/src/apps/converterApp.js
@@ -121,6 +121,7 @@ export default function startConverterApp() {
       wrapper.className = 'preview-summary';
       const layerName = layer.fileName || `Layer ${index + 1}`;
       const geometryType = layer.geometryType || 'Unknown';
+      const layerTypeLabel = layer.layerTypeLabel || 'Layer';
       const fieldInfo = layer.fields || [];
       const rowCount = Number.isFinite(layer.rowCount) ? layer.rowCount : 0;
 
@@ -128,7 +129,7 @@ export default function startConverterApp() {
       const tbody = document.createElement('tbody');
       const rows = [
         ['Layer name', layerName],
-        ['Layer type', 'Shapefile layer'],
+        ['Layer type', layerTypeLabel],
         ['Number of rows', rowCount.toLocaleString()],
         ['Geometry field', 'geometry'],
         ['Geometry type', geometryType],
@@ -396,6 +397,9 @@ export default function startConverterApp() {
     }
     if (lower.endsWith('.parquet')) {
       return `${fileNameValue.slice(0, -8)}.geoparquet`;
+    }
+    if (lower.endsWith('.gpkg')) {
+      return `${fileNameValue.slice(0, -5)}.geoparquet`;
     }
     if (lower.endsWith('.geoparquet')) {
       return fileNameValue;

--- a/util/src/apps/converterExportWorker.js
+++ b/util/src/apps/converterExportWorker.js
@@ -40,6 +40,26 @@ const loadShapefileGeoJsonWithEntries = async (zipBuffer) => {
   return { geojson, entries };
 };
 
+const loadGpkgGeoJsonWithInfo = async (file) => {
+  const gdal = await gdalPromise;
+  const { datasets, errors } = await gdal.open(file);
+  if (!datasets?.length) {
+    const err = errors?.[0] || 'GDAL could not open this GeoPackage.';
+    throw new Error(Array.isArray(err) ? err.join('\n') : String(err));
+  }
+
+  const dataset = datasets[0];
+  const out = await gdal.ogr2ogr(dataset, ['-f', 'GeoJSON']);
+  const bytes = await gdal.getFileBytes(out);
+  const geojsonText = new TextDecoder().decode(bytes);
+  const geojson = JSON.parse(geojsonText);
+  const info = dataset.info || null;
+
+  try { await gdal.close(dataset); } catch (_) {}
+
+  return { geojson, info };
+};
+
 let parquetModulePromise = null;
 let arrowHelpersPromise = null;
 let parquetInitialized = false;
@@ -75,6 +95,13 @@ const getPrjText = (entries) => {
   const prjName = Object.keys(entries).find((name) => name.toLowerCase().endsWith('.prj'));
   if (!prjName) return null;
   return textDecoder.decode(entries[prjName]);
+};
+
+const getCrsWktFromInfo = (info) => {
+  const layer = info?.layers?.[0];
+  const geometryField = layer?.geometryFields?.[0];
+  const coordinateSystem = geometryField?.coordinateSystem || layer?.coordinateSystem;
+  return coordinateSystem?.wkt || coordinateSystem?.wkt2_2019 || coordinateSystem?.wkt2_2018 || null;
 };
 
 const parseEpsgFromWkt = (wkt) => {
@@ -223,25 +250,41 @@ self.onmessage = async (event) => {
     return;
   }
 
-  sendProgress(25, 'Opening archive...');
-  const entries = readZipEntries(buffer);
-  if (!entries) {
-    self.postMessage({
-      type: 'error',
-      payload: { message: 'This file is not a supported shapefile zip. Please try another file.' }
-    });
-    return;
+  const lowerName = file.name?.toLowerCase() || '';
+  const isGeoPackage = lowerName.endsWith('.gpkg');
+  let entries = null;
+  let info = null;
+
+  if (isGeoPackage) {
+    sendProgress(25, 'Opening GeoPackage...');
+  } else {
+    sendProgress(25, 'Opening archive...');
+    entries = readZipEntries(buffer);
+    if (!entries) {
+      self.postMessage({
+        type: 'error',
+        payload: { message: 'This file is not a supported shapefile zip or GeoPackage. Please try another file.' }
+      });
+      return;
+    }
   }
 
-  sendProgress(40, 'Parsing shapefile features...');
+  sendProgress(40, isGeoPackage ? 'Parsing GeoPackage features...' : 'Parsing shapefile features...');
   let layerData;
   try {
-    const { geojson } = await loadShapefileGeoJsonWithEntries(buffer);
-    layerData = geojson;
+    if (isGeoPackage) {
+      const result = await loadGpkgGeoJsonWithInfo(file);
+      layerData = result.geojson;
+      info = result.info;
+    } else {
+      const { geojson } = await loadShapefileGeoJsonWithEntries(buffer);
+      layerData = geojson;
+    }
   } catch (err) {
+    const context = isGeoPackage ? 'We could not read this GeoPackage' : 'We could not read this shapefile';
     self.postMessage({
       type: 'error',
-      payload: { message: formatError('We could not read this shapefile', err) }
+      payload: { message: formatError(context, err) }
     });
     return;
   }
@@ -255,7 +298,8 @@ self.onmessage = async (event) => {
   const fieldEntries = Array.from(fieldTypes.entries());
   const geometryType = collectGeometryTypes(features);
   const prjText = getPrjText(entries);
-  const epsgFromWkt = parseEpsgFromWkt(prjText);
+  const wktText = prjText || getCrsWktFromInfo(info);
+  const epsgFromWkt = parseEpsgFromWkt(wktText);
 
   const Arrow = self.Arrow;
   if (!Arrow) {
@@ -272,8 +316,8 @@ self.onmessage = async (event) => {
 
   let geoMetadata;
   try {
-    const spatialRef = prjText
-      ? { wkt: prjText, wkid: epsgFromWkt, latestWkid: epsgFromWkt }
+    const spatialRef = wktText
+      ? { wkt: wktText, wkid: epsgFromWkt, latestWkid: epsgFromWkt }
       : null;
     geoMetadata = await createGeoMetadata(spatialRef, geometryType);
   } catch (err) {

--- a/util/src/apps/converterWorker.js
+++ b/util/src/apps/converterWorker.js
@@ -40,6 +40,26 @@ const loadShapefileAsGeoJson = async (zipBuffer) => {
   return { geojson, entries };
 };
 
+const loadGpkgAsGeoJson = async (file) => {
+  const gdal = await gdalPromise;
+  const { datasets, errors } = await gdal.open(file);
+  if (!datasets?.length) {
+    const err = errors?.[0] || 'GDAL could not open this GeoPackage.';
+    throw new Error(Array.isArray(err) ? err.join('\n') : String(err));
+  }
+
+  const dataset = datasets[0];
+  const out = await gdal.ogr2ogr(dataset, ['-f', 'GeoJSON']);
+  const bytes = await gdal.getFileBytes(out);
+  const text = new TextDecoder().decode(bytes);
+  const geojson = JSON.parse(text);
+  const info = dataset.info || null;
+
+  try { await gdal.close(dataset); } catch (_) {}
+
+  return { geojson, info };
+};
+
 
 const sendProgress = (percent, detail) => {
   self.postMessage({ type: 'progress', payload: { percent, detail } });
@@ -95,14 +115,29 @@ const getFieldInfo = (features) => {
   return Array.from(fieldTypes.entries()).map(([name, type]) => ({ name, type }));
 };
 
-const getCrsLabel = (entries) => {
+const getCrsLabelFromWkt = (wkt) => {
+  if (!wkt) {
+    return 'Unknown';
+  }
+  const match = wkt.match(/^(?:PROJCS|GEOGCS|LOCAL_CS|COMPD_CS)\s*\["([^"]+)"/i);
+  return match?.[1] || wkt.split(/\r?\n/)[0]?.trim() || 'Unknown';
+};
+
+const getCrsLabelFromEntries = (entries) => {
   const prjName = Object.keys(entries).find((name) => name.toLowerCase().endsWith('.prj'));
   if (!prjName) {
     return 'Unknown';
   }
   const prjText = textDecoder.decode(entries[prjName]);
-  const match = prjText.match(/^(?:PROJCS|GEOGCS|LOCAL_CS|COMPD_CS)\s*\["([^"]+)"/i);
-  return match?.[1] || prjText.split(/\r?\n/)[0]?.trim() || 'Unknown';
+  return getCrsLabelFromWkt(prjText);
+};
+
+const getCrsLabelFromInfo = (info) => {
+  const layer = info?.layers?.[0];
+  const geometryField = layer?.geometryFields?.[0];
+  const coordinateSystem = geometryField?.coordinateSystem || layer?.coordinateSystem;
+  const wkt = coordinateSystem?.wkt || coordinateSystem?.wkt2_2019 || coordinateSystem?.wkt2_2018;
+  return getCrsLabelFromWkt(wkt);
 };
 
 const readZipEntries = (buffer) => {
@@ -136,78 +171,93 @@ self.onmessage = async (event) => {
     return;
   }
 
-  sendProgress(30, 'Inspecting archive contents...');
-  let entries = readZipEntries(buffer);
-  if (!entries) {
-    self.postMessage({
-      type: 'invalid',
-      payload: {
-        label: 'Unknown',
-        message: 'Not a supported format. Upload a zipped ESRI Shapefile (.zip containing .shp + .dbf + .shx).'
-      }
-    });
-    return;
+  const lowerName = file.name?.toLowerCase() || '';
+  const isGeoPackage = lowerName.endsWith('.gpkg');
+  let entries = null;
+  let info = null;
+
+  if (!isGeoPackage) {
+    sendProgress(30, 'Inspecting archive contents...');
+    entries = readZipEntries(buffer);
+    if (!entries) {
+      self.postMessage({
+        type: 'invalid',
+        payload: {
+          label: 'Unknown',
+          message: 'Not a supported format. Upload a zipped ESRI Shapefile (.shp.zip) or a GeoPackage (.gpkg).'
+        }
+      });
+      return;
+    }
+
+    const entryNames = Object.keys(entries).map((name) => name.toLowerCase());
+    const hasShp = entryNames.some((name) => name.endsWith('.shp'));
+    const hasDbf = entryNames.some((name) => name.endsWith('.dbf'));
+    const hasShx = entryNames.some((name) => name.endsWith('.shx'));
+
+    if (!hasShp || !hasDbf) {
+      self.postMessage({
+        type: 'invalid',
+        payload: {
+          label: 'ZIP archive',
+          message: 'Not a supported format. This zip archive does not contain the required .shp and .dbf files for a valid ESRI Shapefile.'
+        }
+      });
+      return;
+    }
+
+    if (!hasShx) {
+      self.postMessage({
+        type: 'invalid',
+        payload: {
+          label: 'Partial ESRI Shapefile (missing .shx)',
+          message: 'Not a supported format. The zip archive is missing the .shx index file required for a complete ESRI Shapefile.'
+        }
+      });
+      return;
+    }
   }
 
-  const entryNames = Object.keys(entries).map((name) => name.toLowerCase());
-  const hasShp = entryNames.some((name) => name.endsWith('.shp'));
-  const hasDbf = entryNames.some((name) => name.endsWith('.dbf'));
-  const hasShx = entryNames.some((name) => name.endsWith('.shx'));
-
-  if (!hasShp || !hasDbf) {
-    self.postMessage({
-      type: 'invalid',
-      payload: {
-        label: 'ZIP archive',
-        message: 'Not a supported format. This zip archive does not contain the required .shp and .dbf files for a valid ESRI Shapefile.'
-      }
-    });
-    return;
-  }
-
-  if (!hasShx) {
-    self.postMessage({
-      type: 'invalid',
-      payload: {
-        label: 'Partial ESRI Shapefile (missing .shx)',
-        message: 'Not a supported format. The zip archive is missing the .shx index file required for a complete ESRI Shapefile.'
-      }
-    });
-    return;
-  }
-
-  sendProgress(55, 'Reading shapefile metadata...');
+  sendProgress(55, isGeoPackage ? 'Reading GeoPackage metadata...' : 'Reading shapefile metadata...');
   let layerData;
   try {
-    const { geojson, entries: zipEntries } = await loadShapefileAsGeoJson(buffer);
-    layerData = geojson;
-    entries = zipEntries;
+    if (isGeoPackage) {
+      const result = await loadGpkgAsGeoJson(file);
+      layerData = result.geojson;
+      info = result.info;
+    } else {
+      const { geojson, entries: zipEntries } = await loadShapefileAsGeoJson(buffer);
+      layerData = geojson;
+      entries = zipEntries;
+    }
   } catch (err) {
     const message = err?.message
-      ? `We found a valid zipped shapefile, but could not read its metadata. ${err.message}`
-      : 'We found a valid zipped shapefile, but could not read its metadata.';
+      ? `We found a valid ${isGeoPackage ? 'GeoPackage' : 'zipped shapefile'}, but could not read its metadata. ${err.message}`
+      : `We found a valid ${isGeoPackage ? 'GeoPackage' : 'zipped shapefile'}, but could not read its metadata.`;
     self.postMessage({ type: 'error', payload: { message } });
     return;
   }
 
   sendProgress(80, 'Summarizing layers...');
+  const layerTypeLabel = isGeoPackage ? 'GeoPackage layer' : 'Shapefile layer';
   const layers = (Array.isArray(layerData) ? layerData : [layerData]).map((layer) => {
     const features = layer?.features || [];
     return {
       fileName: layer?.fileName || 'Layer',
       rowCount: features.length,
       geometryType: getGeometryType(features),
-      fields: getFieldInfo(features)
+      fields: getFieldInfo(features),
+      layerTypeLabel
     };
   });
 
-  const crs = getCrsLabel(entries);
+  const crs = isGeoPackage ? getCrsLabelFromInfo(info) : getCrsLabelFromEntries(entries);
   sendProgress(95, 'Finalizing metadata...');
 
   self.postMessage({
     type: 'success',
     payload: {
-      label: 'ESRI Shapefile (zipped)',
+      label: isGeoPackage ? 'GeoPackage (.gpkg)' : 'ESRI Shapefile (zipped)',
       message: 'Metadata loaded. You may proceed to the conversion step.',
       layers,
       crs


### PR DESCRIPTION
### Motivation

- Extend the converter app to accept GeoPackage (`.gpkg`) inputs so users can convert GeoPackage datasets to GeoParquet as they already do with zipped shapefiles.  
- Use the vendored GDAL (`gdal3.js`) to drive only the loading/inspection step for GeoPackage files and preserve the existing GeoParquet export pipeline.  
- Surface layer/CRS metadata for GeoPackages in the same UI flow used for shapefiles.  
- Keep existing conversion/export code intact and reuse the same GeoParquet creation logic.

### Description

- Added `GeoPackage (.gpkg)` to the supported formats list in `util/convert.html`.  
- Implemented GeoPackage inspection helpers and flow: added `loadGpkgAsGeoJson`/`loadGpkgGeoJsonWithInfo` in `util/src/apps/converterWorker.js` and `util/src/apps/converterExportWorker.js` to open a `.gpkg` with GDAL and export GeoJSON for inspection/export.  
- Enhanced CRS extraction to read WKT from dataset `info` for GeoPackages and introduced `getCrsLabelFromInfo` / `getCrsWktFromInfo` helpers, while preserving the existing `.prj`-based logic for shapefile zips.  
- Updated UI and metadata rendering in `util/src/apps/converterApp.js` to display `layerTypeLabel` (e.g. `GeoPackage layer`) and to build output filenames for `.gpkg` inputs (convert `mydata.gpkg` → `mydata.geoparquet`).

### Testing

- No automated unit or integration tests were run against the modified code.  
- Performed an automated smoke check by serving the site locally and capturing `/util/convert.html` (Playwright screenshot), which verified the updated supported formats UI and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695885ca6a4c832682785cbf87eba725)