### PR TITLE
Add GeoJSON support to converter pipeline

### DIFF
--- a/util/convert.html
+++ b/util/convert.html
@@ -137,6 +137,7 @@
         <ul class="tree">
           <li>ESRI Shapefile (must be supplied as a zip file containing .shp + .dbf + .shx)</li>
           <li>GeoPackage (.gpkg)</li>
+          <li>GeoJSON (.geojson or .json)</li>
         </ul>
       </div>
       <div id="dropZone" class="drop-zone" role="button" tabindex="0" aria-label="File upload drop zone">

--- a/util/src/apps/converterApp.js
+++ b/util/src/apps/converterApp.js
@@ -395,6 +395,12 @@ export default function startConverterApp() {
     if (lower.endsWith('.zip')) {
       return `${fileNameValue.slice(0, -4)}.geoparquet`;
     }
+    if (lower.endsWith('.geojson')) {
+      return `${fileNameValue.slice(0, -8)}.geoparquet`;
+    }
+    if (lower.endsWith('.json')) {
+      return `${fileNameValue.slice(0, -5)}.geoparquet`;
+    }
     if (lower.endsWith('.parquet')) {
       return `${fileNameValue.slice(0, -8)}.geoparquet`;
     }

--- a/util/src/apps/converterExportWorker.js
+++ b/util/src/apps/converterExportWorker.js
@@ -60,6 +60,26 @@ const loadGpkgGeoJsonWithInfo = async (file) => {
   return { geojson, info };
 };
 
+const loadGeoJsonWithInfo = async (file) => {
+  const gdal = await gdalPromise;
+  const { datasets, errors } = await gdal.open(file);
+  if (!datasets?.length) {
+    const err = errors?.[0] || 'GDAL could not open this GeoJSON.';
+    throw new Error(Array.isArray(err) ? err.join('\n') : String(err));
+  }
+
+  const dataset = datasets[0];
+  const out = await gdal.ogr2ogr(dataset, ['-f', 'GeoJSON']);
+  const bytes = await gdal.getFileBytes(out);
+  const geojsonText = new TextDecoder().decode(bytes);
+  const geojson = JSON.parse(geojsonText);
+  const info = dataset.info || null;
+
+  try { await gdal.close(dataset); } catch (_) {}
+
+  return { geojson, info };
+};
+
 let parquetModulePromise = null;
 let arrowHelpersPromise = null;
 let parquetInitialized = false;
@@ -252,28 +272,41 @@ self.onmessage = async (event) => {
 
   const lowerName = file.name?.toLowerCase() || '';
   const isGeoPackage = lowerName.endsWith('.gpkg');
+  const isGeoJson = lowerName.endsWith('.geojson') || lowerName.endsWith('.json');
   let entries = null;
   let info = null;
 
   if (isGeoPackage) {
     sendProgress(25, 'Opening GeoPackage...');
+  } else if (isGeoJson) {
+    sendProgress(25, 'Opening GeoJSON...');
   } else {
     sendProgress(25, 'Opening archive...');
     entries = readZipEntries(buffer);
     if (!entries) {
       self.postMessage({
         type: 'error',
-        payload: { message: 'This file is not a supported shapefile zip or GeoPackage. Please try another file.' }
+        payload: { message: 'This file is not a supported shapefile zip, GeoPackage, or GeoJSON file. Please try another file.' }
       });
       return;
     }
   }
 
-  sendProgress(40, isGeoPackage ? 'Parsing GeoPackage features...' : 'Parsing shapefile features...');
+  let parsingLabel = 'Parsing shapefile features...';
+  if (isGeoPackage) {
+    parsingLabel = 'Parsing GeoPackage features...';
+  } else if (isGeoJson) {
+    parsingLabel = 'Parsing GeoJSON features...';
+  }
+  sendProgress(40, parsingLabel);
   let layerData;
   try {
     if (isGeoPackage) {
       const result = await loadGpkgGeoJsonWithInfo(file);
+      layerData = result.geojson;
+      info = result.info;
+    } else if (isGeoJson) {
+      const result = await loadGeoJsonWithInfo(file);
       layerData = result.geojson;
       info = result.info;
     } else {
@@ -281,7 +314,12 @@ self.onmessage = async (event) => {
       layerData = geojson;
     }
   } catch (err) {
-    const context = isGeoPackage ? 'We could not read this GeoPackage' : 'We could not read this shapefile';
+    let context = 'We could not read this shapefile';
+    if (isGeoPackage) {
+      context = 'We could not read this GeoPackage';
+    } else if (isGeoJson) {
+      context = 'We could not read this GeoJSON file';
+    }
     self.postMessage({
       type: 'error',
       payload: { message: formatError(context, err) }

--- a/util/src/apps/converterWorker.js
+++ b/util/src/apps/converterWorker.js
@@ -60,6 +60,26 @@ const loadGpkgAsGeoJson = async (file) => {
   return { geojson, info };
 };
 
+const loadGeoJsonAsGeoJson = async (file) => {
+  const gdal = await gdalPromise;
+  const { datasets, errors } = await gdal.open(file);
+  if (!datasets?.length) {
+    const err = errors?.[0] || 'GDAL could not open this GeoJSON.';
+    throw new Error(Array.isArray(err) ? err.join('\n') : String(err));
+  }
+
+  const dataset = datasets[0];
+  const out = await gdal.ogr2ogr(dataset, ['-f', 'GeoJSON']);
+  const bytes = await gdal.getFileBytes(out);
+  const text = new TextDecoder().decode(bytes);
+  const geojson = JSON.parse(text);
+  const info = dataset.info || null;
+
+  try { await gdal.close(dataset); } catch (_) {}
+
+  return { geojson, info };
+};
+
 
 const sendProgress = (percent, detail) => {
   self.postMessage({ type: 'progress', payload: { percent, detail } });
@@ -173,10 +193,11 @@ self.onmessage = async (event) => {
 
   const lowerName = file.name?.toLowerCase() || '';
   const isGeoPackage = lowerName.endsWith('.gpkg');
+  const isGeoJson = lowerName.endsWith('.geojson') || lowerName.endsWith('.json');
   let entries = null;
   let info = null;
 
-  if (!isGeoPackage) {
+  if (!isGeoPackage && !isGeoJson) {
     sendProgress(30, 'Inspecting archive contents...');
     entries = readZipEntries(buffer);
     if (!entries) {
@@ -184,7 +205,7 @@ self.onmessage = async (event) => {
         type: 'invalid',
         payload: {
           label: 'Unknown',
-          message: 'Not a supported format. Upload a zipped ESRI Shapefile (.shp.zip) or a GeoPackage (.gpkg).'
+          message: 'Not a supported format. Upload a zipped ESRI Shapefile (.shp.zip), GeoPackage (.gpkg), or GeoJSON (.geojson or .json).'
         }
       });
       return;
@@ -218,11 +239,21 @@ self.onmessage = async (event) => {
     }
   }
 
-  sendProgress(55, isGeoPackage ? 'Reading GeoPackage metadata...' : 'Reading shapefile metadata...');
+  let metadataLabel = 'Reading shapefile metadata...';
+  if (isGeoPackage) {
+    metadataLabel = 'Reading GeoPackage metadata...';
+  } else if (isGeoJson) {
+    metadataLabel = 'Reading GeoJSON metadata...';
+  }
+  sendProgress(55, metadataLabel);
   let layerData;
   try {
     if (isGeoPackage) {
       const result = await loadGpkgAsGeoJson(file);
+      layerData = result.geojson;
+      info = result.info;
+    } else if (isGeoJson) {
+      const result = await loadGeoJsonAsGeoJson(file);
       layerData = result.geojson;
       info = result.info;
     } else {
@@ -231,15 +262,26 @@ self.onmessage = async (event) => {
       entries = zipEntries;
     }
   } catch (err) {
+    let formatLabel = 'zipped shapefile';
+    if (isGeoPackage) {
+      formatLabel = 'GeoPackage';
+    } else if (isGeoJson) {
+      formatLabel = 'GeoJSON file';
+    }
     const message = err?.message
-      ? `We found a valid ${isGeoPackage ? 'GeoPackage' : 'zipped shapefile'}, but could not read its metadata. ${err.message}`
-      : `We found a valid ${isGeoPackage ? 'GeoPackage' : 'zipped shapefile'}, but could not read its metadata.`;
+      ? `We found a valid ${formatLabel}, but could not read its metadata. ${err.message}`
+      : `We found a valid ${formatLabel}, but could not read its metadata.`;
     self.postMessage({ type: 'error', payload: { message } });
     return;
   }
 
   sendProgress(80, 'Summarizing layers...');
-  const layerTypeLabel = isGeoPackage ? 'GeoPackage layer' : 'Shapefile layer';
+  let layerTypeLabel = 'Shapefile layer';
+  if (isGeoPackage) {
+    layerTypeLabel = 'GeoPackage layer';
+  } else if (isGeoJson) {
+    layerTypeLabel = 'GeoJSON layer';
+  }
   const layers = (Array.isArray(layerData) ? layerData : [layerData]).map((layer) => {
     const features = layer?.features || [];
     return {
@@ -251,13 +293,17 @@ self.onmessage = async (event) => {
     };
   });
 
-  const crs = isGeoPackage ? getCrsLabelFromInfo(info) : getCrsLabelFromEntries(entries);
+  const crs = isGeoPackage || isGeoJson ? getCrsLabelFromInfo(info) : getCrsLabelFromEntries(entries);
   sendProgress(95, 'Finalizing metadata...');
 
   self.postMessage({
     type: 'success',
     payload: {
-      label: isGeoPackage ? 'GeoPackage (.gpkg)' : 'ESRI Shapefile (zipped)',
+      label: isGeoPackage
+        ? 'GeoPackage (.gpkg)'
+        : isGeoJson
+          ? 'GeoJSON (.geojson)'
+          : 'ESRI Shapefile (zipped)',
       message: 'Metadata loaded. You may proceed to the conversion step.',
       layers,
       crs


### PR DESCRIPTION
### Motivation

- Permit users to upload GeoJSON (`.geojson` or `.json`) files so they can be inspected and converted to GeoParquet like existing shapefiles and GeoPackages.
- Reuse the vendored GDAL runtime for inspection/metadata extraction while keeping the existing GeoParquet export logic intact.

### Description

- Added GeoJSON detection and output name handling in the converter UI by updating `util/src/apps/converterApp.js` to produce `.geoparquet` names for `.geojson`/`.json` inputs and updated `util/convert.html` to list GeoJSON as a supported input.
- Implemented `loadGeoJsonAsGeoJson` and `loadGeoJsonWithInfo` helpers and added `isGeoJson` detection in `util/src/apps/converterWorker.js` and `util/src/apps/converterExportWorker.js` so GDAL can open and return GeoJSON metadata and features.
- Updated worker flow and user-facing progress/error labels to include GeoJSON-specific messages and to derive CRS info from GDAL `dataset.info` when available.
- Kept the existing GeoParquet export pipeline unchanged and fed the inspected GeoJSON features into the same export logic.

### Testing

- No automated tests were run for these changes.
- Basic worker flows were implemented to mirror existing shapefile/GeoPackage paths, and error messages are surfaced via the worker `postMessage` channels.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69588821cddc83268e73928691f68e6f)