### PR TITLE
Add GeoPackage export option to converter

### DIFF
--- a/util/convert.html
+++ b/util/convert.html
@@ -203,6 +203,10 @@
           <input type="radio" name="outputFormat" value="geoparquet">
           GeoParquet (.geoparquet)
         </label>
+        <label>
+          <input type="radio" name="outputFormat" value="geopackage">
+          GeoPackage (.gpkg)
+        </label>
       </div>
       <div class="step-actions">
         <button id="convertBtn" type="button" disabled>Convert</button>

--- a/util/src/apps/converterApp.js
+++ b/util/src/apps/converterApp.js
@@ -220,7 +220,10 @@ export default function startConverterApp() {
 
   const updateOutputStatus = () => {
     if (selectedOutputFormat) {
-      outputStatus.textContent = 'Output format selected: GeoParquet (.geoparquet). Ready to convert.';
+      const label = selectedOutputFormat === 'geopackage'
+        ? 'GeoPackage (.gpkg)'
+        : 'GeoParquet (.geoparquet)';
+      outputStatus.textContent = `Output format selected: ${label}. Ready to convert.`;
       return;
     }
     outputStatus.textContent = 'Conversion options are ready once you select a format.';
@@ -387,30 +390,34 @@ export default function startConverterApp() {
     });
   });
 
-  const buildOutputName = (fileNameValue) => {
+  const buildOutputName = (fileNameValue, outputFormat) => {
     const lower = fileNameValue.toLowerCase();
+    const extension = outputFormat === 'geopackage' ? 'gpkg' : 'geoparquet';
     if (lower.endsWith('.shp.zip')) {
-      return `${fileNameValue.slice(0, -8)}.geoparquet`;
+      return `${fileNameValue.slice(0, -8)}.${extension}`;
     }
     if (lower.endsWith('.zip')) {
-      return `${fileNameValue.slice(0, -4)}.geoparquet`;
+      return `${fileNameValue.slice(0, -4)}.${extension}`;
     }
     if (lower.endsWith('.geojson')) {
-      return `${fileNameValue.slice(0, -8)}.geoparquet`;
+      return `${fileNameValue.slice(0, -8)}.${extension}`;
     }
     if (lower.endsWith('.json')) {
-      return `${fileNameValue.slice(0, -5)}.geoparquet`;
+      return `${fileNameValue.slice(0, -5)}.${extension}`;
     }
     if (lower.endsWith('.parquet')) {
-      return `${fileNameValue.slice(0, -8)}.geoparquet`;
+      return `${fileNameValue.slice(0, -8)}.${extension}`;
     }
     if (lower.endsWith('.gpkg')) {
-      return `${fileNameValue.slice(0, -5)}.geoparquet`;
+      return `${fileNameValue.slice(0, -5)}.${extension}`;
     }
-    if (lower.endsWith('.geoparquet')) {
+    if (lower.endsWith('.geoparquet') && extension === 'geoparquet') {
       return fileNameValue;
     }
-    return `${fileNameValue}.geoparquet`;
+    if (lower.endsWith('.gpkg') && extension === 'gpkg') {
+      return fileNameValue;
+    }
+    return `${fileNameValue}.${extension}`;
   };
 
   const beginConversion = () => {
@@ -419,7 +426,7 @@ export default function startConverterApp() {
     }
     stopConversionWorker();
     convertedBlob = null;
-    convertedFileName = buildOutputName(currentFile.name);
+    convertedFileName = buildOutputName(currentFile.name, selectedOutputFormat);
     conversionInProgress = true;
     outputStatus.textContent = 'Starting conversion...';
     updateOutputProgress({ percent: 5, detail: 'Preparing conversion...' });
@@ -485,7 +492,7 @@ export default function startConverterApp() {
       stopConversionWorker();
     };
 
-    worker.postMessage({ file: currentFile });
+    worker.postMessage({ file: currentFile, outputFormat: selectedOutputFormat });
   };
 
   convertBtn.addEventListener('click', beginConversion);
@@ -505,7 +512,10 @@ export default function startConverterApp() {
     if (!convertedBlob) {
       return;
     }
-    triggerDownload(convertedBlob, convertedFileName || 'converted.geoparquet');
+    const fallbackName = selectedOutputFormat === 'geopackage'
+      ? 'converted.gpkg'
+      : 'converted.geoparquet';
+    triggerDownload(convertedBlob, convertedFileName || fallbackName);
   });
 
   cancelBtn.addEventListener('click', () => {

--- a/util/src/apps/converterExportWorker.js
+++ b/util/src/apps/converterExportWorker.js
@@ -80,6 +80,25 @@ const loadGeoJsonWithInfo = async (file) => {
   return { geojson, info };
 };
 
+const convertGeoJsonToGpkg = async (geojson) => {
+  const gdal = await gdalPromise;
+  const geojsonText = JSON.stringify(geojson);
+  const geojsonFile = new File([geojsonText], 'source.geojson', { type: 'application/geo+json' });
+  const { datasets, errors } = await gdal.open(geojsonFile);
+  if (!datasets?.length) {
+    const err = errors?.[0] || 'GDAL could not open this GeoJSON for GeoPackage export.';
+    throw new Error(Array.isArray(err) ? err.join('\n') : String(err));
+  }
+
+  const dataset = datasets[0];
+  const out = await gdal.ogr2ogr(dataset, ['-f', 'GPKG']);
+  const bytes = await gdal.getFileBytes(out);
+
+  try { await gdal.close(dataset); } catch (_) {}
+
+  return bytes;
+};
+
 let parquetModulePromise = null;
 let arrowHelpersPromise = null;
 let parquetInitialized = false;
@@ -454,10 +473,11 @@ const ensureArrowHelpers = async () => {
 };
 
 self.onmessage = async (event) => {
-  const { file } = event.data || {};
+  const { file, outputFormat } = event.data || {};
   if (!file) {
     return;
   }
+  const targetFormat = outputFormat === 'geopackage' ? 'geopackage' : 'geoparquet';
 
   sendProgress(10, 'Reading file contents...');
   let buffer;
@@ -545,6 +565,28 @@ self.onmessage = async (event) => {
   const collections = Array.isArray(layerData) ? layerData : [layerData];
   const primaryCollection = collections[0] || { features: [] };
   const features = primaryCollection.features || [];
+
+  if (targetFormat === 'geopackage') {
+    sendProgress(55, 'Preparing GeoPackage export...');
+    let gpkgBytes;
+    try {
+      gpkgBytes = await convertGeoJsonToGpkg(primaryCollection);
+    } catch (err) {
+      self.postMessage({
+        type: 'error',
+        payload: { message: formatError('We could not build the GeoPackage file', err) }
+      });
+      return;
+    }
+
+    sendProgress(100, 'Conversion complete.');
+    const blob = new Blob([gpkgBytes], { type: 'application/geopackage+sqlite3' });
+    self.postMessage({
+      type: 'success',
+      payload: { blob }
+    });
+    return;
+  }
 
   sendProgress(55, 'Preparing GeoParquet schema...');
   const fieldTypes = collectFieldTypes(features);


### PR DESCRIPTION
### Motivation
- Extend the converter to support exporting to GeoPackage so users can choose `.gpkg` as an output format.  
- Reuse the existing GDAL-based export infrastructure to implement GeoPackage generation in the browser worker.  
- Keep the GeoParquet export flow intact while making output naming and UI state adapt to the selected format.

### Description
- Add a new `GeoPackage (.gpkg)` radio option to the output formats UI in `util/convert.html`.  
- Update `util/src/apps/converterApp.js` to display the selected output label, build filenames for either format, pass `outputFormat` to the worker, and use format-appropriate fallback filenames for download.  
- Implement `convertGeoJsonToGpkg` and `outputFormat` handling in `util/src/apps/converterExportWorker.js` using the existing GDAL bindings to run `ogr2ogr -f GPKG` and return a GeoPackage blob.  
- Preserve the existing GeoParquet export path and only branch to the GeoPackage path when `outputFormat === 'geopackage'`.

### Testing
- Launched a local HTTP server with `python -m http.server 8000` and opened `/util/convert.html` in a headless browser via Playwright to verify the UI shows the new GeoPackage option and captured a screenshot, and this check completed successfully.  
- The code changes were staged and committed (`git commit`) successfully.  
- No unit tests or end-to-end conversion tests were executed against actual file conversions in CI as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69595fc729e08326a992e3a4ddca5bf3)