### PR TITLE
Add Convert card and unify landing page buttons

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -42,11 +42,6 @@
       border: 1px solid var(--accent);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
-    .button.secondary {
-      background: var(--accent-soft);
-      color: var(--accent);
-      border-color: var(--accent-soft);
-    }
     .button:hover { transform: translateY(-1px); box-shadow: 0 8px 18px rgba(45, 79, 139, 0.2); }
     footer {
       padding: 24px 20px;
@@ -88,7 +83,12 @@
             <article class="card">
               <h2>Data Fetcher — Easy ArcGIS endpoint downloader</h2>
               <p>Connect to ArcGIS REST services, browse layers, and export GeoParquet locally.</p>
-              <a class="button secondary" href="/util/fetch.html">Open /util/fetch</a>
+              <a class="button" href="/util/fetch.html">Open /util/fetch</a>
+            </article>
+            <article class="card">
+              <h2>Convert — Simple GIS format converter</h2>
+              <p>Upload GIS files, inspect metadata, and convert them to GeoParquet or GeoPackage.</p>
+              <a class="button" href="/util/convert.html">Open /util/convert</a>
             </article>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Expose the new Convert utility on the main landing page so users can find and open the converter easily.
- Make the app entry buttons visually consistent across all cards to improve UI cohesion.

### Description
- Updated `site/index.html` to add a new `Convert` app card linking to `/util/convert.html` with title and description.
- Removed the `.button.secondary` variant and changed the Data Fetcher button to use the unified `button` styling.
- Adjusted the landing page markup so all app buttons use the same CSS class (`button`).

### Testing
- Served the site using `python -m http.server` and loaded `/site/index.html` with Playwright to capture a screenshot, which succeeded.
- No unit or integration tests were required for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6959899af16c8326a20cbe5271fd5e30)