### PR TITLE
Align landing page buttons

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -22,6 +22,8 @@
       margin-top: 28px;
     }
     .card {
+      display: flex;
+      flex-direction: column;
       background: var(--card);
       border: 1px solid var(--border);
       border-radius: 16px;
@@ -29,12 +31,14 @@
       box-shadow: 0 10px 24px rgba(21, 30, 50, 0.05);
     }
     .card h2 { margin: 0 0 8px; font-size: 1.1rem; }
-    .card p { margin: 0 0 18px; color: var(--muted); }
-    .button {
+    .card p { margin: 0; color: var(--muted); }
+    .card .button {
       display: inline-flex;
       align-items: center;
       gap: 8px;
       padding: 10px 16px;
+      margin-top: auto;
+      align-self: center;
       border-radius: 10px;
       background: var(--accent);
       color: #fff;


### PR DESCRIPTION
### Motivation
- The call-to-action buttons on the landing page cards were not vertically aligned and left large dead space in some cards. 
- The intent is to center each button within its card and push it toward the bottom so all CTAs line up across cards.

### Description
- Updated `site/index.html` CSS to make `.card` a flex column by adding `display: flex; flex-direction: column;`.
- Reduced paragraph bottom spacing by changing `.card p` margin to `0`.
- Scoped and adjusted the button rule to `.card .button` and added `margin-top: auto; align-self: center;` to center the button and push it to the card bottom.

### Testing
- Started a local server with `python -m http.server --directory site` and ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot, which completed successfully.
- No unit tests were applicable for this static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69598e8827c48326b33e496a647465de)