### PR TITLE
Add download_manifest.json to fetch zip with source URLs

### DIFF
--- a/util/src/apps/arcGisToGeoparquetApp.js
+++ b/util/src/apps/arcGisToGeoparquetApp.js
@@ -475,6 +475,7 @@ export default async function startArcgisToGeoparquetApp() {
       downloadDetail.textContent = `Fetching ${item.fullName}...`;
       const { info, url } = await fetchLayerMetadata(item.serviceUrl, item.id);
       item.info = info;
+      item.sourceUrl = url;
       const { features, spatialRef } = await fetchAllFeatures(url, info, ({ fetched, total }) => {
         downloadDetail.textContent = `Fetched ${fetched} of ${total} records for ${info.name}...`;
       });
@@ -663,11 +664,19 @@ export default async function startArcgisToGeoparquetApp() {
         const readyItems = queuedLayers.filter(item => item.enabled && item.status === 'ready' && item.blob);
         if (!readyItems.length) return;
         const files = [];
+        const manifestEntries = [];
         for (const item of readyItems) {
           const data = new Uint8Array(await item.blob.arrayBuffer());
           const extension = item.fileExtension ?? 'geoparquet';
-          files.push({ name: `${item.slug}.${extension}`, data });
+          const filename = `${item.slug}.${extension}`;
+          files.push({ name: filename, data });
+          manifestEntries.push({
+            filename,
+            url: item.sourceUrl || item.layerUrl || item.serviceUrl || ''
+          });
         }
+        const manifestData = new TextEncoder().encode(JSON.stringify({ files: manifestEntries }, null, 2));
+        files.push({ name: 'download_manifest.json', data: manifestData });
         const zipBlob = buildZipBlob(files);
         triggerDownload(zipBlob, 'layers.zip');
       });


### PR DESCRIPTION
### Motivation
- Provide traceability for downloaded layers by recording the original endpoint URL for each exported file.
- Make it easier to map saved files back to their ArcGIS source for auditing or re-fetching.

### Description
- Capture the layer source URL by setting `item.sourceUrl` when metadata is fetched in `downloadLayerItem`.
- When zipping ready items, build a `files` manifest array containing `{ filename, url }` entries for each exported file.
- Add a `download_manifest.json` file to the ZIP (created via `TextEncoder`) and include it alongside the exported blobs.
- Use fallbacks for the URL (`item.sourceUrl || item.layerUrl || item.serviceUrl || ''`) when populating the manifest.

### Testing
- No automated tests were run for this change.
- Functionality was implemented by updating `util/src/apps/arcGisToGeoparquetApp.js` and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695d296069e083269efa87ae81028bde)