### PR TITLE
Improve ArcGIS fetch error messaging

### DIFF
--- a/util/src/apps/arcGisToGeoparquetApp.js
+++ b/util/src/apps/arcGisToGeoparquetApp.js
@@ -60,6 +60,41 @@ export default async function startArcgisToGeoparquetApp() {
       line.textContent = msg;
       document.getElementById("log").appendChild(line);
     }
+
+    function buildFetchErrorMessage(err) {
+      const status = err?.status;
+      const bodyText = (err?.bodyText || '').toLowerCase();
+      const isAuthKeyword = /authentication required|unauthorized|login required|token required|invalid token/.test(bodyText);
+      const hasRefererKeyword = /referer|referrer/.test(bodyText);
+
+      if (status === 401 || isAuthKeyword) {
+        return 'This endpoint requires authentication. This app only fetches from unauthenticated endpoints, so it cannot access this service.';
+      }
+
+      if (status === 403 && hasRefererKeyword) {
+        return 'This endpoint requires a Referer header. This app runs entirely locally and cannot send custom Referer headers, so it cannot access this service.';
+      }
+
+      if (err?.isNetworkError || /failed to fetch/i.test(err?.message || '')) {
+        return 'Unable to reach this endpoint from the browser. The server may be blocking cross-origin requests or the network is unavailable.';
+      }
+
+      if (status === 404) {
+        return 'The endpoint was not found (404). Double-check the URL and try again.';
+      }
+
+      if (status) {
+        const statusLabel = err?.statusText ? ` ${err.statusText}` : '';
+        return `Request failed with status ${status}${statusLabel}.`;
+      }
+
+      return err?.message || 'An unexpected error occurred while contacting the service.';
+    }
+
+    function formatFetchError(err, context) {
+      const message = buildFetchErrorMessage(err);
+      return context ? `${context}: ${message}` : message;
+    }
     
     function buildLayerTree(layers = [], tables = [], serviceUrl) {
       const container = document.createElement('div');
@@ -158,7 +193,7 @@ export default async function startArcgisToGeoparquetApp() {
               const subtree = buildDirectoryTree(folderUrl, data);
               content.replaceWith(subtree);
             } catch (err) {
-              content.textContent = `Failed to load folder: ${err.message}`;
+              content.textContent = formatFetchError(err, 'Failed to load folder');
             }
           });
           li.appendChild(details);
@@ -206,7 +241,7 @@ export default async function startArcgisToGeoparquetApp() {
               content.replaceWith(tree);
               updateSelectedLayers();
             } catch (err) {
-              content.textContent = `Failed to load service: ${err.message}`;
+              content.textContent = formatFetchError(err, 'Failed to load service');
             }
           });
           li.appendChild(details);
@@ -322,7 +357,7 @@ export default async function startArcgisToGeoparquetApp() {
           setStep(2);
         } catch (err) {
           console.error(err);
-          endpointStatus.textContent = `Failed to load service: ${err.message}`;
+          endpointStatus.textContent = formatFetchError(err, 'Failed to load service');
         }
       });
     }
@@ -558,7 +593,7 @@ export default async function startArcgisToGeoparquetApp() {
             const preview = await fetchLayerPreview(item.serviceUrl, item.id);
             metadataContent.innerHTML = buildPreviewMarkup(preview);
           } catch (err) {
-            metadataContent.innerHTML = `<div class="muted">Failed to load metadata: ${err.message}</div>`;
+            metadataContent.innerHTML = `<div class="muted">${formatFetchError(err, 'Failed to load metadata')}</div>`;
           }
         });
         actions.appendChild(previewBtn);
@@ -619,7 +654,7 @@ export default async function startArcgisToGeoparquetApp() {
           });
         } catch (err) {
           console.error(err);
-          previewContent.innerHTML = `<div class="muted">Failed to load preview: ${err.message}</div>`;
+          previewContent.innerHTML = `<div class="muted">${formatFetchError(err, 'Failed to load preview')}</div>`;
         } finally {
           previewLayerBtn.disabled = false;
         }
@@ -641,9 +676,9 @@ export default async function startArcgisToGeoparquetApp() {
               await downloadLayerItem(item);
             } catch (err) {
               item.status = 'error';
-              item.error = err?.stack || err?.message || String(err)
+              item.error = formatFetchError(err);
               console.error("Export error:", err)
-              log(`Failed to download ${item.fullName}: ${err.message}`);
+              log(`Failed to download ${item.fullName}: ${buildFetchErrorMessage(err)}`);
               renderQueueList();
             }
             updateOverallProgress();

--- a/util/src/core/http.js
+++ b/util/src/core/http.js
@@ -1,5 +1,27 @@
 export async function fetchJson(url) {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Request failed (${res.status}) for ${url}`);
+  let res;
+  try {
+    res = await fetch(url);
+  } catch (err) {
+    const error = new Error(`Network error while requesting ${url}`);
+    error.isNetworkError = true;
+    error.url = url;
+    error.cause = err;
+    throw error;
+  }
+  if (!res.ok) {
+    let bodyText = '';
+    try {
+      bodyText = await res.text();
+    } catch (err) {
+      bodyText = '';
+    }
+    const error = new Error(`Request failed (${res.status}) for ${url}`);
+    error.status = res.status;
+    error.statusText = res.statusText;
+    error.url = url;
+    error.bodyText = bodyText;
+    throw error;
+  }
   return res.json();
 }


### PR DESCRIPTION
### Motivation
- Provide clearer error messages that distinguish authentication, Referer header, network/CORS, and generic failures when fetching ArcGIS services.
- Give the UI better diagnostics by surfacing HTTP status and response body information from fetch failures.
- Make it explicit when an error is caused by authentication or a Referer requirement and note that fixing Referer/auth is beyond the app's local-only scope.

### Description
- Update `util/src/core/http.js` so `fetchJson` catches network errors and annotates thrown errors with `isNetworkError`, `url`, and `cause`, and on non-OK responses captures `status`, `statusText`, and `bodyText` before throwing.
- Add `buildFetchErrorMessage` and `formatFetchError` to `util/src/apps/arcGisToGeoparquetApp.js` to translate error details into user-facing messages that handle auth (401/keywords), Referer (403+keyword), network/CORS failures, 404, and other HTTP statuses.
- Replace instances that previously used `err.message` for user output with `formatFetchError(...)`, set queued item `item.error` to a formatted message, and use `buildFetchErrorMessage(...)` for concise log entries.
- Apply the new messaging across endpoint load, folder/service listing, preview, metadata, and download error handling paths.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69728a6eb5c883268d372e4b1fed5b3a)