### PR TITLE
Fix categorical legend visibility filter in viz app

### DIFF
--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -2408,7 +2408,7 @@ function applyVisibilityFilters() {
       // Hide specific categories
       const hiddenCategories = Array.from(hiddenLegendItems);
       if (hiddenCategories.length > 0) {
-        filter.push(['!', ['in', ['get', currentField], ['literal', hiddenCategories]]]);
+        filter.push(['!', ['in', ['to-string', ['get', currentField]], ['literal', hiddenCategories]]]);
       }
     } else {
       // For numeric fields, hide specific ranges


### PR DESCRIPTION
### Motivation
- The legend eye toggle did not hide/show categorical neighborhoods when category codes were numeric because the filter compared raw feature values to string keys.

### Description
- In `applyVisibilityFilters()` the categorical filter now stringifies the feature value by using `['to-string', ['get', currentField]]` so it correctly matches the entries in `hiddenLegendItems`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697947008a848326ac7686b704b8be43)