### PR TITLE
Paint submenu: always show opacity, add dividers, move color scaling below color ramp

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -484,7 +484,7 @@
       <!-- Numeric field options -->
       <fieldset id="numericOptions">
         <label>Field type: numeric</label>
-        
+
         <!-- Normalization choices -->
         <div id="normGroup" style="display:grid; gap:6px; margin-top:6px;">
           <label style="display:flex; gap:8px; align-items:center;">
@@ -501,20 +501,6 @@
           </label>
         </div>
 
-        <fieldset>
-          <label>Color scaling</label>
-          <div style="display:grid; gap:6px;">
-            <label style="display:flex; gap:8px; align-items:center;">
-              <input type="radio" name="colorMode" id="color-cont" value="continuous">
-              <span>Linear (min→max, clamped p1–p99)</span>
-            </label>
-            <label style="display:flex; gap:8px; align-items:center;">
-              <input type="radio" name="colorMode" id="color-quant" value="quantiles" checked>
-              <span>Quantiles (equal-frequency, p1–p99)</span>
-            </label>
-          </div>
-        </fieldset>
-		
         <fieldset class="row">
           <div>
 			<label>Super Fancy 3D Extrusion!</label>
@@ -543,6 +529,8 @@
           </div>
         </fieldset>
       </fieldset>
+
+      <div id="paintDividerNumeric" class="divider"></div>
 
       <!-- Categorical field options -->
       <fieldset id="categoricalOptions" style="display: none;">
@@ -579,21 +567,40 @@
         </div>
       </fieldset>
 
+      <div id="paintDividerCategorical" class="divider"></div>
+
       <!-- Shared visualization options -->
-      <fieldset id="sharedOptions" style="display: none;">
-        <fieldset class="row">
-          <div>
-            <label for="ramp">Color ramp</label>
-            <select id="ramp"></select>
-          </div>
-          <div>
-            <label for="opacity">Opacity</label>
-            <div class="inline">
-              <input id="opacity" type="range" min="0" max="1" step="0.05" value="0.9" />
-              <output id="opacityVal">0.9</output>
-            </div>
-          </div>
-        </fieldset>
+      <fieldset id="colorRampOptions" style="display: none;">
+        <label>Color ramp</label>
+        <div>
+          <select id="ramp"></select>
+        </div>
+      </fieldset>
+
+      <div id="paintDividerRamp" class="divider"></div>
+
+      <fieldset id="colorScalingOptions" style="display: none;">
+        <label>Color scaling</label>
+        <div style="display:grid; gap:6px;">
+          <label style="display:flex; gap:8px; align-items:center;">
+            <input type="radio" name="colorMode" id="color-cont" value="continuous">
+            <span>Linear (min→max, clamped p1–p99)</span>
+          </label>
+          <label style="display:flex; gap:8px; align-items:center;">
+            <input type="radio" name="colorMode" id="color-quant" value="quantiles" checked>
+            <span>Quantiles (equal-frequency, p1–p99)</span>
+          </label>
+        </div>
+      </fieldset>
+
+      <div id="paintDividerScaling" class="divider"></div>
+
+      <fieldset id="opacityOptions" style="display: none;">
+        <label>Opacity</label>
+        <div class="inline">
+          <input id="opacity" type="range" min="0" max="1" step="0.05" value="0.9" />
+          <output id="opacityVal">0.9</output>
+        </div>
       </fieldset>
     </div>
   </div>

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -692,7 +692,13 @@ const normLand = document.getElementById('norm-land') as HTMLInputElement;
 const normBldg = document.getElementById('norm-bldg') as HTMLInputElement;
 const normLandUnitEl = document.getElementById('normLandUnit') as HTMLElement;
 const normBldgUnitEl = document.getElementById('normBldgUnit') as HTMLElement;
-const sharedOptions = document.getElementById('sharedOptions') as HTMLFieldSetElement;
+const colorRampOptions = document.getElementById('colorRampOptions') as HTMLFieldSetElement;
+const colorScalingOptions = document.getElementById('colorScalingOptions') as HTMLFieldSetElement;
+const opacityOptions = document.getElementById('opacityOptions') as HTMLFieldSetElement;
+const paintDividerNumeric = document.getElementById('paintDividerNumeric') as HTMLDivElement;
+const paintDividerCategorical = document.getElementById('paintDividerCategorical') as HTMLDivElement;
+const paintDividerRamp = document.getElementById('paintDividerRamp') as HTMLDivElement;
+const paintDividerScaling = document.getElementById('paintDividerScaling') as HTMLDivElement;
 
 // Camera view buttons
 const viewButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-view]'));
@@ -4296,18 +4302,31 @@ function updateFieldTypeUI() {
     if (numericOptions) numericOptions.style.display = 'none';
     if (categoricalOptions) categoricalOptions.style.display = 'none';
     if (colorOptions) colorOptions.style.display = 'none';
-    if (sharedOptions) sharedOptions.style.display = 'none';
+    if (colorRampOptions) colorRampOptions.style.display = 'none';
+    if (colorScalingOptions) colorScalingOptions.style.display = 'none';
+    if (opacityOptions) opacityOptions.style.display = 'none';
+    if (paintDividerNumeric) paintDividerNumeric.style.display = 'none';
+    if (paintDividerCategorical) paintDividerCategorical.style.display = 'none';
+    if (paintDividerRamp) paintDividerRamp.style.display = 'none';
+    if (paintDividerScaling) paintDividerScaling.style.display = 'none';
     extrusionOptions.style.display = 'none';
   } else {
-    // Show shared options when a field is selected
-    if (sharedOptions) sharedOptions.style.display = 'grid';
+    const showNumericOptions = currentFieldType === 'numeric';
+    const showCategoricalOptions = currentFieldType === 'categorical';
+    const showColorRampOptions = showNumericOptions || (showCategoricalOptions && categoricalColorMode === 'colorRamp');
+    const showColorScalingOptions = showNumericOptions;
+    const showOpacityOptions = true;
     
-    if (currentFieldType === 'numeric') {
+    if (colorRampOptions) colorRampOptions.style.display = showColorRampOptions ? 'grid' : 'none';
+    if (colorScalingOptions) colorScalingOptions.style.display = showColorScalingOptions ? 'grid' : 'none';
+    if (opacityOptions) opacityOptions.style.display = showOpacityOptions ? 'grid' : 'none';
+    
+    if (showNumericOptions) {
       if (numericOptions) numericOptions.style.display = 'grid';
       if (categoricalOptions) categoricalOptions.style.display = 'none';
       if (colorOptions) colorOptions.style.display = 'none';
       update3DUI(); // This will show/hide extrusion options based on 3D mode
-    } else if (currentFieldType === 'categorical') {
+    } else if (showCategoricalOptions) {
       if (numericOptions) numericOptions.style.display = 'none';
       if (categoricalOptions) categoricalOptions.style.display = 'grid';
       if (colorOptions) colorOptions.style.display = 'none';
@@ -4318,12 +4337,21 @@ function updateFieldTypeUI() {
         colorOptions.style.display = categoricalColorMode === 'single' ? 'block' : 'none';
       }
     }
-	
-	// Show/hide color ramp widget based on categorical color mode
-	const rampContainer = rampSelect.parentElement?.parentElement;
-	if (rampContainer) {
-	  rampContainer.style.display = (categoricalColorMode === 'colorRamp' || currentFieldType === 'numeric') ? 'block' : 'none';
-	}
+
+    const sectionVisibility = [
+      showNumericOptions,
+      showCategoricalOptions,
+      showColorRampOptions,
+      showColorScalingOptions,
+      showOpacityOptions
+    ];
+    const dividers = [paintDividerNumeric, paintDividerCategorical, paintDividerRamp, paintDividerScaling];
+    dividers.forEach((divider, index) => {
+      if (!divider) return;
+      const hasPrev = sectionVisibility[index];
+      const hasNext = sectionVisibility.slice(index + 1).some(Boolean);
+      divider.style.display = hasPrev && hasNext ? 'block' : 'none';
+    });
   }
 }
 


### PR DESCRIPTION
### Motivation
- Improve the visual structure and consistency of the paint submenu so users can more easily find and control color ramp, scaling and opacity settings.
- Ensure opacity is always available regardless of numeric vs categorical field mode to simplify visual adjustments.
- Separate logical pieces (color ramp, color scaling, opacity) into distinct sections with dividers to make the UI clearer.

### Description
- Restructured the paint submenu markup in `viz/index.html` by extracting color ramp, color scaling, and opacity into separate fieldsets (`#colorRampOptions`, `#colorScalingOptions`, `#opacityOptions`) and added divider elements (`#paintDividerNumeric`, `#paintDividerCategorical`, `#paintDividerRamp`, `#paintDividerScaling`).
- Removed the inline `Color scaling` block from the numeric section and placed it below the `Color ramp` section so `Color scaling` now appears after `Color ramp` in the DOM.
- Updated `viz/src/main.ts` to reference the new DOM elements and implemented `updateFieldTypeUI()` logic to show/hide the new sections appropriately for `numeric` and `categorical` modes, keep opacity visible whenever a field is selected, and control divider visibility between sections.

### Testing
- Ran a local static server (`python -m http.server`) and executed a Playwright smoke script that opened `http://localhost:8000/viz/index.html`, clicked the paint button and captured a screenshot `paint-menu.png`, and the script completed successfully producing the artifact.
- No unit tests or build steps were executed in this change set; manual/visual verification was performed via the Playwright screenshot which shows the updated layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6979694da68c83269d5bf25e84fc5f95)