### PR TITLE
Update viz settings layout and layer list labels

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -126,6 +126,18 @@
       cursor: not-allowed;
     }
 
+    .current-layer-header {
+      font-size: 14px;
+      font-weight: 700;
+      color: #111827;
+      margin-top: 6px;
+    }
+
+    .current-layer-source {
+      font-size: 12px;
+      color: #4b5563;
+    }
+
     .layer-add-row {
       display: flex;
       align-items: center;
@@ -429,13 +441,27 @@
       <div id="settingsTopActions" class="buttons" style="margin-bottom: 8px;">
         <button id="btn-zoomto" type="button">Zoom to data</button>
       </div>
+      <fieldset>
+        <label>View presets</label>
+        <div class="buttons">
+          <button data-view="top">Top</button>
+          <button data-view="iso">Perspective</button>
+          <button data-view="north">North</button>
+          <button data-view="east">East</button>
+          <button data-view="south">South</button>
+          <button data-view="west">West</button>
+        </div>
+      </fieldset>
       <fieldset id="layerPanel">
         <label>Layers</label>
-        <div id="layerList" class="layer-list"></div>
         <div class="layer-add-row">
           <button id="addLayerFromStore" type="button">Add layer</button>
         </div>
+        <div id="layerList" class="layer-list"></div>
       </fieldset>
+
+      <div class="current-layer-header">Current layer</div>
+      <div id="currentLayerSource" class="current-layer-source">layer source: —</div>
 
       <div class="divider"></div>
 
@@ -452,19 +478,6 @@
       </div>
 
       <div class="divider"></div>
-
-      <fieldset>
-        <label>View presets</label>
-        <div class="buttons">
-          <button data-view="top">Top</button>
-          <button data-view="iso">Perspective</button>
-          <button data-view="north">North</button>
-          <button data-view="east">East</button>
-          <button data-view="south">South</button>
-          <button data-view="west">West</button>
-        </div>
-      </fieldset>
-
 
       <fieldset id="legend">      </fieldset>
       </div>

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -693,6 +693,7 @@ const normBldg = document.getElementById('norm-bldg') as HTMLInputElement;
 const normLandUnitEl = document.getElementById('normLandUnit') as HTMLElement;
 const normBldgUnitEl = document.getElementById('normBldgUnit') as HTMLElement;
 const sharedOptions = document.getElementById('sharedOptions') as HTMLFieldSetElement;
+const currentLayerSource = document.getElementById('currentLayerSource') as HTMLDivElement;
 
 // Camera view buttons
 const viewButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-view]'));
@@ -1191,6 +1192,7 @@ function applyLayerState(layer: LayerState) {
   }
 
   enable3DCheckbox.checked = is3DMode;
+  updateCurrentLayerDetails();
   updateFieldTypeUI();
   update3DUI();
   updateFloatingLegend();
@@ -1459,6 +1461,22 @@ function handleMouseUp() {
   document.body.style.userSelect = '';
 }
 
+function updateCurrentLayerDetails() {
+  if (!currentLayerSource) return;
+  if (!currentLayerId) {
+    currentLayerSource.textContent = 'layer source: —';
+    return;
+  }
+  const layer = layers.get(currentLayerId);
+  if (!layer) {
+    currentLayerSource.textContent = 'layer source: —';
+    return;
+  }
+  const store = dataStores.get(layer.dataStoreId);
+  const sourceName = store?.file?.name ?? store?.name ?? '—';
+  currentLayerSource.textContent = `layer source: ${sourceName}`;
+}
+
 function renderLayerList() {
   if (!layerList) return;
   layerList.replaceChildren();
@@ -1468,10 +1486,11 @@ function renderLayerList() {
     empty.className = 'muted';
     empty.textContent = 'No layers loaded yet.';
     layerList.appendChild(empty);
+    updateCurrentLayerDetails();
     return;
   }
 
-  layerOrder.forEach(layerId => {
+  layerOrder.forEach((layerId, index) => {
     const layer = layers.get(layerId);
     if (!layer) return;
 
@@ -1499,7 +1518,7 @@ function renderLayerList() {
     const nameButton = document.createElement('button');
     nameButton.type = 'button';
     nameButton.className = 'layer-name';
-    nameButton.textContent = layer.name || `Layer ${layerId}`;
+    nameButton.textContent = layer.field ?? `layer ${index + 1}`;
     nameButton.addEventListener('click', () => setCurrentLayer(layerId));
 
     const moveUpBtn = document.createElement('button');
@@ -1529,6 +1548,8 @@ function renderLayerList() {
     row.append(visibilityToggle, currentRadio, nameButton, moveUpBtn, moveDownBtn, deleteBtn);
     layerList.appendChild(row);
   });
+
+  updateCurrentLayerDetails();
 }
 
 // Floating legend functions
@@ -4569,6 +4590,7 @@ fieldSelect.addEventListener('change', () => {
     if (map.getLayer('markup-layer-outline')) map.removeLayer('markup-layer-outline');
     if (map.getSource('markup-source')) map.removeSource('markup-source');
     persistCurrentLayerState();
+    renderLayerList();
     return;
   }
   
@@ -4612,6 +4634,7 @@ fieldSelect.addEventListener('change', () => {
   
   scheduleUpdate('recomputeAndAutoScale', /*refreshLegend*/ true);
   persistCurrentLayerState();
+  renderLayerList();
 });
 
 document.querySelectorAll<HTMLInputElement>('input[name="normMode"]').forEach(r => {


### PR DESCRIPTION
### Motivation
- Reorder the Settings panel to surface view controls and make layer controls easier to find by moving "View presets" above the Layers section and the "Add layer" control to the top of the Layers list.
- Make layer entries show the currently visualized field (or a simple fallback name) so users can see at-a-glance what each layer is visualizing.
- Add a clear "Current layer" header and a visible `layer source` line to show which file the current layer came from.

### Description
- Moved the `View presets` fieldset above the `Layers` fieldset and relocated the `Add layer` button to the top of the layers list in `viz/index.html`.
- Inserted a new header and source line (`<div class="current-layer-header">Current layer</div>` and `#currentLayerSource`) into `viz/index.html` and added styles for `.current-layer-header` and `.current-layer-source`.
- Added `const currentLayerSource = document.getElementById('currentLayerSource')` and new function `updateCurrentLayerDetails()` in `viz/src/main.ts` to populate the source line from the `DataStore` file name.
- Updated `renderLayerList()` to show the layer's `field` (or fallback `layer N`) as the visible label and to call `updateCurrentLayerDetails()` after rendering.
- Ensured `updateCurrentLayerDetails()` is called from `applyLayerState()` and that `renderLayerList()` is invoked after field changes so the UI stays in sync.
- Files changed: `viz/index.html` and `viz/src/main.ts`.

### Testing
- Started the dev server (`vite`) and confirmed it reported ready and served the app (Vite startup succeeded).
- Loaded the page and captured a screenshot using a Playwright script which completed and produced `artifacts/viz-settings.png` showing the updated Settings layout (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69796a74bd6c8326b2d5a01ad899d53f)