### PR TITLE
Move Paint toggle to toolbar, open Paint by default, and replace layer/legend controls with eye icons

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -48,21 +48,21 @@
     #controls button:hover,
     #paintControls button:hover { background: #f0f0f0; }
 
-    .paint-menu-button {
+    .eye-button {
+      border: none;
+      background: none;
+      cursor: pointer;
+      padding: 2px;
       display: inline-flex;
       align-items: center;
-      gap: 6px;
-      font-weight: 600;
+      justify-content: center;
+      flex-shrink: 0;
     }
 
-    .paint-menu-button img {
-      width: 18px;
-      height: 18px;
-    }
-
-    .paint-menu-button.active {
-      border-color: #3b82f6;
-      box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.2);
+    .eye-button img {
+      width: 16px;
+      height: 16px;
+      display: block;
     }
 
     #legend { display: none; align-items: center; gap: 6px; }
@@ -401,6 +401,10 @@
         <button id="settingsToolButton" class="toolbar-button" title="Show/hide settings">
           <img src="./src/svg/settings.svg" alt="Settings" />
         </button>
+
+        <button id="btnPaintMenu" class="toolbar-button" title="Show/hide paint">
+          <img src="./src/svg/paint.svg" alt="Paint" />
+        </button>
                
         <button id="legendToolButton" class="toolbar-button" title="Show/hide legend">
           <img src="./src/svg/legend.svg" alt="Legend" />
@@ -470,13 +474,6 @@
         <select id="field"><option value="" disabled selected>— load a file first —</option></select>
       </fieldset>
 
-      <div class="buttons">
-        <button id="btnPaintMenu" type="button" class="paint-menu-button">
-          <img src="./src/svg/paint.svg" alt="" />
-          Paint
-        </button>
-      </div>
-
       <div class="divider"></div>
 
       <fieldset id="legend">      </fieldset>
@@ -484,7 +481,7 @@
     </div>
   </div>
 
-  <div id="paintControls" style="position: absolute; top: 10px; left: 520px; width: min(calc(92vw - 80px), 360px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
+  <div id="paintControls" style="position: absolute; top: 10px; left: 80px; width: min(calc(92vw - 80px), 360px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: grid; gap: var(--gap); z-index: 10; cursor: move;">
     <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
       <div style="font-weight: 600; font-size: 13px;">Paint</div>
       <button id="btnMinimizePaint" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -722,8 +722,8 @@ const settingsContent = document.getElementById('settingsContent') as HTMLDivEle
 const paintControlsEl = document.getElementById('paintControls') as HTMLDivElement;
 const paintContent = document.getElementById('paintContent') as HTMLDivElement;
 
-const EYE_ICON_OPEN = './src/svg/eye.svg';
-const EYE_ICON_CLOSED = './src/svg/eye_closed.svg';
+const EYE_ICON_OPEN = new URL('./svg/eye.svg', import.meta.url).href;
+const EYE_ICON_CLOSED = new URL('./svg/eye_closed.svg', import.meta.url).href;
 
 function setEyeButtonIcon(button: HTMLButtonElement, isHidden: boolean) {
   const img = button.querySelector('img');

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -722,6 +722,28 @@ const settingsContent = document.getElementById('settingsContent') as HTMLDivEle
 const paintControlsEl = document.getElementById('paintControls') as HTMLDivElement;
 const paintContent = document.getElementById('paintContent') as HTMLDivElement;
 
+const EYE_ICON_OPEN = './src/svg/eye.svg';
+const EYE_ICON_CLOSED = './src/svg/eye_closed.svg';
+
+function setEyeButtonIcon(button: HTMLButtonElement, isHidden: boolean) {
+  const img = button.querySelector('img');
+  if (!img) return;
+  img.src = isHidden ? EYE_ICON_CLOSED : EYE_ICON_OPEN;
+  img.alt = isHidden ? 'Hidden' : 'Visible';
+}
+
+function createEyeButton(isHidden: boolean, title: string) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'eye-button';
+  button.title = title;
+  const img = document.createElement('img');
+  img.src = isHidden ? EYE_ICON_CLOSED : EYE_ICON_OPEN;
+  img.alt = isHidden ? 'Hidden' : 'Visible';
+  button.appendChild(img);
+  return button;
+}
+
 // Quality button (create after elements are declared)
 const btnQuality = document.createElement('button');
 btnQuality.id = 'btn-quality';
@@ -955,7 +977,7 @@ type MetricUnitKey = 'centimeters' | 'meters' | 'kilometers';
 
 // Window state
 let isSettingsMinimized = false;
-let isPaintMinimized = true;
+let isPaintMinimized = false;
 let isLegendVisible = true;  // Start with legend visible
 let isLegendMinimized = false;
 let hiddenLegendItems = new Set<string>(); // Track which categories/ranges are hidden
@@ -1352,23 +1374,36 @@ function showSettings() {
   isSettingsMinimized = false;
   settingsContent.style.display = 'block';
   controlsEl.style.display = 'grid';
+  positionPaintPanel();
   
   // Update toolbar button states
   updateToolbarButtonStates();
+}
+
+function positionPaintPanel() {
+  if (!controlsEl || !paintControlsEl) return;
+  if (paintControlsEl.dataset.userPositioned === 'true') return;
+  const rect = controlsEl.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) return;
+  const gap = 10;
+  paintControlsEl.style.left = `${rect.left}px`;
+  paintControlsEl.style.top = `${rect.bottom + gap}px`;
+  paintControlsEl.style.transform = 'none';
 }
 
 function minimizePaint() {
   isPaintMinimized = true;
   paintContent.style.display = 'none';
   paintControlsEl.style.display = 'none';
-  updatePaintButtonState();
+  updateToolbarButtonStates();
 }
 
 function showPaint() {
   isPaintMinimized = false;
   paintContent.style.display = 'grid';
   paintControlsEl.style.display = 'grid';
-  updatePaintButtonState();
+  positionPaintPanel();
+  updateToolbarButtonStates();
 }
 
 function togglePaint() {
@@ -1382,8 +1417,10 @@ function togglePaint() {
 function updatePaintButtonState() {
   if (!btnPaintMenu) return;
   if (isPaintMinimized) {
+    btnPaintMenu.classList.add('inactive');
     btnPaintMenu.classList.remove('active');
   } else {
+    btnPaintMenu.classList.remove('inactive');
     btnPaintMenu.classList.add('active');
   }
 }
@@ -1427,6 +1464,7 @@ function makeDraggable(element: HTMLElement) {
   header.addEventListener('mousedown', (e) => {
     isDragging = true;
     dragTarget = element;
+    element.dataset.userPositioned = 'true';
     const rect = element.getBoundingClientRect();
     dragOffset.x = e.clientX - rect.left;
     dragOffset.y = e.clientY - rect.top;
@@ -1503,13 +1541,12 @@ function renderLayerList() {
     const row = document.createElement('div');
     row.className = `layer-row${layerId === currentLayerId ? ' current' : ''}`;
 
-    const visibilityToggle = document.createElement('input');
-    visibilityToggle.type = 'checkbox';
-    visibilityToggle.checked = layer.visible;
-    visibilityToggle.title = layer.visible ? 'Hide layer' : 'Show layer';
-    visibilityToggle.addEventListener('change', () => {
-      setLayerVisibility(layer, visibilityToggle.checked);
-      visibilityToggle.title = visibilityToggle.checked ? 'Hide layer' : 'Show layer';
+    const visibilityToggle = createEyeButton(!layer.visible, layer.visible ? 'Hide layer' : 'Show layer');
+    visibilityToggle.addEventListener('click', () => {
+      const nextVisible = !layer.visible;
+      setLayerVisibility(layer, nextVisible);
+      visibilityToggle.title = nextVisible ? 'Hide layer' : 'Show layer';
+      setEyeButtonIcon(visibilityToggle, !nextVisible);
     });
 
     const currentRadio = document.createElement('input');
@@ -1530,21 +1567,24 @@ function renderLayerList() {
     const moveUpBtn = document.createElement('button');
     moveUpBtn.type = 'button';
     moveUpBtn.className = 'layer-action-btn';
-    moveUpBtn.textContent = 'Up';
+    moveUpBtn.textContent = '🔼';
+    moveUpBtn.title = 'Move layer up';
     moveUpBtn.disabled = layerOrder.indexOf(layerId) === 0;
     moveUpBtn.addEventListener('click', () => moveLayerInOrder(layerId, 'up'));
 
     const moveDownBtn = document.createElement('button');
     moveDownBtn.type = 'button';
     moveDownBtn.className = 'layer-action-btn';
-    moveDownBtn.textContent = 'Down';
+    moveDownBtn.textContent = '🔽';
+    moveDownBtn.title = 'Move layer down';
     moveDownBtn.disabled = layerOrder.indexOf(layerId) === layerOrder.length - 1;
     moveDownBtn.addEventListener('click', () => moveLayerInOrder(layerId, 'down'));
 
     const deleteBtn = document.createElement('button');
     deleteBtn.type = 'button';
     deleteBtn.className = 'layer-action-btn';
-    deleteBtn.textContent = 'Delete';
+    deleteBtn.textContent = '❌';
+    deleteBtn.title = 'Delete layer';
     deleteBtn.addEventListener('click', () => {
       if (!confirm(`Delete layer "${layer.name}"?`)) return;
       removeLayer(layerId);
@@ -1696,18 +1736,31 @@ function updateFloatingLegend() {
     font-weight: 600;
   `;
   
+  function getLegendCategories() {
+    const categories = new Set<string>();
+    if (!currentGeoJSON) return categories;
+    for (const feature of currentGeoJSON.features) {
+      const value = feature.properties?.[currentField!];
+      if (value != null && value !== '' && value !== undefined) {
+        categories.add(String(value));
+      }
+    }
+    return categories;
+  }
+
+  const isAllLegendHidden = () => {
+    if (currentFieldType === 'categorical') {
+      const categories = getLegendCategories();
+      return categories.size > 0 && Array.from(categories).every(cat => hiddenLegendItems.has(cat));
+    }
+    const ranges = colorMode === 'quantiles' && colorBreaks && colorBreaks.length
+      ? colorBreaks.length + 1
+      : 10;
+    return Array.from({ length: ranges }, (_, i) => `range_${i}`).every(rangeKey => hiddenLegendItems.has(rangeKey));
+  };
+
   // Eye toggle all button
-  const eyeAllBtn = document.createElement('button');
-  eyeAllBtn.textContent = '👁️';
-  eyeAllBtn.title = 'Toggle all visibility';
-  eyeAllBtn.style.cssText = `
-    border: none;
-    background: none;
-    cursor: pointer;
-    font-size: 14px;
-    padding: 2px;
-    flex-shrink: 0;
-  `;
+  const eyeAllBtn = createEyeButton(isAllLegendHidden(), 'Toggle all visibility');
   
   eyeAllBtn.onclick = () => {
     if (currentFieldType === 'categorical') {
@@ -1752,17 +1805,7 @@ function updateFloatingLegend() {
     applyExtrusionWithVisibility();
   };
 
-  const getLegendCategories = () => {
-    const categories = new Set<string>();
-    if (!currentGeoJSON) return categories;
-    for (const feature of currentGeoJSON.features) {
-      const value = feature.properties?.[currentField!];
-      if (value != null && value !== '' && value !== undefined) {
-        categories.add(String(value));
-      }
-    }
-    return categories;
-  };
+  
 
   const getLegendRanges = () => {
     const rangeBounds: { min: number; max: number; key: string }[] = [];
@@ -2065,17 +2108,7 @@ function updateCategoricalFloatingLegend() {
     countDisplay.textContent = count.toString();
     
      // Eye toggle button
-     const eyeBtn = document.createElement('button');
-     eyeBtn.textContent = isHidden ? '👁️‍🗨️' : '👁️';
-     eyeBtn.title = isHidden ? 'Show this category' : 'Hide this category';
-     eyeBtn.style.cssText = `
-       border: none;
-       background: none;
-       cursor: pointer;
-       font-size: 14px;
-       padding: 2px;
-       flex-shrink: 0;
-     `;
+     const eyeBtn = createEyeButton(isHidden, isHidden ? 'Show this category' : 'Hide this category');
      
      eyeBtn.onclick = () => {
        if (hiddenLegendItems.has(category)) {
@@ -2285,17 +2318,7 @@ function updateNumericFloatingLegend() {
     countDisplay.textContent = count.toString();
     
          // Eye toggle button
-     const eyeBtn = document.createElement('button');
-     eyeBtn.textContent = isHidden ? '👁️‍🗨️' : '👁️';
-     eyeBtn.title = isHidden ? 'Show this range' : 'Hide this range';
-     eyeBtn.style.cssText = `
-       border: none;
-       background: none;
-       cursor: pointer;
-       font-size: 14px;
-       padding: 2px;
-       flex-shrink: 0;
-     `;
+     const eyeBtn = createEyeButton(isHidden, isHidden ? 'Show this range' : 'Hide this range');
      
      eyeBtn.onclick = () => {
        if (hiddenLegendItems.has(rangeKey)) {
@@ -2858,6 +2881,7 @@ function installWelcome() {
 function revealUI() {
   if (welcomeEl) { welcomeEl.remove(); welcomeEl = null; }
   if (controlsEl) controlsEl.style.display = 'grid';
+  positionPaintPanel();
 }
 
 function ensureRenderToast() {
@@ -4560,6 +4584,7 @@ document.addEventListener('mouseup', handleMouseUp);
 makeDraggable(controlsEl);
 makeDraggable(paintControlsEl);
 makeDraggable(floatingLegend);
+positionPaintPanel();
 updatePaintButtonState();
 
 rampSelect.addEventListener('change', () => {
@@ -5109,6 +5134,8 @@ function updateToolbarButtonStates() {
     legendToolButton.classList.remove('inactive');
     legendToolButton.classList.add('active');
   }
+
+  updatePaintButtonState();
 }
 
 // Initialize toolbar when DOM is ready


### PR DESCRIPTION
### Motivation
- Make the Paint controls more discoverable by opening the Paint submenu by default and positioning it directly under the Settings panel.  
- Move the Paint toggle out of the Settings panel into the main toolbar so users can show/hide Paint from the top-level UI.  
- Replace emoji-based eye/visibility UI and layer checkboxes with reusable SVG eye icons to provide consistent visuals and behavior.  
- Simplify layer row controls by using emoji icons for move/delete actions to match the requested UX.

### Description
- Added a shared `.eye-button` CSS style to `viz/index.html` and moved the `btnPaintMenu` button from the Settings pane into the vertical toolbar.  
- Defaulted Paint to open on load by changing `isPaintMinimized` to `false` and moved `paintControls` positioning to be aligned under the Settings panel by introducing `positionPaintPanel()` and honoring `dataset.userPositioned` when the user drags the panel (`viz/src/main.ts`).  
- Introduced `createEyeButton()` and `setEyeButtonIcon()` helpers and constants `EYE_ICON_OPEN`/`EYE_ICON_CLOSED` and replaced all textual/emoji eye toggles in the floating legend and numeric/categorical legend items with the new eye SVG buttons so visibility state uses `eye.svg` / `eye_closed.svg`.  
- Replaced the layer-list visibility `input[type=checkbox]` with an eye button wired to `setLayerVisibility()`, and replaced the layer action buttons text with emoji icons (`🔼`, `🔽`, `❌`) and appropriate `title` attributes.  
- Updated toolbar/window state handling so the paint toolbar button reflects the open/closed state and `positionPaintPanel()` is invoked when settings/controls are shown or revealed (changed files: `viz/index.html`, `viz/src/main.ts`).

### Testing
- Attempted to launch the viz dev server with `npm --prefix viz run dev -- --host 0.0.0.0 --port 4173`, which failed because `viz/package.json` was not present in this environment, so the dev server could not be started.  
- Verified code changes by static inspection and grep searches to ensure the new helpers and button replacements are referenced in all legend and layer code paths.  
- Committed the changes (`git` commit completed) but no runnable automated build/test could be executed in this environment due to the missing `package.json` in `viz`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6979728e2fd88326819014d100ec3c45)