### PR TITLE
Add Grayscale color ramp to VIZ app

### DIFF
--- a/viz/src/config.ts
+++ b/viz/src/config.ts
@@ -23,7 +23,8 @@ export const COLOR_RAMPS: Record<string, string[]> = {
   Plasma:  ['#0D0887','#5B02A3','#9A179B','#CB4679','#ED7953','#FB9F3A','#F0F921'],
   Turbo:   ['#30123B','#4145AB','#2CC0F0','#6AE4B4','#C6F86D','#F9DD32','#F28C21','#CB3E1F','#8A0D2C'],
   YlOrRd:  ['#FFFFB2','#FECC5C','#FD8D3C','#F03B20','#BD0026'],
-  Blues:   ['#DEEBF7','#9ECAE1','#6BAED6','#3182BD','#08519C']
+  Blues:   ['#DEEBF7','#9ECAE1','#6BAED6','#3182BD','#08519C'],
+  Grayscale: ['#000000','#2B2B2B','#555555','#7F7F7F','#AAAAAA','#D4D4D4','#F0F0F0','#FFFFFF']
 };
 
 // Unit conversion (unchanged)


### PR DESCRIPTION
### Motivation
- Provide a monochrome/grayscale color ramp option for the VIZ app so users can choose a neutral, print-friendly ramp alongside existing palettes.

### Description
- Add a new `Grayscale` entry to the `COLOR_RAMPS` map in `viz/src/config.ts` containing an 8-step black-to-white hex ramp.

### Testing
- Launched a local server with `python -m http.server 4173` and ran a Playwright script to load `http://localhost:4173/viz/` and capture a screenshot, which completed successfully and produced `artifacts/viz-grayscale-ramp.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69797a0450f08326af48fd007672aaae)