### PR TITLE
Add Settings submenu to VIZ toolbar

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -40,13 +40,16 @@
     #paintControls .row > * { min-width: 0; }
 
     #controls .buttons,
-    #paintControls .buttons { display: flex; flex-wrap: wrap; gap: 6px; }
+    #paintControls .buttons,
+    #settingsControls .buttons { display: flex; flex-wrap: wrap; gap: 6px; }
     #controls button,
-    #paintControls button {
+    #paintControls button,
+    #settingsControls button {
       border: 1px solid #ddd; background: #f8f8f8; padding: 6px 8px; border-radius: 8px; cursor: pointer;
     }
     #controls button:hover,
-    #paintControls button:hover { background: #f0f0f0; }
+    #paintControls button:hover,
+    #settingsControls button:hover { background: #f0f0f0; }
 
     .eye-button {
       border: none;
@@ -370,47 +373,10 @@
       color: white;
     }
 
-    .settings-submenu {
-      min-width: 220px;
-    }
-
-    .settings-submenu .submenu-section {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-      padding: 4px;
-    }
-
-    .settings-submenu .submenu-section + .submenu-section {
-      border-top: 1px solid #eee;
-      margin-top: 2px;
-      padding-top: 8px;
-    }
-
-    .settings-submenu .submenu-title {
-      font-size: 12px;
-      font-weight: 600;
-      color: #555;
-      padding: 0 2px;
-    }
-
-    .settings-submenu .submenu-actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 6px;
-    }
-
-    .settings-submenu button {
-      border: 1px solid #ddd;
-      background: #f8f8f8;
-      padding: 6px 8px;
-      border-radius: 8px;
-      cursor: pointer;
-      font-size: 12px;
-    }
-
-    .settings-submenu button:hover {
-      background: #f0f0f0;
+    #settingsControls .buttons button.active {
+      background: #3b82f6;
+      color: white;
+      border-color: #2d6cdf;
     }
   </style>
 </head>
@@ -445,9 +411,8 @@
           <img src="./src/svg/layers.svg" alt="Layers" />
         </button>
 
-        <button id="settingsToolButton" class="toolbar-button has-submenu" title="Settings">
+        <button id="settingsToolButton" class="toolbar-button" title="Settings">
           <img src="./src/svg/settings.svg" alt="Settings" />
-          <img src="./src/svg/corner_triangle.svg" alt="" class="corner-triangle" />
         </button>
 
         <button id="btnPaintMenu" class="toolbar-button" title="Show/hide paint">
@@ -477,32 +442,13 @@
           </button>
         </div>
 
-        <div id="settingsSubmenu" class="toolbar-submenu settings-submenu">
-          <div class="submenu-section">
-            <div class="submenu-title">View presets</div>
-            <div class="submenu-actions">
-              <button data-view="top">Top</button>
-              <button data-view="iso">Perspective</button>
-              <button data-view="north">North</button>
-              <button data-view="east">East</button>
-              <button data-view="south">South</button>
-              <button data-view="west">West</button>
-            </div>
-          </div>
-          <div class="submenu-section">
-            <div class="submenu-title">Other</div>
-            <div id="settingsOtherActions" class="submenu-actions">
-              <button id="btn-zoomto" type="button">Zoom to data</button>
-            </div>
-          </div>
-        </div>
       </div>
 
 
       <div id="controls" style="position: absolute; top: 10px; left: 80px; width: min(calc(92vw - 80px), 420px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: grid; gap: var(--gap); z-index: 10; cursor: move;">
       <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
         <div style="font-weight: 600; font-size: 13px;">Layers</div>
-        <button id="btnMinimizeSettings" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+        <button id="btnMinimizeLayers" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
 			<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
 				<path d="M7 10l5 5 5-5z"/>
 			</svg>
@@ -529,6 +475,44 @@
 
       <fieldset id="legend">      </fieldset>
       </div>
+    </div>
+  </div>
+
+  <div id="settingsControls" style="position: absolute; top: 10px; left: 520px; width: min(calc(92vw - 80px), 320px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: grid; gap: var(--gap); z-index: 10; cursor: move;">
+    <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
+      <div style="font-weight: 600; font-size: 13px;">Settings</div>
+      <button id="btnMinimizeSettingsMenu" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M7 10l5 5 5-5z"/>
+        </svg>
+      </button>
+    </div>
+    <div id="settingsMenuContent" style="padding: 12px; display: grid; gap: 10px;">
+      <fieldset>
+        <label>View presets</label>
+        <div class="buttons">
+          <button data-view="top" type="button">Top</button>
+          <button data-view="iso" type="button">Perspective</button>
+          <button data-view="north" type="button">North</button>
+          <button data-view="east" type="button">East</button>
+          <button data-view="south" type="button">South</button>
+          <button data-view="west" type="button">West</button>
+        </div>
+      </fieldset>
+      <fieldset>
+        <label>Basemap</label>
+        <div class="buttons">
+          <button data-basemap="streets" type="button">Streets</button>
+          <button data-basemap="satellite" type="button">Satellite</button>
+          <button data-basemap="none" type="button">Nothing</button>
+        </div>
+      </fieldset>
+      <fieldset>
+        <label>Other</label>
+        <div id="settingsOtherActions" class="buttons">
+          <button id="btn-zoomto" type="button">Zoom to data</button>
+        </div>
+      </fieldset>
     </div>
   </div>
 

--- a/viz/index.html
+++ b/viz/index.html
@@ -369,6 +369,49 @@
       background: #3b82f6;
       color: white;
     }
+
+    .settings-submenu {
+      min-width: 220px;
+    }
+
+    .settings-submenu .submenu-section {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 4px;
+    }
+
+    .settings-submenu .submenu-section + .submenu-section {
+      border-top: 1px solid #eee;
+      margin-top: 2px;
+      padding-top: 8px;
+    }
+
+    .settings-submenu .submenu-title {
+      font-size: 12px;
+      font-weight: 600;
+      color: #555;
+      padding: 0 2px;
+    }
+
+    .settings-submenu .submenu-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .settings-submenu button {
+      border: 1px solid #ddd;
+      background: #f8f8f8;
+      padding: 6px 8px;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 12px;
+    }
+
+    .settings-submenu button:hover {
+      background: #f0f0f0;
+    }
   </style>
 </head>
   <body>
@@ -402,6 +445,11 @@
           <img src="./src/svg/layers.svg" alt="Layers" />
         </button>
 
+        <button id="settingsToolButton" class="toolbar-button has-submenu" title="Settings">
+          <img src="./src/svg/settings.svg" alt="Settings" />
+          <img src="./src/svg/corner_triangle.svg" alt="" class="corner-triangle" />
+        </button>
+
         <button id="btnPaintMenu" class="toolbar-button" title="Show/hide paint">
           <img src="./src/svg/paint.svg" alt="Paint" />
         </button>
@@ -428,6 +476,26 @@
             Polygon
           </button>
         </div>
+
+        <div id="settingsSubmenu" class="toolbar-submenu settings-submenu">
+          <div class="submenu-section">
+            <div class="submenu-title">View presets</div>
+            <div class="submenu-actions">
+              <button data-view="top">Top</button>
+              <button data-view="iso">Perspective</button>
+              <button data-view="north">North</button>
+              <button data-view="east">East</button>
+              <button data-view="south">South</button>
+              <button data-view="west">West</button>
+            </div>
+          </div>
+          <div class="submenu-section">
+            <div class="submenu-title">Other</div>
+            <div id="settingsOtherActions" class="submenu-actions">
+              <button id="btn-zoomto" type="button">Zoom to data</button>
+            </div>
+          </div>
+        </div>
       </div>
 
 
@@ -441,20 +509,6 @@
 		</button>
       </div>
       <div id="settingsContent" style="padding: 12px;">
-      <div id="settingsTopActions" class="buttons" style="margin-bottom: 8px;">
-        <button id="btn-zoomto" type="button">Zoom to data</button>
-      </div>
-      <fieldset>
-        <label>View presets</label>
-        <div class="buttons">
-          <button data-view="top">Top</button>
-          <button data-view="iso">Perspective</button>
-          <button data-view="north">North</button>
-          <button data-view="east">East</button>
-          <button data-view="south">South</button>
-          <button data-view="west">West</button>
-        </div>
-      </fieldset>
       <fieldset id="layerPanel">
         <label>Layers</label>
         <div class="layer-add-row">

--- a/viz/src/config.ts
+++ b/viz/src/config.ts
@@ -7,6 +7,31 @@ export const OSM_STYLE: any = {
   layers: [{ id: 'osm-tiles', type: 'raster', source: 'osm-tiles', minzoom: 0, maxzoom: 19 }]
 };
 
+export const SATELLITE_STYLE: any = {
+  version: 8,
+  sources: {
+    'satellite-tiles': {
+      type: 'raster',
+      tiles: ['https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+      tileSize: 256,
+      attribution: 'Tiles © Esri — Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community'
+    }
+  },
+  layers: [{ id: 'satellite-tiles', type: 'raster', source: 'satellite-tiles', minzoom: 0, maxzoom: 19 }]
+};
+
+export const EMPTY_STYLE: any = {
+  version: 8,
+  sources: {},
+  layers: [
+    {
+      id: 'background',
+      type: 'background',
+      paint: { 'background-color': '#f8f8f8' }
+    }
+  ]
+};
+
 // Source / layer IDs
 export const SOURCE_ID = 'gp-source';
 export const LAYER_ID = 'gp-extrusions';

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -683,7 +683,7 @@ const multInput = document.getElementById('mult') as HTMLInputElement;
 const unitsSelect = document.getElementById('units') as HTMLSelectElement;
 const layerList = document.getElementById('layerList') as HTMLDivElement;
 const addLayerFromStoreButton = document.getElementById('addLayerFromStore') as HTMLButtonElement;
-const settingsTopActions = document.getElementById('settingsTopActions') as HTMLDivElement;
+const settingsOtherActions = document.getElementById('settingsOtherActions') as HTMLDivElement;
 const btnPaintMenu = document.getElementById('btnPaintMenu') as HTMLButtonElement;
 const opacityInput = document.getElementById('opacity') as HTMLInputElement;
 const opacityOut = document.getElementById('opacityVal') as HTMLOutputElement
@@ -748,10 +748,9 @@ function createEyeButton(isHidden: boolean, title: string) {
 const btnQuality = document.createElement('button');
 btnQuality.id = 'btn-quality';
 btnQuality.textContent = 'Quality: Fast';
-btnQuality.style.cssText = 'border:1px solid #ddd;background:#f8f8f8;padding:6px 8px;border-radius:8px;cursor:pointer;';
 btnQuality.onclick = () => setQuality(qualityMode === 'high' ? 'fast' : 'high');
-if (settingsTopActions) {
-  settingsTopActions.prepend(btnQuality);
+if (settingsOtherActions) {
+  settingsOtherActions.prepend(btnQuality);
 } else {
   settingsContent.prepend(btnQuality);
 }
@@ -4822,9 +4821,11 @@ let currentSelectionMode: 'select-one' | 'select-rectangle' | 'select-lasso' | '
 // Toolbar elements
 const selectToolButton = document.getElementById('selectToolButton') as HTMLButtonElement;
 const layersToolButton = document.getElementById('layersToolButton') as HTMLButtonElement;
+const settingsToolButton = document.getElementById('settingsToolButton') as HTMLButtonElement;
 const infoToolButton = document.getElementById('infoToolButton') as HTMLButtonElement;
 const panToolButton = document.getElementById('panToolButton') as HTMLButtonElement;
 const selectSubmenu = document.getElementById('selectSubmenu') as HTMLDivElement;
+const settingsSubmenu = document.getElementById('settingsSubmenu') as HTMLDivElement;
 const submenuButtons = document.querySelectorAll('.submenu-button') as NodeListOf<HTMLButtonElement>;
 
 // Tool state
@@ -4983,7 +4984,11 @@ function setupSelectionModeHandlers() {
 // Helper function to close all submenus
 function closeAllSubmenus() {
   selectSubmenu.classList.remove('show');
-  // Add other submenus here if they exist in the future
+  settingsSubmenu.classList.remove('show');
+}
+
+function positionSubmenu(button: HTMLElement, submenu: HTMLElement) {
+  submenu.style.top = `${button.offsetTop}px`;
 }
 
 // Initialize toolbar
@@ -5013,6 +5018,7 @@ function initializeToolbar() {
     
     // Start hold timer
     selectButtonHoldTimer = window.setTimeout(() => {
+      positionSubmenu(selectToolButton, selectSubmenu);
       selectSubmenu.classList.add('show');
       selectButtonHoldTimer = null;
     }, selectButtonHoldDuration);
@@ -5053,6 +5059,17 @@ function initializeToolbar() {
     } else {
       minimizeSettings();
     }
+  });
+
+  settingsToolButton.addEventListener('click', (e) => {
+    e.stopPropagation();
+    closeAllSubmenus();
+    if (settingsSubmenu.classList.contains('show')) {
+      settingsSubmenu.classList.remove('show');
+      return;
+    }
+    positionSubmenu(settingsToolButton, settingsSubmenu);
+    settingsSubmenu.classList.add('show');
   });
   
   // Handle pan button click
@@ -5109,7 +5126,13 @@ function initializeToolbar() {
   
   // Close submenu when clicking outside
   document.addEventListener('click', (e) => {
-    if (!selectToolButton.contains(e.target as Node) && !selectSubmenu.contains(e.target as Node)) {
+    const target = e.target as Node;
+    if (
+      !selectToolButton.contains(target) &&
+      !selectSubmenu.contains(target) &&
+      !settingsToolButton.contains(target) &&
+      !settingsSubmenu.contains(target)
+    ) {
       closeAllSubmenus();
     }
   });

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -4855,7 +4855,6 @@ unitsSelect.value = 'centimeters';
 // Initialize UI - show numeric options by default, hide categorical
 updateFieldTypeUI();
 
-installWelcome();
 setQuality('high');
 renderLayerList();
 renderDataStoreList();
@@ -5289,6 +5288,8 @@ if (document.readyState === 'loading') {
 } else {
   initializeToolbar();
 }
+
+installWelcome();
 
 
 /* ---------------- Lasso Selection Tool ---------------- */

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -78,6 +78,25 @@ function restoreLayersAfterStyleChange() {
       updateErrorLayer();
     }
   }
+
+  ensureBasemapAtBottom();
+}
+
+function ensureBasemapAtBottom() {
+  const basemapLayerIds = new Set<string>();
+  if (currentBasemap === 'streets') {
+    basemapLayerIds.add('osm-tiles');
+  } else if (currentBasemap === 'satellite') {
+    basemapLayerIds.add('satellite-tiles');
+  } else if (currentBasemap === 'none') {
+    basemapLayerIds.add('background');
+  }
+  const styleLayers = map.getStyle().layers ?? [];
+  styleLayers
+    .filter(layer => !basemapLayerIds.has(layer.id))
+    .forEach(layer => {
+      map.moveLayer(layer.id);
+    });
 }
 
 function setBasemapMode(mode: BasemapMode) {

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -8,7 +8,7 @@ import { parquetMetadataAsync, parquetSchema } from 'hyparquet';
 
 
 // Local imports
-import { OSM_STYLE, SATELLITE_STYLE, EMPTY_STYLE, SOURCE_ID, LAYER_ID, ERROR_LAYER_ID, HEIGHT_CAP_METERS, HEIGHT_PCTL, COLOR_RAMPS, UNIT_TO_METERS } from './config';
+import { OSM_STYLE, SATELLITE_STYLE, SOURCE_ID, LAYER_ID, ERROR_LAYER_ID, HEIGHT_CAP_METERS, HEIGHT_PCTL, COLOR_RAMPS, UNIT_TO_METERS } from './config';
 import { coerceScalar, sanitizeFeatureInPlace, sanitizeFeaturesInPlace, fileToAsyncBuffer, } from './utils.sanitize';
 import { type AsyncBuffer } from './utils.sanitize';
 import { roundGeometryInPlace, trimPropertiesInPlace, bbox } from './utils.geo';
@@ -38,75 +38,89 @@ map.addControl(new maplibregl.ScaleControl({ unit: 'metric' }), 'bottom-left');
 type BasemapMode = 'streets' | 'satellite' | 'none';
 let currentBasemap: BasemapMode = 'streets';
 
-function getBasemapStyle(mode: BasemapMode) {
-  switch (mode) {
-    case 'satellite':
-      return SATELLITE_STYLE;
-    case 'none':
-      return EMPTY_STYLE;
-    case 'streets':
-    default:
-      return OSM_STYLE;
-  }
-}
-
 function updateBasemapButtonStates() {
   basemapButtons.forEach(button => {
     button.classList.toggle('active', button.dataset.basemap === currentBasemap);
   });
 }
 
-function restoreLayersAfterStyleChange() {
-  layers.forEach(layer => {
-    if (!layer.geojson) return;
-    if (!map.getSource(layer.sourceId)) {
-      map.addSource(layer.sourceId, { type: 'geojson', data: layer.geojson });
-    }
-    addExtrusionLayer(layer);
-    ensureErrorLayer(layer);
-  });
+const BASEMAP_LAYER_IDS: Record<BasemapMode, string> = {
+  streets: 'osm-tiles',
+  satellite: 'satellite-tiles',
+  none: 'background'
+};
 
-  if (currentLayerId) {
-    const layer = layers.get(currentLayerId);
-    if (layer) {
-      applyLayerState(layer);
-      if (currentGeoJSON && currentField) {
-        applyExtrusion();
-      } else if (currentGeoJSON) {
-        applyGrayRendering();
-      }
-      updateErrorLayer();
-    }
+const BASEMAP_SOURCE_IDS: Partial<Record<BasemapMode, string>> = {
+  streets: 'osm-tiles',
+  satellite: 'satellite-tiles'
+};
+
+const ALL_BASEMAP_LAYER_IDS = new Set(Object.values(BASEMAP_LAYER_IDS));
+
+function getBasemapSourceConfig(mode: BasemapMode) {
+  if (mode === 'streets') {
+    return OSM_STYLE.sources['osm-tiles'];
   }
-
-  ensureBasemapAtBottom();
+  if (mode === 'satellite') {
+    return SATELLITE_STYLE.sources['satellite-tiles'];
+  }
+  return null;
 }
 
-function ensureBasemapAtBottom() {
-  const basemapLayerIds = new Set<string>();
-  if (currentBasemap === 'streets') {
-    basemapLayerIds.add('osm-tiles');
-  } else if (currentBasemap === 'satellite') {
-    basemapLayerIds.add('satellite-tiles');
-  } else if (currentBasemap === 'none') {
-    basemapLayerIds.add('background');
-  }
+function getBasemapInsertBeforeId() {
   const styleLayers = map.getStyle().layers ?? [];
-  styleLayers
-    .filter(layer => !basemapLayerIds.has(layer.id))
-    .forEach(layer => {
-      map.moveLayer(layer.id);
+  const nextLayer = styleLayers.find(layer => !ALL_BASEMAP_LAYER_IDS.has(layer.id));
+  return nextLayer?.id;
+}
+
+function removeBasemap(mode: BasemapMode) {
+  const layerId = BASEMAP_LAYER_IDS[mode];
+  if (map.getLayer(layerId)) {
+    map.removeLayer(layerId);
+  }
+  const sourceId = BASEMAP_SOURCE_IDS[mode];
+  if (sourceId && map.getSource(sourceId)) {
+    map.removeSource(sourceId);
+  }
+}
+
+function addBasemap(mode: BasemapMode) {
+  const beforeId = getBasemapInsertBeforeId();
+  if (mode === 'none') {
+    map.addLayer({
+      id: BASEMAP_LAYER_IDS.none,
+      type: 'background',
+      paint: { 'background-color': '#f8f8f8' }
+    }, beforeId);
+    return;
+  }
+
+  const sourceConfig = getBasemapSourceConfig(mode);
+  if (!sourceConfig) return;
+  const sourceId = BASEMAP_SOURCE_IDS[mode]!;
+  if (!map.getSource(sourceId)) {
+    map.addSource(sourceId, {
+      type: 'raster',
+      tiles: sourceConfig.tiles,
+      tileSize: sourceConfig.tileSize,
+      attribution: sourceConfig.attribution
     });
+  }
+  map.addLayer({
+    id: BASEMAP_LAYER_IDS[mode],
+    type: 'raster',
+    source: sourceId,
+    minzoom: sourceConfig.minzoom ?? 0,
+    maxzoom: sourceConfig.maxzoom ?? 19
+  }, beforeId);
 }
 
 function setBasemapMode(mode: BasemapMode) {
   if (mode === currentBasemap) return;
+  removeBasemap(currentBasemap);
   currentBasemap = mode;
   updateBasemapButtonStates();
-  map.setStyle(getBasemapStyle(mode));
-  map.once('style.load', () => {
-    restoreLayersAfterStyleChange();
-  });
+  addBasemap(mode);
 }
 
 /* ---------------- Cursor Management ---------------- */

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -2971,8 +2971,9 @@ function updateLegendPosition() {
 }
 
 function installWelcome() {
-  // hide controls initially
-  if (controlsEl) controlsEl.style.display = 'none';
+  minimizeLayers();
+  minimizeSettingsMenu();
+  minimizePaint();
 
   welcomeEl = document.createElement('div');
   welcomeEl.id = 'welcomeOverlay';
@@ -3000,8 +3001,9 @@ function installWelcome() {
 
 function revealUI() {
   if (welcomeEl) { welcomeEl.remove(); welcomeEl = null; }
-  if (controlsEl) controlsEl.style.display = 'grid';
-  positionPaintPanel();
+  showLayers();
+  showPaint();
+  minimizeSettingsMenu();
 }
 
 function ensureRenderToast() {

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -8,7 +8,7 @@ import { parquetMetadataAsync, parquetSchema } from 'hyparquet';
 
 
 // Local imports
-import { OSM_STYLE, SOURCE_ID, LAYER_ID, ERROR_LAYER_ID, HEIGHT_CAP_METERS, HEIGHT_PCTL, COLOR_RAMPS, UNIT_TO_METERS } from './config';
+import { OSM_STYLE, SATELLITE_STYLE, EMPTY_STYLE, SOURCE_ID, LAYER_ID, ERROR_LAYER_ID, HEIGHT_CAP_METERS, HEIGHT_PCTL, COLOR_RAMPS, UNIT_TO_METERS } from './config';
 import { coerceScalar, sanitizeFeatureInPlace, sanitizeFeaturesInPlace, fileToAsyncBuffer, } from './utils.sanitize';
 import { type AsyncBuffer } from './utils.sanitize';
 import { roundGeometryInPlace, trimPropertiesInPlace, bbox } from './utils.geo';
@@ -34,6 +34,62 @@ const map = new maplibregl.Map({
   pixelRatio: HQ_PR // supersample: render at higher internal resolution (smooth lines)
 });
 map.addControl(new maplibregl.ScaleControl({ unit: 'metric' }), 'bottom-left');
+
+type BasemapMode = 'streets' | 'satellite' | 'none';
+let currentBasemap: BasemapMode = 'streets';
+
+function getBasemapStyle(mode: BasemapMode) {
+  switch (mode) {
+    case 'satellite':
+      return SATELLITE_STYLE;
+    case 'none':
+      return EMPTY_STYLE;
+    case 'streets':
+    default:
+      return OSM_STYLE;
+  }
+}
+
+function updateBasemapButtonStates() {
+  basemapButtons.forEach(button => {
+    button.classList.toggle('active', button.dataset.basemap === currentBasemap);
+  });
+}
+
+function restoreLayersAfterStyleChange() {
+  layers.forEach(layer => {
+    if (!layer.geojson) return;
+    if (!map.getSource(layer.sourceId)) {
+      map.addSource(layer.sourceId, { type: 'geojson', data: layer.geojson });
+    }
+    addExtrusionLayer(layer);
+    ensureErrorLayer(layer);
+  });
+
+  if (currentLayerId) {
+    const layer = layers.get(currentLayerId);
+    if (layer) {
+      applyLayerState(layer);
+      if (currentGeoJSON && currentField) {
+        applyExtrusion();
+      } else if (currentGeoJSON) {
+        applyGrayRendering();
+      }
+      updateErrorLayer();
+    }
+  }
+}
+
+function setBasemapMode(mode: BasemapMode) {
+  if (mode === currentBasemap) return;
+  currentBasemap = mode;
+  updateBasemapButtonStates();
+  map.setStyle(getBasemapStyle(mode));
+  map.once('style.load', () => {
+    restoreLayersAfterStyleChange();
+  });
+}
+
 /* ---------------- Cursor Management ---------------- */
 
 // Update cursor based on active tool
@@ -700,12 +756,23 @@ const paintDividerCategorical = document.getElementById('paintDividerCategorical
 const paintDividerRamp = document.getElementById('paintDividerRamp') as HTMLDivElement;
 const paintDividerScaling = document.getElementById('paintDividerScaling') as HTMLDivElement;
 const currentLayerSource = document.getElementById('currentLayerSource') as HTMLDivElement;
+const basemapButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-basemap]'));
 
 // Camera view buttons
 const viewButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-view]'));
 (document.getElementById('btn-persp') as HTMLButtonElement)?.addEventListener('click', () => setPerspective());
 (document.getElementById('btn-ortho') as HTMLButtonElement)?.addEventListener('click', () => setOrtho());
 viewButtons.forEach(btn => btn.onclick = () => setView(btn.dataset.view!));
+
+basemapButtons.forEach(button => {
+  button.addEventListener('click', () => {
+    const mode = button.dataset.basemap as BasemapMode | undefined;
+    if (mode) {
+      setBasemapMode(mode);
+    }
+  });
+});
+updateBasemapButtonStates();
 
 // Zoom to data button
 const btnZoomTo = document.getElementById('btn-zoomto') as HTMLButtonElement;
@@ -719,6 +786,8 @@ if (addLayerFromStoreButton) {
 // Window elements
 const controlsEl = document.getElementById('controls') as HTMLDivElement;
 const settingsContent = document.getElementById('settingsContent') as HTMLDivElement;
+const settingsControlsEl = document.getElementById('settingsControls') as HTMLDivElement;
+const settingsMenuContent = document.getElementById('settingsMenuContent') as HTMLDivElement;
 const paintControlsEl = document.getElementById('paintControls') as HTMLDivElement;
 const paintContent = document.getElementById('paintContent') as HTMLDivElement;
 
@@ -752,9 +821,10 @@ btnQuality.onclick = () => setQuality(qualityMode === 'high' ? 'fast' : 'high');
 if (settingsOtherActions) {
   settingsOtherActions.prepend(btnQuality);
 } else {
-  settingsContent.prepend(btnQuality);
+  settingsMenuContent.prepend(btnQuality);
 }
-const btnMinimizeSettings = document.getElementById('btnMinimizeSettings') as HTMLButtonElement;
+const btnMinimizeLayers = document.getElementById('btnMinimizeLayers') as HTMLButtonElement;
+const btnMinimizeSettingsMenu = document.getElementById('btnMinimizeSettingsMenu') as HTMLButtonElement;
 const btnMinimizePaint = document.getElementById('btnMinimizePaint') as HTMLButtonElement;
 
 // Toolbar elements
@@ -975,7 +1045,8 @@ let _pendingRefreshLegend = false;
 type MetricUnitKey = 'centimeters' | 'meters' | 'kilometers';
 
 // Window state
-let isSettingsMinimized = false;
+let isLayersMinimized = false;
+let isSettingsMenuMinimized = false;
 let isPaintMinimized = false;
 let isLegendVisible = true;  // Start with legend visible
 let isLegendMinimized = false;
@@ -1359,24 +1430,44 @@ function removeLayer(layerId: string) {
 }
 
 // Window management functions
-function minimizeSettings() {
-  isSettingsMinimized = true;
+function minimizeLayers() {
+  isLayersMinimized = true;
   settingsContent.style.display = 'none';
   controlsEl.style.display = 'none';
   minimizePaint();
-  
-  // Update toolbar button states
   updateToolbarButtonStates();
 }
 
-function showSettings() {
-  isSettingsMinimized = false;
+function showLayers() {
+  isLayersMinimized = false;
   settingsContent.style.display = 'block';
   controlsEl.style.display = 'grid';
   positionPaintPanel();
-  
-  // Update toolbar button states
+  positionSettingsPanel();
   updateToolbarButtonStates();
+}
+
+function minimizeSettingsMenu() {
+  isSettingsMenuMinimized = true;
+  settingsMenuContent.style.display = 'none';
+  settingsControlsEl.style.display = 'none';
+  updateToolbarButtonStates();
+}
+
+function showSettingsMenu() {
+  isSettingsMenuMinimized = false;
+  settingsMenuContent.style.display = 'grid';
+  settingsControlsEl.style.display = 'grid';
+  positionSettingsPanel();
+  updateToolbarButtonStates();
+}
+
+function toggleSettingsMenu() {
+  if (isSettingsMenuMinimized) {
+    showSettingsMenu();
+  } else {
+    minimizeSettingsMenu();
+  }
 }
 
 function positionPaintPanel() {
@@ -1388,6 +1479,17 @@ function positionPaintPanel() {
   paintControlsEl.style.left = `${rect.left}px`;
   paintControlsEl.style.top = `${rect.bottom + gap}px`;
   paintControlsEl.style.transform = 'none';
+}
+
+function positionSettingsPanel() {
+  if (!controlsEl || !settingsControlsEl) return;
+  if (settingsControlsEl.dataset.userPositioned === 'true') return;
+  const rect = controlsEl.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) return;
+  const gap = 10;
+  settingsControlsEl.style.left = `${rect.right + gap}px`;
+  settingsControlsEl.style.top = `${rect.top}px`;
+  settingsControlsEl.style.transform = 'none';
 }
 
 function minimizePaint() {
@@ -4568,7 +4670,8 @@ colorPicker.addEventListener('input', () => {
 });
 
 // Window management event listeners
-btnMinimizeSettings.addEventListener('click', minimizeSettings);
+btnMinimizeLayers.addEventListener('click', minimizeLayers);
+btnMinimizeSettingsMenu.addEventListener('click', minimizeSettingsMenu);
 btnMinimizePaint.addEventListener('click', minimizePaint);
 btnMinimizeLegend.addEventListener('click', minimizeLegend);
 btnPaintMenu.addEventListener('click', togglePaint);
@@ -4581,9 +4684,11 @@ document.addEventListener('mouseup', handleMouseUp);
 
 // Make windows draggable
 makeDraggable(controlsEl);
+makeDraggable(settingsControlsEl);
 makeDraggable(paintControlsEl);
 makeDraggable(floatingLegend);
 positionPaintPanel();
+positionSettingsPanel();
 updatePaintButtonState();
 
 rampSelect.addEventListener('change', () => {
@@ -4825,7 +4930,6 @@ const settingsToolButton = document.getElementById('settingsToolButton') as HTML
 const infoToolButton = document.getElementById('infoToolButton') as HTMLButtonElement;
 const panToolButton = document.getElementById('panToolButton') as HTMLButtonElement;
 const selectSubmenu = document.getElementById('selectSubmenu') as HTMLDivElement;
-const settingsSubmenu = document.getElementById('settingsSubmenu') as HTMLDivElement;
 const submenuButtons = document.querySelectorAll('.submenu-button') as NodeListOf<HTMLButtonElement>;
 
 // Tool state
@@ -4984,7 +5088,6 @@ function setupSelectionModeHandlers() {
 // Helper function to close all submenus
 function closeAllSubmenus() {
   selectSubmenu.classList.remove('show');
-  settingsSubmenu.classList.remove('show');
 }
 
 function positionSubmenu(button: HTMLElement, submenu: HTMLElement) {
@@ -5050,26 +5153,21 @@ function initializeToolbar() {
     }
   });
   
-  // Handle settings button click
+  // Handle layers button click
   layersToolButton.addEventListener('click', (e) => {
     e.stopPropagation();
     closeAllSubmenus();
-    if (isSettingsMinimized) {
-      showSettings();
+    if (isLayersMinimized) {
+      showLayers();
     } else {
-      minimizeSettings();
+      minimizeLayers();
     }
   });
 
   settingsToolButton.addEventListener('click', (e) => {
     e.stopPropagation();
     closeAllSubmenus();
-    if (settingsSubmenu.classList.contains('show')) {
-      settingsSubmenu.classList.remove('show');
-      return;
-    }
-    positionSubmenu(settingsToolButton, settingsSubmenu);
-    settingsSubmenu.classList.add('show');
+    toggleSettingsMenu();
   });
   
   // Handle pan button click
@@ -5127,12 +5225,7 @@ function initializeToolbar() {
   // Close submenu when clicking outside
   document.addEventListener('click', (e) => {
     const target = e.target as Node;
-    if (
-      !selectToolButton.contains(target) &&
-      !selectSubmenu.contains(target) &&
-      !settingsToolButton.contains(target) &&
-      !settingsSubmenu.contains(target)
-    ) {
+    if (!selectToolButton.contains(target) && !selectSubmenu.contains(target)) {
       closeAllSubmenus();
     }
   });
@@ -5141,12 +5234,20 @@ function initializeToolbar() {
 // Update toolbar button states based on window visibility
 function updateToolbarButtonStates() {
   // Settings button state
-  if (isSettingsMinimized) {
+  if (isLayersMinimized) {
     layersToolButton.classList.add('inactive');
     layersToolButton.classList.remove('active');
   } else {
     layersToolButton.classList.remove('inactive');
     layersToolButton.classList.add('active');
+  }
+
+  if (isSettingsMenuMinimized) {
+    settingsToolButton.classList.add('inactive');
+    settingsToolButton.classList.remove('active');
+  } else {
+    settingsToolButton.classList.remove('inactive');
+    settingsToolButton.classList.add('active');
   }
   
   // Legend button state


### PR DESCRIPTION
### Motivation
- Remove UI cruft from the top of the Layers panel by moving view-related controls into a dedicated Settings menu.
- Provide a single toolbar entry for settings using the existing `settings.svg` icon so presets and misc actions are easier to discover.

### Description
- Added a new Settings toolbar button (`#settingsToolButton`) and a new submenu (`#settingsSubmenu`) containing two sections: `View presets` and `Other` (which holds quality and zoom actions).
- Moved the existing view preset buttons and the `Zoom to data` action out of the Layers panel and into the settings submenu, and wired the quality control (`#btn-quality`) to prepend into the submenu container (`#settingsOtherActions`).
- Added styling for the settings submenu (`.settings-submenu`, `.submenu-section`, `.submenu-title`, `.submenu-actions`) and positioned submenu display behavior using a new helper `positionSubmenu` to align the submenu with its toolbar button.
- Updated toolbar logic in `viz/src/main.ts` to register the new DOM elements (`settingsToolButton`, `settingsSubmenu`, `settingsOtherActions`), handle show/hide for the settings submenu, and include settings submenu in the global `closeAllSubmenus`/outside-click logic.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69797f189b6c83268b846b0832b7f48d)