### PR TITLE
Add Statistics menu to VIZ app

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -781,10 +781,6 @@
                 <label>Min: <input id="statsOverflowMinPct" type="text" inputmode="decimal" data-step="0.1" /></label>
                 <label>Max: <input id="statsOverflowMaxPct" type="text" inputmode="decimal" data-step="0.1" /></label>
               </div>
-              <div class="range-values">
-                <label>Min: <input id="statsOverflowMinAbs" type="number" step="0.1" /></label>
-                <label>Max: <input id="statsOverflowMaxAbs" type="number" step="0.1" /></label>
-              </div>
             </div>
             <div id="statsHistogram" style="display: grid; grid-template-columns: repeat(10, 1fr); gap: 4px; align-items: end; height: 80px; margin-top: 6px;"></div>
           </div>

--- a/viz/index.html
+++ b/viz/index.html
@@ -206,8 +206,9 @@
       gap: 12px;
       align-items: center;
     }
-    .stats-range .range-values input[type="number"] {
-      width: 90px;
+    .stats-range .range-values input[type="number"],
+    .stats-range .range-values input[type="text"] {
+      width: 70px;
       padding: 4px 6px;
       border-radius: 6px;
       border: 1px solid #ddd;

--- a/viz/index.html
+++ b/viz/index.html
@@ -200,25 +200,6 @@
       display: grid;
       gap: 6px;
     }
-    .stats-range .range-inputs {
-      position: relative;
-      height: 24px;
-    }
-    .stats-range .range-inputs input[type="range"] {
-      position: absolute;
-      left: 0;
-      top: 0;
-      width: 100%;
-      margin: 0;
-      background: transparent;
-      pointer-events: auto;
-    }
-    .stats-range .range-inputs input[type="range"]:first-child {
-      z-index: 2;
-    }
-    .stats-range .range-inputs input[type="range"]:last-child {
-      z-index: 3;
-    }
     .stats-range .range-values {
       display: flex;
       justify-content: space-between;
@@ -231,27 +212,6 @@
       border-radius: 6px;
       border: 1px solid #ddd;
       font-size: 12px;
-    }
-    .stats-range .range-summary {
-      position: relative;
-      height: 16px;
-      font-size: 11px;
-      color: #374151;
-    }
-    .stats-range .range-summary .summary-left {
-      position: absolute;
-      left: 0;
-      text-align: left;
-    }
-    .stats-range .range-summary .summary-center {
-      position: absolute;
-      transform: translateX(-50%);
-      text-align: center;
-    }
-    .stats-range .range-summary .summary-right {
-      position: absolute;
-      right: 0;
-      text-align: right;
     }
     .stats-table {
       width: 100%;
@@ -805,6 +765,7 @@
                 <tr>
                   <th>Percentile</th>
                   <th>Value</th>
+                  <th>Count</th>
                 </tr>
               </thead>
               <tbody id="statsPercentiles"></tbody>
@@ -814,18 +775,14 @@
           <div>
             <strong>Histogram</strong>
             <div class="stats-range">
-              <div class="range-summary" id="statsRangeSummary">
-                <span class="summary-left" id="statsRangeLeft">0%</span>
-                <span class="summary-center" id="statsRangeCenter">0%</span>
-                <span class="summary-right" id="statsRangeRight">0%</span>
-              </div>
-              <div class="range-inputs">
-                <input id="statsRangeMinSlider" type="range" />
-                <input id="statsRangeMaxSlider" type="range" />
+              <div class="section-title">Overflow buckets</div>
+              <div class="range-values">
+                <label>Min: <input id="statsOverflowMinPct" type="number" min="0" max="100" step="0.1" />%</label>
+                <label>Max: <input id="statsOverflowMaxPct" type="number" min="0" max="100" step="0.1" />%</label>
               </div>
               <div class="range-values">
-                <label>Min: <input id="statsRangeMinInput" type="number" /></label>
-                <label>Max: <input id="statsRangeMaxInput" type="number" /></label>
+                <label>Min: <input id="statsOverflowMinAbs" type="number" step="0.1" /></label>
+                <label>Max: <input id="statsOverflowMaxAbs" type="number" step="0.1" /></label>
               </div>
             </div>
             <div id="statsHistogram" style="display: grid; grid-template-columns: repeat(10, 1fr); gap: 4px; align-items: end; height: 80px; margin-top: 6px;"></div>

--- a/viz/index.html
+++ b/viz/index.html
@@ -194,6 +194,14 @@
     .progress.indeterminate .bar { width: 30%; animation: indet 1.2s infinite linear; }
     @keyframes indet { 0% { margin-left: -30% } 100% { margin-left: 100% } }
 
+    .histogram-bar {
+      background: #3b82f6;
+      border-radius: 3px 3px 0 0;
+      min-height: 4px;
+      display: block;
+      width: 100%;
+    }
+
     /* Vertical Toolbar Styles */
     #verticalToolbar {
       position: absolute;
@@ -421,6 +429,10 @@
         <button id="legendToolButton" class="toolbar-button" title="Show/hide legend">
           <img src="./src/svg/legend.svg" alt="Legend" />
         </button>
+
+        <button id="statisticsToolButton" class="toolbar-button" title="Statistics">
+          <img src="./src/svg/chart.svg" alt="Statistics" />
+        </button>
         
         <div id="selectSubmenu" class="toolbar-submenu">
           <button class="submenu-button" data-mode="select-one" title="Select individual parcels by clicking">
@@ -642,6 +654,53 @@
         <div class="inline">
           <input id="opacity" type="range" min="0" max="1" step="0.05" value="0.9" />
           <output id="opacityVal">0.9</output>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+
+  <div id="statisticsControls" style="position: absolute; top: 10px; left: 900px; width: min(calc(92vw - 80px), 320px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
+    <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
+      <div style="font-weight: 600; font-size: 13px;">Statistics</div>
+      <button id="btnMinimizeStatistics" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M7 10l5 5 5-5z"/>
+        </svg>
+      </button>
+    </div>
+    <div id="statisticsContent" style="padding: 12px; display: grid; gap: 12px;">
+      <fieldset style="display: grid; gap: 8px;">
+        <div class="section-title">Category</div>
+        <label for="statsCategoryField">Category field</label>
+        <select id="statsCategoryField">
+          <option value="" selected disabled>Choose a field</option>
+        </select>
+        <label for="statsCategoryValue">Category value</label>
+        <select id="statsCategoryValue" disabled>
+          <option value="" selected disabled>Choose a value</option>
+        </select>
+      </fieldset>
+
+      <fieldset id="statisticsSection" style="display: none; gap: 8px;">
+        <div class="section-title">Statistic</div>
+        <label for="statsNumericField">Numeric field</label>
+        <select id="statsNumericField">
+          <option value="" selected disabled>Choose a field</option>
+        </select>
+        <div id="statsResults" style="display: grid; gap: 6px;">
+          <div><strong>Parcel count</strong>: <span id="statsParcelCount">—</span></div>
+          <div><strong>Median</strong>: <span id="statsMedian">—</span></div>
+          <div><strong>Mean</strong>: <span id="statsMean">—</span></div>
+          <div><strong>Standard deviation</strong>: <span id="statsStdDev">—</span></div>
+          <div><strong>Coefficient of dispersion</strong>: <span id="statsCod">—</span></div>
+          <div>
+            <strong>Percentiles</strong>
+            <div id="statsPercentiles" class="muted" style="display: grid; gap: 2px; margin-top: 4px;"></div>
+          </div>
+          <div>
+            <strong>Histogram</strong>
+            <div id="statsHistogram" style="display: grid; grid-template-columns: repeat(10, 1fr); gap: 4px; align-items: end; height: 80px; margin-top: 6px;"></div>
+          </div>
         </div>
       </fieldset>
     </div>

--- a/viz/index.html
+++ b/viz/index.html
@@ -201,8 +201,16 @@
       gap: 6px;
     }
     .stats-range .range-inputs {
-      display: grid;
-      gap: 4px;
+      position: relative;
+      height: 24px;
+    }
+    .stats-range .range-inputs input[type="range"] {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 100%;
+      margin: 0;
+      background: transparent;
     }
     .stats-range .range-values {
       display: grid;
@@ -216,6 +224,41 @@
       border-radius: 6px;
       border: 1px solid #ddd;
       font-size: 12px;
+    }
+    .stats-range .range-summary {
+      position: relative;
+      height: 16px;
+      font-size: 11px;
+      color: #374151;
+    }
+    .stats-range .range-summary .summary-left {
+      position: absolute;
+      left: 0;
+      text-align: left;
+    }
+    .stats-range .range-summary .summary-center {
+      position: absolute;
+      transform: translateX(-50%);
+      text-align: center;
+    }
+    .stats-range .range-summary .summary-right {
+      position: absolute;
+      right: 0;
+      text-align: right;
+    }
+    .stats-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+    .stats-table th,
+    .stats-table td {
+      padding: 4px 0;
+      text-align: left;
+    }
+    .stats-table th:last-child,
+    .stats-table td:last-child {
+      text-align: right;
     }
 
     .histogram-bar {
@@ -713,7 +756,6 @@
       <div class="divider"></div>
 
       <div id="statisticsSection" class="stats-section" style="display: none;">
-        <div class="section-title">Statistic</div>
         <label for="statsNumericField">Numeric field</label>
         <select id="statsNumericField">
           <option value="" selected disabled>Choose a field</option>
@@ -732,16 +774,36 @@
             <span>…per building size <em id="statsNormBldgUnit">(unit)</em></span>
           </label>
         </div>
+        <div class="divider"></div>
         <div id="statsResults" style="display: grid; gap: 6px;">
-          <div><strong>Parcel count</strong>: <span id="statsParcelCount">—</span></div>
-          <div><strong>Median</strong>: <span id="statsMedian">—</span></div>
-          <div><strong>Mean</strong>: <span id="statsMean">—</span></div>
-          <div><strong>Standard deviation</strong>: <span id="statsStdDev">—</span></div>
-          <div><strong>Coefficient of dispersion</strong>: <span id="statsCod">—</span></div>
+          <table class="stats-table">
+            <thead>
+              <tr>
+                <th>Statistic</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td>Parcel count</td><td><span id="statsParcelCount">—</span></td></tr>
+              <tr><td>Median</td><td><span id="statsMedian">—</span></td></tr>
+              <tr><td>Mean</td><td><span id="statsMean">—</span></td></tr>
+              <tr><td>Standard deviation</td><td><span id="statsStdDev">—</span></td></tr>
+              <tr><td>Coefficient of dispersion</td><td><span id="statsCod">—</span></td></tr>
+            </tbody>
+          </table>
+          <div class="divider"></div>
           <div>
-            <strong>Percentiles</strong>
-            <div id="statsPercentiles" class="muted" style="display: grid; gap: 2px; margin-top: 4px;"></div>
+            <table class="stats-table">
+              <thead>
+                <tr>
+                  <th>Percentile</th>
+                  <th>Value</th>
+                </tr>
+              </thead>
+              <tbody id="statsPercentiles"></tbody>
+            </table>
           </div>
+          <div class="divider"></div>
           <div>
             <strong>Histogram</strong>
             <div class="stats-range">
@@ -756,6 +818,11 @@
                 <label>Max
                   <input id="statsRangeMaxInput" type="number" />
                 </label>
+              </div>
+              <div class="range-summary" id="statsRangeSummary">
+                <span class="summary-left" id="statsRangeLeft">0%</span>
+                <span class="summary-center" id="statsRangeCenter">0%</span>
+                <span class="summary-right" id="statsRangeRight">0%</span>
               </div>
             </div>
             <div id="statsHistogram" style="display: grid; grid-template-columns: repeat(10, 1fr); gap: 4px; align-items: end; height: 80px; margin-top: 6px;"></div>

--- a/viz/index.html
+++ b/viz/index.html
@@ -777,8 +777,8 @@
             <div class="stats-range">
               <div class="section-title">Overflow buckets</div>
               <div class="range-values">
-                <label>Min: <input id="statsOverflowMinPct" type="number" min="0" max="100" step="0.1" />%</label>
-                <label>Max: <input id="statsOverflowMaxPct" type="number" min="0" max="100" step="0.1" />%</label>
+                <label>Min: <input id="statsOverflowMinPct" type="text" inputmode="decimal" data-step="0.1" /></label>
+                <label>Max: <input id="statsOverflowMaxPct" type="text" inputmode="decimal" data-step="0.1" /></label>
               </div>
               <div class="range-values">
                 <label>Min: <input id="statsOverflowMinAbs" type="number" step="0.1" /></label>

--- a/viz/index.html
+++ b/viz/index.html
@@ -194,12 +194,41 @@
     .progress.indeterminate .bar { width: 30%; animation: indet 1.2s infinite linear; }
     @keyframes indet { 0% { margin-left: -30% } 100% { margin-left: 100% } }
 
+    .stats-section { display: grid; gap: 8px; }
+    .stats-section label { display: block; font-size: 12px; color: #333; }
+    .stats-range {
+      display: grid;
+      gap: 6px;
+    }
+    .stats-range .range-inputs {
+      display: grid;
+      gap: 4px;
+    }
+    .stats-range .range-values {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      gap: 8px;
+      align-items: center;
+    }
+    .stats-range .range-values input[type="number"] {
+      width: 100%;
+      padding: 4px 6px;
+      border-radius: 6px;
+      border: 1px solid #ddd;
+      font-size: 12px;
+    }
+
     .histogram-bar {
       background: #3b82f6;
       border-radius: 3px 3px 0 0;
       min-height: 4px;
       display: block;
       width: 100%;
+    }
+    .histogram-bin {
+      display: flex;
+      align-items: flex-end;
+      height: 100%;
     }
 
     /* Vertical Toolbar Styles */
@@ -669,7 +698,7 @@
       </button>
     </div>
     <div id="statisticsContent" style="padding: 12px; display: grid; gap: 12px;">
-      <fieldset style="display: grid; gap: 8px;">
+      <div class="stats-section">
         <div class="section-title">Category</div>
         <label for="statsCategoryField">Category field</label>
         <select id="statsCategoryField">
@@ -679,14 +708,30 @@
         <select id="statsCategoryValue" disabled>
           <option value="" selected disabled>Choose a value</option>
         </select>
-      </fieldset>
+      </div>
 
-      <fieldset id="statisticsSection" style="display: none; gap: 8px;">
+      <div class="divider"></div>
+
+      <div id="statisticsSection" class="stats-section" style="display: none;">
         <div class="section-title">Statistic</div>
         <label for="statsNumericField">Numeric field</label>
         <select id="statsNumericField">
           <option value="" selected disabled>Choose a field</option>
         </select>
+        <div style="display: grid; gap: 6px;">
+          <label style="display:flex; gap:8px; align-items:center;">
+            <input type="radio" name="statsNormMode" id="stats-norm-asis" value="asis" checked />
+            <span>as-is</span>
+          </label>
+          <label style="display:flex; gap:8px; align-items:center;">
+            <input type="radio" name="statsNormMode" id="stats-norm-land" value="perLand" disabled />
+            <span>…per land size <em id="statsNormLandUnit">(unit)</em></span>
+          </label>
+          <label style="display:flex; gap:8px; align-items:center;">
+            <input type="radio" name="statsNormMode" id="stats-norm-bldg" value="perBuilding" disabled />
+            <span>…per building size <em id="statsNormBldgUnit">(unit)</em></span>
+          </label>
+        </div>
         <div id="statsResults" style="display: grid; gap: 6px;">
           <div><strong>Parcel count</strong>: <span id="statsParcelCount">—</span></div>
           <div><strong>Median</strong>: <span id="statsMedian">—</span></div>
@@ -699,10 +744,24 @@
           </div>
           <div>
             <strong>Histogram</strong>
+            <div class="stats-range">
+              <div class="range-inputs">
+                <input id="statsRangeMinSlider" type="range" />
+                <input id="statsRangeMaxSlider" type="range" />
+              </div>
+              <div class="range-values">
+                <label>Min
+                  <input id="statsRangeMinInput" type="number" />
+                </label>
+                <label>Max
+                  <input id="statsRangeMaxInput" type="number" />
+                </label>
+              </div>
+            </div>
             <div id="statsHistogram" style="display: grid; grid-template-columns: repeat(10, 1fr); gap: 4px; align-items: end; height: 80px; margin-top: 6px;"></div>
           </div>
         </div>
-      </fieldset>
+      </div>
     </div>
   </div>
 

--- a/viz/index.html
+++ b/viz/index.html
@@ -211,15 +211,22 @@
       width: 100%;
       margin: 0;
       background: transparent;
+      pointer-events: auto;
+    }
+    .stats-range .range-inputs input[type="range"]:first-child {
+      z-index: 2;
+    }
+    .stats-range .range-inputs input[type="range"]:last-child {
+      z-index: 3;
     }
     .stats-range .range-values {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-      gap: 8px;
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
       align-items: center;
     }
     .stats-range .range-values input[type="number"] {
-      width: 100%;
+      width: 90px;
       padding: 4px 6px;
       border-radius: 6px;
       border: 1px solid #ddd;
@@ -807,22 +814,18 @@
           <div>
             <strong>Histogram</strong>
             <div class="stats-range">
+              <div class="range-summary" id="statsRangeSummary">
+                <span class="summary-left" id="statsRangeLeft">0%</span>
+                <span class="summary-center" id="statsRangeCenter">0%</span>
+                <span class="summary-right" id="statsRangeRight">0%</span>
+              </div>
               <div class="range-inputs">
                 <input id="statsRangeMinSlider" type="range" />
                 <input id="statsRangeMaxSlider" type="range" />
               </div>
               <div class="range-values">
-                <label>Min
-                  <input id="statsRangeMinInput" type="number" />
-                </label>
-                <label>Max
-                  <input id="statsRangeMaxInput" type="number" />
-                </label>
-              </div>
-              <div class="range-summary" id="statsRangeSummary">
-                <span class="summary-left" id="statsRangeLeft">0%</span>
-                <span class="summary-center" id="statsRangeCenter">0%</span>
-                <span class="summary-right" id="statsRangeRight">0%</span>
+                <label>Min: <input id="statsRangeMinInput" type="number" /></label>
+                <label>Max: <input id="statsRangeMaxInput" type="number" /></label>
               </div>
             </div>
             <div id="statsHistogram" style="display: grid; grid-template-columns: repeat(10, 1fr); gap: 4px; align-items: end; height: 80px; margin-top: 6px;"></div>

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -834,7 +834,7 @@ const statsMedian = document.getElementById('statsMedian') as HTMLSpanElement;
 const statsMean = document.getElementById('statsMean') as HTMLSpanElement;
 const statsStdDev = document.getElementById('statsStdDev') as HTMLSpanElement;
 const statsCod = document.getElementById('statsCod') as HTMLSpanElement;
-const statsPercentiles = document.getElementById('statsPercentiles') as HTMLDivElement;
+const statsPercentiles = document.getElementById('statsPercentiles') as HTMLTableSectionElement;
 const statsHistogram = document.getElementById('statsHistogram') as HTMLDivElement;
 const statsNormAsIs = document.getElementById('stats-norm-asis') as HTMLInputElement;
 const statsNormLand = document.getElementById('stats-norm-land') as HTMLInputElement;
@@ -845,6 +845,10 @@ const statsRangeMinSlider = document.getElementById('statsRangeMinSlider') as HT
 const statsRangeMaxSlider = document.getElementById('statsRangeMaxSlider') as HTMLInputElement;
 const statsRangeMinInput = document.getElementById('statsRangeMinInput') as HTMLInputElement;
 const statsRangeMaxInput = document.getElementById('statsRangeMaxInput') as HTMLInputElement;
+const statsRangeSummary = document.getElementById('statsRangeSummary') as HTMLDivElement;
+const statsRangeLeft = document.getElementById('statsRangeLeft') as HTMLSpanElement;
+const statsRangeCenter = document.getElementById('statsRangeCenter') as HTMLSpanElement;
+const statsRangeRight = document.getElementById('statsRangeRight') as HTMLSpanElement;
 
 const EYE_ICON_OPEN = new URL('./svg/eye.svg', import.meta.url).href;
 const EYE_ICON_CLOSED = new URL('./svg/eye_closed.svg', import.meta.url).href;
@@ -1674,6 +1678,7 @@ function resetStatisticsDisplay() {
   statsRangeMaxSlider.disabled = true;
   statsRangeMinInput.disabled = true;
   statsRangeMaxInput.disabled = true;
+  statsRangeSummary.style.visibility = 'hidden';
 }
 
 function populateStatisticsCategoryFields() {
@@ -1815,9 +1820,11 @@ function updateHistogramRangeControls(values: number[]) {
     statsRangeMaxSlider.disabled = true;
     statsRangeMinInput.disabled = true;
     statsRangeMaxInput.disabled = true;
+    statsRangeSummary.style.visibility = 'hidden';
     return;
   }
 
+  statsRangeSummary.style.visibility = 'visible';
   statsRangeMinSlider.disabled = false;
   statsRangeMaxSlider.disabled = false;
   statsRangeMinInput.disabled = false;
@@ -1852,6 +1859,35 @@ function updateHistogramRangeControls(values: number[]) {
   statsRangeMaxSlider.value = String(statsHistogramRange.max);
   statsRangeMinInput.value = String(statsHistogramRange.min);
   statsRangeMaxInput.value = String(statsHistogramRange.max);
+}
+
+function updateHistogramSummary(values: number[], rangeMin: number, rangeMax: number) {
+  if (!values.length) {
+    statsRangeLeft.textContent = '0%';
+    statsRangeCenter.textContent = '0%';
+    statsRangeRight.textContent = '0%';
+    statsRangeCenter.style.left = '50%';
+    return;
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const total = values.length;
+  const leftCount = values.filter(v => v < rangeMin).length;
+  const middleCount = values.filter(v => v >= rangeMin && v <= rangeMax).length;
+  const rightCount = values.filter(v => v > rangeMax).length;
+  const leftPct = (leftCount / total) * 100;
+  const middlePct = (middleCount / total) * 100;
+  const rightPct = (rightCount / total) * 100;
+
+  statsRangeLeft.textContent = `${leftPct.toFixed(0)}%`;
+  statsRangeCenter.textContent = `${middlePct.toFixed(0)}%`;
+  statsRangeRight.textContent = `${rightPct.toFixed(0)}%`;
+
+  const span = max - min || 1;
+  const centerValue = (rangeMin + rangeMax) / 2;
+  const centerPercent = ((centerValue - min) / span) * 100;
+  statsRangeCenter.style.left = `${centerPercent}%`;
 }
 
 function renderStatisticsHistogram(values: number[]) {
@@ -1904,6 +1940,8 @@ function renderStatisticsHistogram(values: number[]) {
     }
     statsHistogram.appendChild(bin);
   });
+
+  updateHistogramSummary(values, range.min, range.max);
 }
 
 function updateStatisticsResults() {
@@ -1957,8 +1995,12 @@ function updateStatisticsResults() {
 
   statsPercentiles.replaceChildren();
   stats.percentiles.forEach(item => {
-    const row = document.createElement('div');
-    row.textContent = `${item.label}: ${Number.isFinite(item.value) ? fmt(item.value) : '—'}`;
+    const row = document.createElement('tr');
+    const labelCell = document.createElement('td');
+    labelCell.textContent = item.label;
+    const valueCell = document.createElement('td');
+    valueCell.textContent = Number.isFinite(item.value) ? fmt(item.value) : '—';
+    row.append(labelCell, valueCell);
     statsPercentiles.appendChild(row);
   });
 
@@ -1974,7 +2016,6 @@ function refreshStatisticsPanel() {
     populateStatisticsNumericFields();
   } else {
     statisticsSection.style.display = 'none';
-    statsNumericField = null;
   }
 
   if (statsNumericField) {
@@ -5124,25 +5165,20 @@ btnPaintMenu.addEventListener('click', togglePaint);
 statsCategoryFieldSelect.addEventListener('change', () => {
   statsCategoryField = statsCategoryFieldSelect.value || null;
   statsCategoryValueIndex = null;
-  statsNumericField = null;
-  statsHistogramRange = null;
   populateStatisticsCategoryValues(statsCategoryField);
   statisticsSection.style.display = 'none';
-  const placeholder = new Option('Choose a field', '');
-  placeholder.disabled = true;
-  placeholder.selected = true;
-  statsNumericFieldSelect.replaceChildren(placeholder);
-  statsNumericFieldSelect.disabled = true;
   resetStatisticsDisplay();
 });
 
 statsCategoryValueSelect.addEventListener('change', () => {
   statsCategoryValueIndex = statsCategoryValueSelect.value || null;
-  statsNumericField = null;
-  statsHistogramRange = null;
   if (statsCategoryValueIndex) {
     statisticsSection.style.display = 'grid';
     populateStatisticsNumericFields();
+    if (statsNumericField) {
+      updateStatisticsResults();
+      return;
+    }
   } else {
     statisticsSection.style.display = 'none';
   }

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -823,6 +823,19 @@ const settingsControlsEl = document.getElementById('settingsControls') as HTMLDi
 const settingsMenuContent = document.getElementById('settingsMenuContent') as HTMLDivElement;
 const paintControlsEl = document.getElementById('paintControls') as HTMLDivElement;
 const paintContent = document.getElementById('paintContent') as HTMLDivElement;
+const statisticsControlsEl = document.getElementById('statisticsControls') as HTMLDivElement;
+const statisticsContent = document.getElementById('statisticsContent') as HTMLDivElement;
+const statsCategoryFieldSelect = document.getElementById('statsCategoryField') as HTMLSelectElement;
+const statsCategoryValueSelect = document.getElementById('statsCategoryValue') as HTMLSelectElement;
+const statsNumericFieldSelect = document.getElementById('statsNumericField') as HTMLSelectElement;
+const statisticsSection = document.getElementById('statisticsSection') as HTMLFieldSetElement;
+const statsParcelCount = document.getElementById('statsParcelCount') as HTMLSpanElement;
+const statsMedian = document.getElementById('statsMedian') as HTMLSpanElement;
+const statsMean = document.getElementById('statsMean') as HTMLSpanElement;
+const statsStdDev = document.getElementById('statsStdDev') as HTMLSpanElement;
+const statsCod = document.getElementById('statsCod') as HTMLSpanElement;
+const statsPercentiles = document.getElementById('statsPercentiles') as HTMLDivElement;
+const statsHistogram = document.getElementById('statsHistogram') as HTMLDivElement;
 
 const EYE_ICON_OPEN = new URL('./svg/eye.svg', import.meta.url).href;
 const EYE_ICON_CLOSED = new URL('./svg/eye_closed.svg', import.meta.url).href;
@@ -859,9 +872,11 @@ if (settingsOtherActions) {
 const btnMinimizeLayers = document.getElementById('btnMinimizeLayers') as HTMLButtonElement;
 const btnMinimizeSettingsMenu = document.getElementById('btnMinimizeSettingsMenu') as HTMLButtonElement;
 const btnMinimizePaint = document.getElementById('btnMinimizePaint') as HTMLButtonElement;
+const btnMinimizeStatistics = document.getElementById('btnMinimizeStatistics') as HTMLButtonElement;
 
 // Toolbar elements
 const legendToolButton = document.getElementById('legendToolButton') as HTMLButtonElement;
+const statisticsToolButton = document.getElementById('statisticsToolButton') as HTMLButtonElement;
 
 // Floating legend elements
 const floatingLegend = document.getElementById('floatingLegend') as HTMLDivElement;
@@ -1083,7 +1098,14 @@ let isSettingsMenuMinimized = false;
 let isPaintMinimized = false;
 let isLegendVisible = true;  // Start with legend visible
 let isLegendMinimized = false;
+let isStatisticsMinimized = true;
 let hiddenLegendItems = new Set<string>(); // Track which categories/ranges are hidden
+
+// Statistics state
+let statsCategoryValueMap: Array<{ label: string; value: unknown }> = [];
+let statsCategoryField: string | null = null;
+let statsCategoryValueIndex: string | null = null;
+let statsNumericField: string | null = null;
 
 // Selection state
 let selectedLegendItems = new Set<string>(); // Track which categories/ranges are selected
@@ -1329,6 +1351,7 @@ function applyLayerState(layer: LayerState) {
   updateFloatingLegend();
   updateSelectionControls();
   renderDataStoreList();
+  refreshStatisticsPanel();
 
   if (map.getLayer(layer.layerId)) {
     setLayerVisibility(layer, layer.visible);
@@ -1453,6 +1476,7 @@ function removeLayer(layerId: string) {
       fieldSelect.replaceChildren(new Option('— load a file first —', ''));
       updateFieldTypeUI();
       updateFloatingLegend();
+      refreshStatisticsPanel();
       if (selectionControlsPanel) {
         selectionControlsPanel.style.display = 'none';
       }
@@ -1588,6 +1612,275 @@ function showLegend() {
   updateSelectionControlsPosition();
   // Update legend position
   updateLegendPosition();
+}
+
+function positionStatisticsPanel() {
+  if (!statisticsControlsEl) return;
+  if (statisticsControlsEl.dataset.userPositioned === 'true') return;
+  const anchor = (!isSettingsMenuMinimized && settingsControlsEl) ? settingsControlsEl : controlsEl;
+  if (!anchor) return;
+  const rect = anchor.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) return;
+  const gap = 10;
+  statisticsControlsEl.style.left = `${rect.right + gap}px`;
+  statisticsControlsEl.style.top = `${rect.top}px`;
+  statisticsControlsEl.style.transform = 'none';
+}
+
+function minimizeStatistics() {
+  isStatisticsMinimized = true;
+  statisticsContent.style.display = 'none';
+  statisticsControlsEl.style.display = 'none';
+  updateToolbarButtonStates();
+}
+
+function showStatistics() {
+  isStatisticsMinimized = false;
+  statisticsContent.style.display = 'grid';
+  statisticsControlsEl.style.display = 'grid';
+  positionStatisticsPanel();
+  updateToolbarButtonStates();
+}
+
+function toggleStatistics() {
+  if (isStatisticsMinimized) {
+    showStatistics();
+  } else {
+    minimizeStatistics();
+  }
+}
+
+function resetStatisticsDisplay() {
+  statsParcelCount.textContent = '—';
+  statsMedian.textContent = '—';
+  statsMean.textContent = '—';
+  statsStdDev.textContent = '—';
+  statsCod.textContent = '—';
+  statsPercentiles.replaceChildren();
+  statsHistogram.replaceChildren();
+}
+
+function populateStatisticsCategoryFields() {
+  statsCategoryFieldSelect.replaceChildren();
+  const placeholder = new Option('Choose a field', '');
+  placeholder.disabled = true;
+  placeholder.selected = true;
+  statsCategoryFieldSelect.appendChild(placeholder);
+
+  if (!currentGeoJSON) {
+    statsCategoryFieldSelect.disabled = true;
+    statsCategoryField = null;
+    return;
+  }
+
+  const availableCategorical = chosenCategoricalFields.filter(k =>
+    currentGeoJSON?.features?.some(f => f?.properties?.hasOwnProperty(k))
+  );
+
+  availableCategorical.forEach(field => {
+    statsCategoryFieldSelect.appendChild(new Option(field, field));
+  });
+
+  statsCategoryFieldSelect.disabled = availableCategorical.length === 0;
+  if (statsCategoryField && availableCategorical.includes(statsCategoryField)) {
+    statsCategoryFieldSelect.value = statsCategoryField;
+  } else {
+    statsCategoryField = null;
+  }
+}
+
+function populateStatisticsCategoryValues(field: string | null) {
+  statsCategoryValueSelect.replaceChildren();
+  const placeholder = new Option('Choose a value', '');
+  placeholder.disabled = true;
+  placeholder.selected = true;
+  statsCategoryValueSelect.appendChild(placeholder);
+
+  if (!currentGeoJSON || !field) {
+    statsCategoryValueSelect.disabled = true;
+    statsCategoryValueMap = [];
+    statsCategoryValueIndex = null;
+    return;
+  }
+
+  const valueMap = new Map<string, { label: string; value: unknown }>();
+  currentGeoJSON.features.forEach(feature => {
+    const raw = (feature.properties as Record<string, unknown> | undefined)?.[field];
+    if (raw === null || raw === undefined) return;
+    const key = `${typeof raw}:${String(raw)}`;
+    if (!valueMap.has(key)) {
+      valueMap.set(key, { label: String(raw), value: raw });
+    }
+  });
+
+  statsCategoryValueMap = Array.from(valueMap.values()).sort((a, b) => a.label.localeCompare(b.label));
+
+  const everythingOption = new Option('Everything', 'everything');
+  statsCategoryValueSelect.appendChild(everythingOption);
+
+  statsCategoryValueMap.forEach((entry, index) => {
+    statsCategoryValueSelect.appendChild(new Option(entry.label, String(index)));
+  });
+
+  statsCategoryValueSelect.disabled = false;
+
+  if (statsCategoryValueIndex === 'everything') {
+    statsCategoryValueSelect.value = 'everything';
+  } else if (statsCategoryValueIndex && statsCategoryValueMap[Number(statsCategoryValueIndex)]) {
+    statsCategoryValueSelect.value = statsCategoryValueIndex;
+  } else {
+    statsCategoryValueIndex = null;
+  }
+}
+
+function populateStatisticsNumericFields() {
+  statsNumericFieldSelect.replaceChildren();
+  const placeholder = new Option('Choose a field', '');
+  placeholder.disabled = true;
+  placeholder.selected = true;
+  statsNumericFieldSelect.appendChild(placeholder);
+
+  if (!currentGeoJSON) {
+    statsNumericFieldSelect.disabled = true;
+    statsNumericField = null;
+    return;
+  }
+
+  const availableNumeric = chosenNumericFields.filter(k =>
+    currentGeoJSON?.features?.some(f => f?.properties?.hasOwnProperty(k))
+  );
+  availableNumeric.forEach(field => {
+    statsNumericFieldSelect.appendChild(new Option(field, field));
+  });
+  statsNumericFieldSelect.disabled = availableNumeric.length === 0;
+  if (statsNumericField && availableNumeric.includes(statsNumericField)) {
+    statsNumericFieldSelect.value = statsNumericField;
+  } else {
+    statsNumericField = null;
+  }
+}
+
+function computeStatisticsValues(values: number[]) {
+  if (values.length === 0) {
+    return {
+      median: NaN,
+      mean: NaN,
+      stdDev: NaN,
+      cod: NaN,
+      percentiles: [] as Array<{ label: string; value: number }>
+    };
+  }
+
+  const mean = values.reduce((sum, v) => sum + v, 0) / values.length;
+  const median = percentile(values, 50);
+  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / values.length;
+  const stdDev = Math.sqrt(variance);
+  const absDeviation = values.reduce((sum, v) => sum + Math.abs(v - median), 0) / values.length;
+  const cod = Number.isFinite(median) && median !== 0 ? (absDeviation / Math.abs(median)) * 100 : NaN;
+  const percentiles = [10, 25, 50, 75, 90].map(p => ({
+    label: `p${p}`,
+    value: percentile(values, p)
+  }));
+
+  return { median, mean, stdDev, cod, percentiles };
+}
+
+function renderStatisticsHistogram(values: number[]) {
+  statsHistogram.replaceChildren();
+  if (values.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'muted';
+    empty.textContent = 'No data';
+    empty.style.gridColumn = '1 / -1';
+    statsHistogram.appendChild(empty);
+    return;
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const bins = 10;
+  const counts = new Array(bins).fill(0);
+  if (min === max) {
+    counts[bins - 1] = values.length;
+  } else {
+    const step = (max - min) / bins;
+    values.forEach(value => {
+      const idx = Math.min(bins - 1, Math.floor((value - min) / step));
+      counts[idx] += 1;
+    });
+  }
+
+  const maxCount = Math.max(...counts, 1);
+  counts.forEach((count, idx) => {
+    const bar = document.createElement('div');
+    bar.className = 'histogram-bar';
+    bar.style.height = `${(count / maxCount) * 100}%`;
+    const rangeStart = min + ((max - min) / bins) * idx;
+    const rangeEnd = min + ((max - min) / bins) * (idx + 1);
+    bar.title = `${fmt(rangeStart)}–${fmt(rangeEnd)} (${count})`;
+    statsHistogram.appendChild(bar);
+  });
+}
+
+function updateStatisticsResults() {
+  if (!currentGeoJSON || !statsCategoryField || !statsCategoryValueIndex || !statsNumericField) {
+    resetStatisticsDisplay();
+    return;
+  }
+
+  let selection = currentGeoJSON.features;
+  if (statsCategoryValueIndex !== 'everything') {
+    const entry = statsCategoryValueMap[Number(statsCategoryValueIndex)];
+    if (entry) {
+      selection = selection.filter(feature => {
+        const value = (feature.properties as Record<string, unknown> | undefined)?.[statsCategoryField];
+        return value === entry.value;
+      });
+    }
+  }
+
+  const totalCount = currentGeoJSON.features.length;
+  const selectionCount = selection.length;
+  const percent = totalCount > 0 ? (selectionCount / totalCount) * 100 : 0;
+  statsParcelCount.textContent = `${selectionCount.toLocaleString()} (${percent.toFixed(1)}%)`;
+
+  const values = selection
+    .map(feature => numOrNull((feature.properties as Record<string, unknown> | undefined)?.[statsNumericField]))
+    .filter((value): value is number => value !== null);
+
+  const stats = computeStatisticsValues(values);
+  statsMedian.textContent = Number.isFinite(stats.median) ? fmt(stats.median) : '—';
+  statsMean.textContent = Number.isFinite(stats.mean) ? fmt(stats.mean) : '—';
+  statsStdDev.textContent = Number.isFinite(stats.stdDev) ? fmt(stats.stdDev) : '—';
+  statsCod.textContent = Number.isFinite(stats.cod) ? `${fmt(stats.cod)}%` : '—';
+
+  statsPercentiles.replaceChildren();
+  stats.percentiles.forEach(item => {
+    const row = document.createElement('div');
+    row.textContent = `${item.label}: ${Number.isFinite(item.value) ? fmt(item.value) : '—'}`;
+    statsPercentiles.appendChild(row);
+  });
+
+  renderStatisticsHistogram(values);
+}
+
+function refreshStatisticsPanel() {
+  populateStatisticsCategoryFields();
+  populateStatisticsCategoryValues(statsCategoryField);
+
+  if (statsCategoryValueIndex) {
+    statisticsSection.style.display = 'grid';
+    populateStatisticsNumericFields();
+  } else {
+    statisticsSection.style.display = 'none';
+    statsNumericField = null;
+  }
+
+  if (statsNumericField) {
+    updateStatisticsResults();
+  } else {
+    resetStatisticsDisplay();
+  }
 }
 
 // Dragging functions
@@ -3586,6 +3879,7 @@ async function loadSelectedColumns() {
 
     // Apply gray rendering when no field is selected
     applyGrayRendering();
+    refreshStatisticsPanel();
 
     fitToData(currentGeoJSON);
     persistCurrentLayerState();
@@ -4709,7 +5003,39 @@ btnMinimizeLayers.addEventListener('click', minimizeLayers);
 btnMinimizeSettingsMenu.addEventListener('click', minimizeSettingsMenu);
 btnMinimizePaint.addEventListener('click', minimizePaint);
 btnMinimizeLegend.addEventListener('click', minimizeLegend);
+btnMinimizeStatistics.addEventListener('click', minimizeStatistics);
 btnPaintMenu.addEventListener('click', togglePaint);
+
+statsCategoryFieldSelect.addEventListener('change', () => {
+  statsCategoryField = statsCategoryFieldSelect.value || null;
+  statsCategoryValueIndex = null;
+  statsNumericField = null;
+  populateStatisticsCategoryValues(statsCategoryField);
+  statisticsSection.style.display = 'none';
+  const placeholder = new Option('Choose a field', '');
+  placeholder.disabled = true;
+  placeholder.selected = true;
+  statsNumericFieldSelect.replaceChildren(placeholder);
+  statsNumericFieldSelect.disabled = true;
+  resetStatisticsDisplay();
+});
+
+statsCategoryValueSelect.addEventListener('change', () => {
+  statsCategoryValueIndex = statsCategoryValueSelect.value || null;
+  statsNumericField = null;
+  if (statsCategoryValueIndex) {
+    statisticsSection.style.display = 'grid';
+    populateStatisticsNumericFields();
+  } else {
+    statisticsSection.style.display = 'none';
+  }
+  resetStatisticsDisplay();
+});
+
+statsNumericFieldSelect.addEventListener('change', () => {
+  statsNumericField = statsNumericFieldSelect.value || null;
+  updateStatisticsResults();
+});
 
 // No longer needed - legend toggle removed from settings
 
@@ -4722,6 +5048,7 @@ makeDraggable(controlsEl);
 makeDraggable(settingsControlsEl);
 makeDraggable(paintControlsEl);
 makeDraggable(floatingLegend);
+makeDraggable(statisticsControlsEl);
 positionPaintPanel();
 positionSettingsPanel();
 updatePaintButtonState();
@@ -4872,6 +5199,7 @@ updateFieldTypeUI();
 setQuality('high');
 renderLayerList();
 renderDataStoreList();
+refreshStatisticsPanel();
 
 function buildNumericColorRanges(): Array<{ min: number; max: number; color: string; rangeKey: string }> {
   if (!currentField || !currentGeoJSON || !currentStats) return [];
@@ -5242,6 +5570,12 @@ function initializeToolbar() {
       minimizeLegend();
     }
   });
+
+  statisticsToolButton.addEventListener('click', (e) => {
+    e.stopPropagation();
+    closeAllSubmenus();
+    toggleStatistics();
+  });
   
   // Handle submenu button clicks
   submenuButtons.forEach(button => {
@@ -5291,6 +5625,14 @@ function updateToolbarButtonStates() {
   } else {
     legendToolButton.classList.remove('inactive');
     legendToolButton.classList.add('active');
+  }
+
+  if (isStatisticsMinimized) {
+    statisticsToolButton.classList.add('inactive');
+    statisticsToolButton.classList.remove('active');
+  } else {
+    statisticsToolButton.classList.remove('inactive');
+    statisticsToolButton.classList.add('active');
   }
 
   updatePaintButtonState();

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -1784,6 +1784,8 @@ function populateStatisticsNumericFields() {
 function computeStatisticsValues(values: number[]) {
   if (values.length === 0) {
     return {
+      min: NaN,
+      max: NaN,
       median: NaN,
       mean: NaN,
       stdDev: NaN,
@@ -1792,6 +1794,8 @@ function computeStatisticsValues(values: number[]) {
     };
   }
 
+  const min = Math.min(...values);
+  const max = Math.max(...values);
   const mean = values.reduce((sum, v) => sum + v, 0) / values.length;
   const median = percentile(values, 50);
   const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / values.length;
@@ -1803,7 +1807,7 @@ function computeStatisticsValues(values: number[]) {
     value: percentile(values, p)
   }));
 
-  return { median, mean, stdDev, cod, percentiles };
+  return { min, max, median, mean, stdDev, cod, percentiles };
 }
 
 function getHistogramDomain(values: number[]) {
@@ -1988,13 +1992,18 @@ function updateStatisticsResults() {
   statsValuesCache = values;
 
   const stats = computeStatisticsValues(values);
+  const percentileRows = [
+    { label: 'min', value: stats.min },
+    ...stats.percentiles,
+    { label: 'max', value: stats.max }
+  ];
   statsMedian.textContent = Number.isFinite(stats.median) ? fmt(stats.median) : '—';
   statsMean.textContent = Number.isFinite(stats.mean) ? fmt(stats.mean) : '—';
   statsStdDev.textContent = Number.isFinite(stats.stdDev) ? fmt(stats.stdDev) : '—';
   statsCod.textContent = Number.isFinite(stats.cod) ? `${fmt(stats.cod)}%` : '—';
 
   statsPercentiles.replaceChildren();
-  stats.percentiles.forEach(item => {
+  percentileRows.forEach(item => {
     const row = document.createElement('tr');
     const labelCell = document.createElement('td');
     labelCell.textContent = item.label;

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -843,8 +843,6 @@ const statsNormLandUnitEl = document.getElementById('statsNormLandUnit') as HTML
 const statsNormBldgUnitEl = document.getElementById('statsNormBldgUnit') as HTMLElement;
 const statsOverflowMinPct = document.getElementById('statsOverflowMinPct') as HTMLInputElement;
 const statsOverflowMaxPct = document.getElementById('statsOverflowMaxPct') as HTMLInputElement;
-const statsOverflowMinAbs = document.getElementById('statsOverflowMinAbs') as HTMLInputElement;
-const statsOverflowMaxAbs = document.getElementById('statsOverflowMaxAbs') as HTMLInputElement;
 
 const EYE_ICON_OPEN = new URL('./svg/eye.svg', import.meta.url).href;
 const EYE_ICON_CLOSED = new URL('./svg/eye_closed.svg', import.meta.url).href;
@@ -1011,6 +1009,7 @@ type LayerState = {
   legendSortField: 'name' | 'count' | null;
   legendSortDirection: 'asc' | 'desc';
   customColors: Map<string, string>;
+  opacity: number;
   is3DMode: boolean;
 };
 
@@ -1118,7 +1117,6 @@ let statsNumericField: string | null = null;
 let statsNormalizationMode: 'asis' | 'perLand' | 'perBuilding' = 'asis';
 let statsValuesCache: number[] = [];
 let statsOverflowPct = { min: 5, max: 95 };
-let statsOverflowAbs: { min: number | null; max: number | null } = { min: null, max: null };
 
 // Selection state
 let selectedLegendItems = new Set<string>(); // Track which categories/ranges are selected
@@ -1248,6 +1246,7 @@ function createLayerState(name: string, dataStoreId: string): LayerState {
     legendSortField: 'count',
     legendSortDirection: 'desc',
     customColors: new Map(),
+    opacity: parseFloat(opacityInput.value),
     is3DMode: false
   };
 }
@@ -1280,6 +1279,7 @@ function persistCurrentLayerState() {
   layer.legendSortField = legendSortField;
   layer.legendSortDirection = legendSortDirection;
   layer.customColors = customColors;
+  layer.opacity = parseFloat(opacityInput.value);
   layer.is3DMode = is3DMode;
 }
 
@@ -1308,6 +1308,8 @@ function applyLayerState(layer: LayerState) {
   legendSortField = layer.legendSortField;
   legendSortDirection = layer.legendSortDirection;
   customColors = layer.customColors;
+  opacityInput.value = String(layer.opacity);
+  if (opacityOut) opacityOut.value = Number(layer.opacity).toFixed(2);
   is3DMode = layer.is3DMode;
   currentDataStoreId = layer.dataStoreId;
   const store = dataStores.get(layer.dataStoreId);
@@ -1673,8 +1675,6 @@ function resetStatisticsDisplay() {
   statsHistogram.replaceChildren();
   statsOverflowMinPct.disabled = true;
   statsOverflowMaxPct.disabled = true;
-  statsOverflowMinAbs.disabled = true;
-  statsOverflowMaxAbs.disabled = true;
 }
 
 function populateStatisticsCategoryFields() {
@@ -1806,12 +1806,6 @@ function computeStatisticsValues(values: number[]) {
   return { min, max, median, mean, stdDev, cod, percentiles };
 }
 
-function percentileRank(values: number[], value: number) {
-  if (!values.length) return 0;
-  const count = values.filter(v => v <= value).length;
-  return (count / values.length) * 100;
-}
-
 function formatPercentValue(value: number) {
   const rounded = Math.round(value * 10) / 10;
   const decimals = Number.isInteger(rounded) ? 0 : 1;
@@ -1840,27 +1834,14 @@ function updateOverflowControls(values: number[]) {
   if (values.length === 0) {
     statsOverflowMinPct.disabled = true;
     statsOverflowMaxPct.disabled = true;
-    statsOverflowMinAbs.disabled = true;
-    statsOverflowMaxAbs.disabled = true;
     return;
   }
 
   statsOverflowMinPct.disabled = false;
   statsOverflowMaxPct.disabled = false;
-  statsOverflowMinAbs.disabled = false;
-  statsOverflowMaxAbs.disabled = false;
 
   setPercentInputValue(statsOverflowMinPct, statsOverflowPct.min);
   setPercentInputValue(statsOverflowMaxPct, statsOverflowPct.max);
-
-  if (statsOverflowAbs.min === null || statsOverflowAbs.max === null) {
-    const minAbs = percentile(values, statsOverflowPct.min);
-    const maxAbs = percentile(values, statsOverflowPct.max);
-    statsOverflowAbs = { min: minAbs, max: maxAbs };
-  }
-
-  statsOverflowMinAbs.value = Number.isFinite(statsOverflowAbs.min) ? String(statsOverflowAbs.min) : '';
-  statsOverflowMaxAbs.value = Number.isFinite(statsOverflowAbs.max) ? String(statsOverflowAbs.max) : '';
 }
 
 function renderStatisticsHistogram(values: number[]) {
@@ -1877,8 +1858,8 @@ function renderStatisticsHistogram(values: number[]) {
 
   updateOverflowControls(values);
   const domain = getHistogramDomain(values);
-  const minAbs = statsOverflowAbs.min ?? percentile(values, statsOverflowPct.min);
-  const maxAbs = statsOverflowAbs.max ?? percentile(values, statsOverflowPct.max);
+  const minAbs = percentile(values, statsOverflowPct.min);
+  const maxAbs = percentile(values, statsOverflowPct.max);
   const overflowMin = Math.min(minAbs, maxAbs);
   const overflowMax = Math.max(minAbs, maxAbs);
 
@@ -5194,7 +5175,6 @@ statsCategoryValueSelect.addEventListener('change', () => {
 
 statsNumericFieldSelect.addEventListener('change', () => {
   statsNumericField = statsNumericFieldSelect.value || null;
-  statsOverflowAbs = { min: null, max: null };
   updateStatisticsResults();
 });
 
@@ -5202,7 +5182,6 @@ document.querySelectorAll<HTMLInputElement>('input[name="statsNormMode"]').forEa
   radio.addEventListener('change', () => {
     statsNormalizationMode = (document.querySelector('input[name="statsNormMode"]:checked') as HTMLInputElement)
       ?.value as 'asis' | 'perLand' | 'perBuilding';
-    statsOverflowAbs = { min: null, max: null };
     updateStatisticsResults();
   });
 });
@@ -5220,21 +5199,6 @@ function clampOverflowPercent(minValue: number, maxValue: number) {
 
 function applyOverflowFromPercent() {
   if (!statsValuesCache.length) return;
-  const minAbs = percentile(statsValuesCache, statsOverflowPct.min);
-  const maxAbs = percentile(statsValuesCache, statsOverflowPct.max);
-  statsOverflowAbs = { min: minAbs, max: maxAbs };
-  updateStatisticsResults();
-}
-
-function applyOverflowFromAbsolute() {
-  if (!statsValuesCache.length) return;
-  const minAbs = Number(statsOverflowMinAbs.value);
-  const maxAbs = Number(statsOverflowMaxAbs.value);
-  if (!Number.isFinite(minAbs) || !Number.isFinite(maxAbs)) return;
-  statsOverflowAbs = { min: minAbs, max: maxAbs };
-  const minPct = percentileRank(statsValuesCache, minAbs);
-  const maxPct = percentileRank(statsValuesCache, maxAbs);
-  clampOverflowPercent(minPct, maxPct);
   updateStatisticsResults();
 }
 
@@ -5278,13 +5242,6 @@ function bindPercentInput(input: HTMLInputElement) {
 bindPercentInput(statsOverflowMinPct);
 bindPercentInput(statsOverflowMaxPct);
 
-statsOverflowMinAbs.addEventListener('input', () => {
-  applyOverflowFromAbsolute();
-});
-
-statsOverflowMaxAbs.addEventListener('input', () => {
-  applyOverflowFromAbsolute();
-});
 
 // No longer needed - legend toggle removed from settings
 

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -828,7 +828,7 @@ const statisticsContent = document.getElementById('statisticsContent') as HTMLDi
 const statsCategoryFieldSelect = document.getElementById('statsCategoryField') as HTMLSelectElement;
 const statsCategoryValueSelect = document.getElementById('statsCategoryValue') as HTMLSelectElement;
 const statsNumericFieldSelect = document.getElementById('statsNumericField') as HTMLSelectElement;
-const statisticsSection = document.getElementById('statisticsSection') as HTMLFieldSetElement;
+const statisticsSection = document.getElementById('statisticsSection') as HTMLDivElement;
 const statsParcelCount = document.getElementById('statsParcelCount') as HTMLSpanElement;
 const statsMedian = document.getElementById('statsMedian') as HTMLSpanElement;
 const statsMean = document.getElementById('statsMean') as HTMLSpanElement;
@@ -836,6 +836,15 @@ const statsStdDev = document.getElementById('statsStdDev') as HTMLSpanElement;
 const statsCod = document.getElementById('statsCod') as HTMLSpanElement;
 const statsPercentiles = document.getElementById('statsPercentiles') as HTMLDivElement;
 const statsHistogram = document.getElementById('statsHistogram') as HTMLDivElement;
+const statsNormAsIs = document.getElementById('stats-norm-asis') as HTMLInputElement;
+const statsNormLand = document.getElementById('stats-norm-land') as HTMLInputElement;
+const statsNormBldg = document.getElementById('stats-norm-bldg') as HTMLInputElement;
+const statsNormLandUnitEl = document.getElementById('statsNormLandUnit') as HTMLElement;
+const statsNormBldgUnitEl = document.getElementById('statsNormBldgUnit') as HTMLElement;
+const statsRangeMinSlider = document.getElementById('statsRangeMinSlider') as HTMLInputElement;
+const statsRangeMaxSlider = document.getElementById('statsRangeMaxSlider') as HTMLInputElement;
+const statsRangeMinInput = document.getElementById('statsRangeMinInput') as HTMLInputElement;
+const statsRangeMaxInput = document.getElementById('statsRangeMaxInput') as HTMLInputElement;
 
 const EYE_ICON_OPEN = new URL('./svg/eye.svg', import.meta.url).href;
 const EYE_ICON_CLOSED = new URL('./svg/eye_closed.svg', import.meta.url).href;
@@ -1106,6 +1115,9 @@ let statsCategoryValueMap: Array<{ label: string; value: unknown }> = [];
 let statsCategoryField: string | null = null;
 let statsCategoryValueIndex: string | null = null;
 let statsNumericField: string | null = null;
+let statsNormalizationMode: 'asis' | 'perLand' | 'perBuilding' = 'asis';
+let statsHistogramRange: { min: number; max: number } | null = null;
+let statsValuesCache: number[] = [];
 
 // Selection state
 let selectedLegendItems = new Set<string>(); // Track which categories/ranges are selected
@@ -1658,6 +1670,10 @@ function resetStatisticsDisplay() {
   statsCod.textContent = '—';
   statsPercentiles.replaceChildren();
   statsHistogram.replaceChildren();
+  statsRangeMinSlider.disabled = true;
+  statsRangeMaxSlider.disabled = true;
+  statsRangeMinInput.disabled = true;
+  statsRangeMaxInput.disabled = true;
 }
 
 function populateStatisticsCategoryFields() {
@@ -1785,9 +1801,63 @@ function computeStatisticsValues(values: number[]) {
   return { median, mean, stdDev, cod, percentiles };
 }
 
+function getHistogramDomain(values: number[]) {
+  if (values.length === 0) {
+    return { min: 0, max: 1 };
+  }
+  return { min: Math.min(...values), max: Math.max(...values) };
+}
+
+function updateHistogramRangeControls(values: number[]) {
+  if (values.length === 0) {
+    statsHistogramRange = null;
+    statsRangeMinSlider.disabled = true;
+    statsRangeMaxSlider.disabled = true;
+    statsRangeMinInput.disabled = true;
+    statsRangeMaxInput.disabled = true;
+    return;
+  }
+
+  statsRangeMinSlider.disabled = false;
+  statsRangeMaxSlider.disabled = false;
+  statsRangeMinInput.disabled = false;
+  statsRangeMaxInput.disabled = false;
+
+  const domain = getHistogramDomain(values);
+  const span = domain.max - domain.min;
+  const step = span > 0 ? span / 100 : 1;
+
+  if (!statsHistogramRange || statsHistogramRange.min < domain.min || statsHistogramRange.max > domain.max) {
+    statsHistogramRange = { min: domain.min, max: domain.max };
+  } else {
+    statsHistogramRange = {
+      min: Math.max(domain.min, statsHistogramRange.min),
+      max: Math.min(domain.max, statsHistogramRange.max)
+    };
+  }
+
+  if (statsHistogramRange.min > statsHistogramRange.max) {
+    statsHistogramRange.min = domain.min;
+    statsHistogramRange.max = domain.max;
+  }
+
+  statsRangeMinSlider.min = String(domain.min);
+  statsRangeMinSlider.max = String(domain.max);
+  statsRangeMinSlider.step = String(step);
+  statsRangeMaxSlider.min = String(domain.min);
+  statsRangeMaxSlider.max = String(domain.max);
+  statsRangeMaxSlider.step = String(step);
+
+  statsRangeMinSlider.value = String(statsHistogramRange.min);
+  statsRangeMaxSlider.value = String(statsHistogramRange.max);
+  statsRangeMinInput.value = String(statsHistogramRange.min);
+  statsRangeMaxInput.value = String(statsHistogramRange.max);
+}
+
 function renderStatisticsHistogram(values: number[]) {
   statsHistogram.replaceChildren();
   if (values.length === 0) {
+    updateHistogramRangeControls(values);
     const empty = document.createElement('div');
     empty.className = 'muted';
     empty.textContent = 'No data';
@@ -1796,15 +1866,18 @@ function renderStatisticsHistogram(values: number[]) {
     return;
   }
 
-  const min = Math.min(...values);
-  const max = Math.max(...values);
+  updateHistogramRangeControls(values);
+  const range = statsHistogramRange ?? getHistogramDomain(values);
+  const min = range.min;
+  const max = range.max;
   const bins = 10;
   const counts = new Array(bins).fill(0);
+  const inRangeValues = values.filter(value => value >= min && value <= max);
   if (min === max) {
-    counts[bins - 1] = values.length;
+    counts[bins - 1] = inRangeValues.length;
   } else {
     const step = (max - min) / bins;
-    values.forEach(value => {
+    inRangeValues.forEach(value => {
       const idx = Math.min(bins - 1, Math.floor((value - min) / step));
       counts[idx] += 1;
     });
@@ -1812,18 +1885,30 @@ function renderStatisticsHistogram(values: number[]) {
 
   const maxCount = Math.max(...counts, 1);
   counts.forEach((count, idx) => {
-    const bar = document.createElement('div');
-    bar.className = 'histogram-bar';
-    bar.style.height = `${(count / maxCount) * 100}%`;
+    const bin = document.createElement('div');
+    bin.className = 'histogram-bin';
     const rangeStart = min + ((max - min) / bins) * idx;
     const rangeEnd = min + ((max - min) / bins) * (idx + 1);
-    bar.title = `${fmt(rangeStart)}–${fmt(rangeEnd)} (${count})`;
-    statsHistogram.appendChild(bar);
+    bin.title = `${fmt(rangeStart)}–${fmt(rangeEnd)} (${count})`;
+    if (count > 0) {
+      const bar = document.createElement('div');
+      bar.className = 'histogram-bar';
+      bar.style.height = `${(count / maxCount) * 100}%`;
+      bin.appendChild(bar);
+    } else {
+      const spacer = document.createElement('div');
+      spacer.style.height = '100%';
+      spacer.style.width = '100%';
+      spacer.style.opacity = '0';
+      bin.appendChild(spacer);
+    }
+    statsHistogram.appendChild(bin);
   });
 }
 
 function updateStatisticsResults() {
   if (!currentGeoJSON || !statsCategoryField || !statsCategoryValueIndex || !statsNumericField) {
+    statsValuesCache = [];
     resetStatisticsDisplay();
     return;
   }
@@ -1845,8 +1930,24 @@ function updateStatisticsResults() {
   statsParcelCount.textContent = `${selectionCount.toLocaleString()} (${percent.toFixed(1)}%)`;
 
   const values = selection
-    .map(feature => numOrNull((feature.properties as Record<string, unknown> | undefined)?.[statsNumericField]))
+    .map(feature => {
+      const props = (feature.properties as Record<string, unknown> | undefined) ?? {};
+      let base = numOrNull(props[statsNumericField]);
+      if (base === null) return null;
+
+      if (statsNormalizationMode === 'perLand' && landSizeField) {
+        const denom = numOrNull(props[landSizeField]);
+        if (denom === null || denom <= 0) return null;
+        base = base / denom;
+      } else if (statsNormalizationMode === 'perBuilding' && bldgSizeField) {
+        const denom = numOrNull(props[bldgSizeField]);
+        if (denom === null || denom <= 0) return null;
+        base = base / denom;
+      }
+      return base;
+    })
     .filter((value): value is number => value !== null);
+  statsValuesCache = values;
 
   const stats = computeStatisticsValues(values);
   statsMedian.textContent = Number.isFinite(stats.median) ? fmt(stats.median) : '—';
@@ -3779,6 +3880,20 @@ function setSizeState(bField: string | null, bUnit: string | null, lField: strin
   normBldg.disabled = !bldgSizeField;
   normLandUnitEl.textContent = landSizeField ? (landSizeUnitLabel ?? '(unit)') : '(unit)';
   normBldgUnitEl.textContent = bldgSizeField ? (bldgSizeUnitLabel ?? '(unit)') : '(unit)';
+
+  statsNormLand.disabled = !landSizeField;
+  statsNormBldg.disabled = !bldgSizeField;
+  statsNormLandUnitEl.textContent = landSizeField ? (landSizeUnitLabel ?? '(unit)') : '(unit)';
+  statsNormBldgUnitEl.textContent = bldgSizeField ? (bldgSizeUnitLabel ?? '(unit)') : '(unit)';
+
+  if (statsNormalizationMode === 'perLand' && !landSizeField) {
+    statsNormalizationMode = 'asis';
+    statsNormAsIs.checked = true;
+  }
+  if (statsNormalizationMode === 'perBuilding' && !bldgSizeField) {
+    statsNormalizationMode = 'asis';
+    statsNormAsIs.checked = true;
+  }
 }
 
 /* ---------------- Loading overlay helpers ---------------- */
@@ -5010,6 +5125,7 @@ statsCategoryFieldSelect.addEventListener('change', () => {
   statsCategoryField = statsCategoryFieldSelect.value || null;
   statsCategoryValueIndex = null;
   statsNumericField = null;
+  statsHistogramRange = null;
   populateStatisticsCategoryValues(statsCategoryField);
   statisticsSection.style.display = 'none';
   const placeholder = new Option('Choose a field', '');
@@ -5023,6 +5139,7 @@ statsCategoryFieldSelect.addEventListener('change', () => {
 statsCategoryValueSelect.addEventListener('change', () => {
   statsCategoryValueIndex = statsCategoryValueSelect.value || null;
   statsNumericField = null;
+  statsHistogramRange = null;
   if (statsCategoryValueIndex) {
     statisticsSection.style.display = 'grid';
     populateStatisticsNumericFields();
@@ -5034,7 +5151,72 @@ statsCategoryValueSelect.addEventListener('change', () => {
 
 statsNumericFieldSelect.addEventListener('change', () => {
   statsNumericField = statsNumericFieldSelect.value || null;
+  statsHistogramRange = null;
   updateStatisticsResults();
+});
+
+document.querySelectorAll<HTMLInputElement>('input[name="statsNormMode"]').forEach(radio => {
+  radio.addEventListener('change', () => {
+    statsNormalizationMode = (document.querySelector('input[name="statsNormMode"]:checked') as HTMLInputElement)
+      ?.value as 'asis' | 'perLand' | 'perBuilding';
+    statsHistogramRange = null;
+    updateStatisticsResults();
+  });
+});
+
+function clampHistogramRange(nextMin: number, nextMax: number) {
+  if (!statsHistogramRange) return;
+  const minLimit = Number(statsRangeMinSlider.min);
+  const maxLimit = Number(statsRangeMaxSlider.max);
+
+  let minValue = Math.max(minLimit, Math.min(nextMin, maxLimit));
+  let maxValue = Math.max(minLimit, Math.min(nextMax, maxLimit));
+
+  if (minValue > maxValue) {
+    [minValue, maxValue] = [maxValue, minValue];
+  }
+
+  statsHistogramRange.min = minValue;
+  statsHistogramRange.max = maxValue;
+
+  statsRangeMinSlider.value = String(minValue);
+  statsRangeMaxSlider.value = String(maxValue);
+  statsRangeMinInput.value = String(minValue);
+  statsRangeMaxInput.value = String(maxValue);
+}
+
+statsRangeMinSlider.addEventListener('input', () => {
+  if (!statsHistogramRange) return;
+  const nextMin = Number(statsRangeMinSlider.value);
+  const nextMax = Math.max(nextMin, Number(statsRangeMaxSlider.value));
+  clampHistogramRange(nextMin, nextMax);
+  renderStatisticsHistogram(statsValuesCache);
+});
+
+statsRangeMaxSlider.addEventListener('input', () => {
+  if (!statsHistogramRange) return;
+  const nextMax = Number(statsRangeMaxSlider.value);
+  const nextMin = Math.min(nextMax, Number(statsRangeMinSlider.value));
+  clampHistogramRange(nextMin, nextMax);
+  renderStatisticsHistogram(statsValuesCache);
+});
+
+statsRangeMinInput.addEventListener('input', () => {
+  if (!statsHistogramRange) return;
+  const nextMin = Number(statsRangeMinInput.value);
+  const nextMax = Number(statsRangeMaxInput.value);
+  if (!Number.isFinite(nextMin) || !Number.isFinite(nextMax)) return;
+  clampHistogramRange(nextMin, nextMax);
+  renderStatisticsHistogram(statsValuesCache);
+});
+
+statsRangeMaxInput.addEventListener('input', () => {
+  if (!statsHistogramRange) return;
+  const nextMin = Number(statsRangeMinInput.value);
+  const nextMax = Number(statsRangeMaxInput.value);
+  if (!Number.isFinite(nextMin) || !Number.isFinite(nextMax)) return;
+  clampHistogramRange(nextMin, nextMax);
+  renderStatisticsHistogram(statsValuesCache);
 });
 
 // No longer needed - legend toggle removed from settings

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -1812,6 +1812,23 @@ function percentileRank(values: number[], value: number) {
   return (count / values.length) * 100;
 }
 
+function formatPercentValue(value: number) {
+  const rounded = Math.round(value * 10) / 10;
+  const decimals = Number.isInteger(rounded) ? 0 : 1;
+  return `${rounded.toFixed(decimals)}%`;
+}
+
+function parsePercentInputValue(raw: string) {
+  const cleaned = raw.replace('%', '').trim();
+  if (!cleaned) return null;
+  const value = Number(cleaned);
+  return Number.isFinite(value) ? value : null;
+}
+
+function setPercentInputValue(input: HTMLInputElement, value: number) {
+  input.value = formatPercentValue(value);
+}
+
 function getHistogramDomain(values: number[]) {
   if (values.length === 0) {
     return { min: 0, max: 1 };
@@ -1833,8 +1850,8 @@ function updateOverflowControls(values: number[]) {
   statsOverflowMinAbs.disabled = false;
   statsOverflowMaxAbs.disabled = false;
 
-  statsOverflowMinPct.value = String(statsOverflowPct.min);
-  statsOverflowMaxPct.value = String(statsOverflowPct.max);
+  setPercentInputValue(statsOverflowMinPct, statsOverflowPct.min);
+  setPercentInputValue(statsOverflowMaxPct, statsOverflowPct.max);
 
   if (statsOverflowAbs.min === null || statsOverflowAbs.max === null) {
     const minAbs = percentile(values, statsOverflowPct.min);
@@ -5197,6 +5214,8 @@ function clampOverflowPercent(minValue: number, maxValue: number) {
     [minPct, maxPct] = [maxPct, minPct];
   }
   statsOverflowPct = { min: minPct, max: maxPct };
+  setPercentInputValue(statsOverflowMinPct, statsOverflowPct.min);
+  setPercentInputValue(statsOverflowMaxPct, statsOverflowPct.max);
 }
 
 function applyOverflowFromPercent() {
@@ -5216,26 +5235,48 @@ function applyOverflowFromAbsolute() {
   const minPct = percentileRank(statsValuesCache, minAbs);
   const maxPct = percentileRank(statsValuesCache, maxAbs);
   clampOverflowPercent(minPct, maxPct);
-  statsOverflowMinPct.value = String(statsOverflowPct.min);
-  statsOverflowMaxPct.value = String(statsOverflowPct.max);
   updateStatisticsResults();
 }
 
-statsOverflowMinPct.addEventListener('input', () => {
-  const minPct = Number(statsOverflowMinPct.value);
-  const maxPct = Number(statsOverflowMaxPct.value);
-  if (!Number.isFinite(minPct) || !Number.isFinite(maxPct)) return;
-  clampOverflowPercent(minPct, maxPct);
-  applyOverflowFromPercent();
-});
+function bindPercentInput(input: HTMLInputElement) {
+  input.addEventListener('focus', () => {
+    const parsed = parsePercentInputValue(input.value);
+    input.value = parsed === null ? '' : String(parsed);
+  });
+  input.addEventListener('blur', () => {
+    const parsed = parsePercentInputValue(input.value);
+    if (parsed === null) {
+      input.value = '';
+      return;
+    }
+    setPercentInputValue(input, parsed);
+  });
+  input.addEventListener('keydown', (event) => {
+    if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+    event.preventDefault();
+    const step = Number(input.dataset.step ?? '0.1');
+    const current = parsePercentInputValue(input.value) ?? 0;
+    const delta = event.key === 'ArrowUp' ? step : -step;
+    const next = Math.min(100, Math.max(0, current + delta));
+    setPercentInputValue(input, next);
+    const minPct = parsePercentInputValue(statsOverflowMinPct.value);
+    const maxPct = parsePercentInputValue(statsOverflowMaxPct.value);
+    if (minPct !== null && maxPct !== null) {
+      clampOverflowPercent(minPct, maxPct);
+      applyOverflowFromPercent();
+    }
+  });
+  input.addEventListener('input', () => {
+    const minPct = parsePercentInputValue(statsOverflowMinPct.value);
+    const maxPct = parsePercentInputValue(statsOverflowMaxPct.value);
+    if (minPct === null || maxPct === null) return;
+    clampOverflowPercent(minPct, maxPct);
+    applyOverflowFromPercent();
+  });
+}
 
-statsOverflowMaxPct.addEventListener('input', () => {
-  const minPct = Number(statsOverflowMinPct.value);
-  const maxPct = Number(statsOverflowMaxPct.value);
-  if (!Number.isFinite(minPct) || !Number.isFinite(maxPct)) return;
-  clampOverflowPercent(minPct, maxPct);
-  applyOverflowFromPercent();
-});
+bindPercentInput(statsOverflowMinPct);
+bindPercentInput(statsOverflowMaxPct);
 
 statsOverflowMinAbs.addEventListener('input', () => {
   applyOverflowFromAbsolute();

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -841,14 +841,10 @@ const statsNormLand = document.getElementById('stats-norm-land') as HTMLInputEle
 const statsNormBldg = document.getElementById('stats-norm-bldg') as HTMLInputElement;
 const statsNormLandUnitEl = document.getElementById('statsNormLandUnit') as HTMLElement;
 const statsNormBldgUnitEl = document.getElementById('statsNormBldgUnit') as HTMLElement;
-const statsRangeMinSlider = document.getElementById('statsRangeMinSlider') as HTMLInputElement;
-const statsRangeMaxSlider = document.getElementById('statsRangeMaxSlider') as HTMLInputElement;
-const statsRangeMinInput = document.getElementById('statsRangeMinInput') as HTMLInputElement;
-const statsRangeMaxInput = document.getElementById('statsRangeMaxInput') as HTMLInputElement;
-const statsRangeSummary = document.getElementById('statsRangeSummary') as HTMLDivElement;
-const statsRangeLeft = document.getElementById('statsRangeLeft') as HTMLSpanElement;
-const statsRangeCenter = document.getElementById('statsRangeCenter') as HTMLSpanElement;
-const statsRangeRight = document.getElementById('statsRangeRight') as HTMLSpanElement;
+const statsOverflowMinPct = document.getElementById('statsOverflowMinPct') as HTMLInputElement;
+const statsOverflowMaxPct = document.getElementById('statsOverflowMaxPct') as HTMLInputElement;
+const statsOverflowMinAbs = document.getElementById('statsOverflowMinAbs') as HTMLInputElement;
+const statsOverflowMaxAbs = document.getElementById('statsOverflowMaxAbs') as HTMLInputElement;
 
 const EYE_ICON_OPEN = new URL('./svg/eye.svg', import.meta.url).href;
 const EYE_ICON_CLOSED = new URL('./svg/eye_closed.svg', import.meta.url).href;
@@ -1120,8 +1116,9 @@ let statsCategoryField: string | null = null;
 let statsCategoryValueIndex: string | null = null;
 let statsNumericField: string | null = null;
 let statsNormalizationMode: 'asis' | 'perLand' | 'perBuilding' = 'asis';
-let statsHistogramRange: { min: number; max: number } | null = null;
 let statsValuesCache: number[] = [];
+let statsOverflowPct = { min: 5, max: 95 };
+let statsOverflowAbs: { min: number | null; max: number | null } = { min: null, max: null };
 
 // Selection state
 let selectedLegendItems = new Set<string>(); // Track which categories/ranges are selected
@@ -1674,11 +1671,10 @@ function resetStatisticsDisplay() {
   statsCod.textContent = '—';
   statsPercentiles.replaceChildren();
   statsHistogram.replaceChildren();
-  statsRangeMinSlider.disabled = true;
-  statsRangeMaxSlider.disabled = true;
-  statsRangeMinInput.disabled = true;
-  statsRangeMaxInput.disabled = true;
-  statsRangeSummary.style.visibility = 'hidden';
+  statsOverflowMinPct.disabled = true;
+  statsOverflowMaxPct.disabled = true;
+  statsOverflowMinAbs.disabled = true;
+  statsOverflowMaxAbs.disabled = true;
 }
 
 function populateStatisticsCategoryFields() {
@@ -1810,6 +1806,12 @@ function computeStatisticsValues(values: number[]) {
   return { min, max, median, mean, stdDev, cod, percentiles };
 }
 
+function percentileRank(values: number[], value: number) {
+  if (!values.length) return 0;
+  const count = values.filter(v => v <= value).length;
+  return (count / values.length) * 100;
+}
+
 function getHistogramDomain(values: number[]) {
   if (values.length === 0) {
     return { min: 0, max: 1 };
@@ -1817,87 +1819,37 @@ function getHistogramDomain(values: number[]) {
   return { min: Math.min(...values), max: Math.max(...values) };
 }
 
-function updateHistogramRangeControls(values: number[]) {
+function updateOverflowControls(values: number[]) {
   if (values.length === 0) {
-    statsHistogramRange = null;
-    statsRangeMinSlider.disabled = true;
-    statsRangeMaxSlider.disabled = true;
-    statsRangeMinInput.disabled = true;
-    statsRangeMaxInput.disabled = true;
-    statsRangeSummary.style.visibility = 'hidden';
+    statsOverflowMinPct.disabled = true;
+    statsOverflowMaxPct.disabled = true;
+    statsOverflowMinAbs.disabled = true;
+    statsOverflowMaxAbs.disabled = true;
     return;
   }
 
-  statsRangeSummary.style.visibility = 'visible';
-  statsRangeMinSlider.disabled = false;
-  statsRangeMaxSlider.disabled = false;
-  statsRangeMinInput.disabled = false;
-  statsRangeMaxInput.disabled = false;
+  statsOverflowMinPct.disabled = false;
+  statsOverflowMaxPct.disabled = false;
+  statsOverflowMinAbs.disabled = false;
+  statsOverflowMaxAbs.disabled = false;
 
-  const domain = getHistogramDomain(values);
-  const span = domain.max - domain.min;
-  const step = span > 0 ? span / 100 : 1;
+  statsOverflowMinPct.value = String(statsOverflowPct.min);
+  statsOverflowMaxPct.value = String(statsOverflowPct.max);
 
-  if (!statsHistogramRange || statsHistogramRange.min < domain.min || statsHistogramRange.max > domain.max) {
-    statsHistogramRange = { min: domain.min, max: domain.max };
-  } else {
-    statsHistogramRange = {
-      min: Math.max(domain.min, statsHistogramRange.min),
-      max: Math.min(domain.max, statsHistogramRange.max)
-    };
+  if (statsOverflowAbs.min === null || statsOverflowAbs.max === null) {
+    const minAbs = percentile(values, statsOverflowPct.min);
+    const maxAbs = percentile(values, statsOverflowPct.max);
+    statsOverflowAbs = { min: minAbs, max: maxAbs };
   }
 
-  if (statsHistogramRange.min > statsHistogramRange.max) {
-    statsHistogramRange.min = domain.min;
-    statsHistogramRange.max = domain.max;
-  }
-
-  statsRangeMinSlider.min = String(domain.min);
-  statsRangeMinSlider.max = String(domain.max);
-  statsRangeMinSlider.step = String(step);
-  statsRangeMaxSlider.min = String(domain.min);
-  statsRangeMaxSlider.max = String(domain.max);
-  statsRangeMaxSlider.step = String(step);
-
-  statsRangeMinSlider.value = String(statsHistogramRange.min);
-  statsRangeMaxSlider.value = String(statsHistogramRange.max);
-  statsRangeMinInput.value = String(statsHistogramRange.min);
-  statsRangeMaxInput.value = String(statsHistogramRange.max);
-}
-
-function updateHistogramSummary(values: number[], rangeMin: number, rangeMax: number) {
-  if (!values.length) {
-    statsRangeLeft.textContent = '0%';
-    statsRangeCenter.textContent = '0%';
-    statsRangeRight.textContent = '0%';
-    statsRangeCenter.style.left = '50%';
-    return;
-  }
-
-  const min = Math.min(...values);
-  const max = Math.max(...values);
-  const total = values.length;
-  const leftCount = values.filter(v => v < rangeMin).length;
-  const middleCount = values.filter(v => v >= rangeMin && v <= rangeMax).length;
-  const rightCount = values.filter(v => v > rangeMax).length;
-  const leftPct = (leftCount / total) * 100;
-  const middlePct = (middleCount / total) * 100;
-  const rightPct = (rightCount / total) * 100;
-
-  statsRangeLeft.textContent = `${leftPct.toFixed(0)}%`;
-  statsRangeCenter.textContent = `${middlePct.toFixed(0)}%`;
-  statsRangeRight.textContent = `${rightPct.toFixed(0)}%`;
-
-  const span = max - min || 1;
-  const centerValue = (rangeMin + rangeMax) / 2;
-  const centerPercent = ((centerValue - min) / span) * 100;
-  statsRangeCenter.style.left = `${centerPercent}%`;
+  statsOverflowMinAbs.value = Number.isFinite(statsOverflowAbs.min) ? String(statsOverflowAbs.min) : '';
+  statsOverflowMaxAbs.value = Number.isFinite(statsOverflowAbs.max) ? String(statsOverflowAbs.max) : '';
 }
 
 function renderStatisticsHistogram(values: number[]) {
   statsHistogram.replaceChildren();
   if (values.length === 0) {
-    updateHistogramRangeControls(values);
+    updateOverflowControls(values);
     const empty = document.createElement('div');
     empty.className = 'muted';
     empty.textContent = 'No data';
@@ -1906,29 +1858,51 @@ function renderStatisticsHistogram(values: number[]) {
     return;
   }
 
-  updateHistogramRangeControls(values);
-  const range = statsHistogramRange ?? getHistogramDomain(values);
-  const min = range.min;
-  const max = range.max;
-  const bins = 10;
-  const counts = new Array(bins).fill(0);
-  const inRangeValues = values.filter(value => value >= min && value <= max);
-  if (min === max) {
-    counts[bins - 1] = inRangeValues.length;
-  } else {
-    const step = (max - min) / bins;
-    inRangeValues.forEach(value => {
-      const idx = Math.min(bins - 1, Math.floor((value - min) / step));
-      counts[idx] += 1;
-    });
-  }
+  updateOverflowControls(values);
+  const domain = getHistogramDomain(values);
+  const minAbs = statsOverflowAbs.min ?? percentile(values, statsOverflowPct.min);
+  const maxAbs = statsOverflowAbs.max ?? percentile(values, statsOverflowPct.max);
+  const overflowMin = Math.min(minAbs, maxAbs);
+  const overflowMax = Math.max(minAbs, maxAbs);
+
+  const buckets = 10;
+  const counts = new Array(buckets).fill(0);
+  const interiorBins = buckets - 2;
+  const interiorStart = overflowMin;
+  const interiorEnd = overflowMax;
+  const interiorSpan = interiorEnd - interiorStart || 1;
+  const interiorStep = interiorSpan / interiorBins;
+
+  values.forEach(value => {
+    if (value <= overflowMin) {
+      counts[0] += 1;
+      return;
+    }
+    if (value >= overflowMax) {
+      counts[buckets - 1] += 1;
+      return;
+    }
+    const idx = Math.min(
+      interiorBins - 1,
+      Math.floor((value - interiorStart) / interiorStep)
+    );
+    counts[1 + idx] += 1;
+  });
 
   const maxCount = Math.max(...counts, 1);
   counts.forEach((count, idx) => {
     const bin = document.createElement('div');
     bin.className = 'histogram-bin';
-    const rangeStart = min + ((max - min) / bins) * idx;
-    const rangeEnd = min + ((max - min) / bins) * (idx + 1);
+    let rangeStart = domain.min;
+    let rangeEnd = domain.max;
+    if (idx === 0) {
+      rangeEnd = overflowMin;
+    } else if (idx === buckets - 1) {
+      rangeStart = overflowMax;
+    } else {
+      rangeStart = interiorStart + interiorStep * (idx - 1);
+      rangeEnd = interiorStart + interiorStep * idx;
+    }
     bin.title = `${fmt(rangeStart)}–${fmt(rangeEnd)} (${count})`;
     if (count > 0) {
       const bar = document.createElement('div');
@@ -1944,8 +1918,6 @@ function renderStatisticsHistogram(values: number[]) {
     }
     statsHistogram.appendChild(bin);
   });
-
-  updateHistogramSummary(values, range.min, range.max);
 }
 
 function updateStatisticsResults() {
@@ -2003,13 +1975,22 @@ function updateStatisticsResults() {
   statsCod.textContent = Number.isFinite(stats.cod) ? `${fmt(stats.cod)}%` : '—';
 
   statsPercentiles.replaceChildren();
+  const sortedValues = values.slice().sort((a, b) => a - b);
   percentileRows.forEach(item => {
     const row = document.createElement('tr');
     const labelCell = document.createElement('td');
     labelCell.textContent = item.label;
     const valueCell = document.createElement('td');
     valueCell.textContent = Number.isFinite(item.value) ? fmt(item.value) : '—';
-    row.append(labelCell, valueCell);
+    const countCell = document.createElement('td');
+    if (Number.isFinite(item.value)) {
+      const cutoff = item.value;
+      const count = sortedValues.filter(v => v <= cutoff).length;
+      countCell.textContent = count.toLocaleString();
+    } else {
+      countCell.textContent = '—';
+    }
+    row.append(labelCell, valueCell, countCell);
     statsPercentiles.appendChild(row);
   });
 
@@ -5196,7 +5177,7 @@ statsCategoryValueSelect.addEventListener('change', () => {
 
 statsNumericFieldSelect.addEventListener('change', () => {
   statsNumericField = statsNumericFieldSelect.value || null;
-  statsHistogramRange = null;
+  statsOverflowAbs = { min: null, max: null };
   updateStatisticsResults();
 });
 
@@ -5204,64 +5185,64 @@ document.querySelectorAll<HTMLInputElement>('input[name="statsNormMode"]').forEa
   radio.addEventListener('change', () => {
     statsNormalizationMode = (document.querySelector('input[name="statsNormMode"]:checked') as HTMLInputElement)
       ?.value as 'asis' | 'perLand' | 'perBuilding';
-    statsHistogramRange = null;
+    statsOverflowAbs = { min: null, max: null };
     updateStatisticsResults();
   });
 });
 
-function clampHistogramRange(nextMin: number, nextMax: number) {
-  if (!statsHistogramRange) return;
-  const minLimit = Number(statsRangeMinSlider.min);
-  const maxLimit = Number(statsRangeMaxSlider.max);
-
-  let minValue = Math.max(minLimit, Math.min(nextMin, maxLimit));
-  let maxValue = Math.max(minLimit, Math.min(nextMax, maxLimit));
-
-  if (minValue > maxValue) {
-    [minValue, maxValue] = [maxValue, minValue];
+function clampOverflowPercent(minValue: number, maxValue: number) {
+  let minPct = Math.max(0, Math.min(minValue, 100));
+  let maxPct = Math.max(0, Math.min(maxValue, 100));
+  if (minPct > maxPct) {
+    [minPct, maxPct] = [maxPct, minPct];
   }
-
-  statsHistogramRange.min = minValue;
-  statsHistogramRange.max = maxValue;
-
-  statsRangeMinSlider.value = String(minValue);
-  statsRangeMaxSlider.value = String(maxValue);
-  statsRangeMinInput.value = String(minValue);
-  statsRangeMaxInput.value = String(maxValue);
+  statsOverflowPct = { min: minPct, max: maxPct };
 }
 
-statsRangeMinSlider.addEventListener('input', () => {
-  if (!statsHistogramRange) return;
-  const nextMin = Number(statsRangeMinSlider.value);
-  const nextMax = Math.max(nextMin, Number(statsRangeMaxSlider.value));
-  clampHistogramRange(nextMin, nextMax);
-  renderStatisticsHistogram(statsValuesCache);
+function applyOverflowFromPercent() {
+  if (!statsValuesCache.length) return;
+  const minAbs = percentile(statsValuesCache, statsOverflowPct.min);
+  const maxAbs = percentile(statsValuesCache, statsOverflowPct.max);
+  statsOverflowAbs = { min: minAbs, max: maxAbs };
+  updateStatisticsResults();
+}
+
+function applyOverflowFromAbsolute() {
+  if (!statsValuesCache.length) return;
+  const minAbs = Number(statsOverflowMinAbs.value);
+  const maxAbs = Number(statsOverflowMaxAbs.value);
+  if (!Number.isFinite(minAbs) || !Number.isFinite(maxAbs)) return;
+  statsOverflowAbs = { min: minAbs, max: maxAbs };
+  const minPct = percentileRank(statsValuesCache, minAbs);
+  const maxPct = percentileRank(statsValuesCache, maxAbs);
+  clampOverflowPercent(minPct, maxPct);
+  statsOverflowMinPct.value = String(statsOverflowPct.min);
+  statsOverflowMaxPct.value = String(statsOverflowPct.max);
+  updateStatisticsResults();
+}
+
+statsOverflowMinPct.addEventListener('input', () => {
+  const minPct = Number(statsOverflowMinPct.value);
+  const maxPct = Number(statsOverflowMaxPct.value);
+  if (!Number.isFinite(minPct) || !Number.isFinite(maxPct)) return;
+  clampOverflowPercent(minPct, maxPct);
+  applyOverflowFromPercent();
 });
 
-statsRangeMaxSlider.addEventListener('input', () => {
-  if (!statsHistogramRange) return;
-  const nextMax = Number(statsRangeMaxSlider.value);
-  const nextMin = Math.min(nextMax, Number(statsRangeMinSlider.value));
-  clampHistogramRange(nextMin, nextMax);
-  renderStatisticsHistogram(statsValuesCache);
+statsOverflowMaxPct.addEventListener('input', () => {
+  const minPct = Number(statsOverflowMinPct.value);
+  const maxPct = Number(statsOverflowMaxPct.value);
+  if (!Number.isFinite(minPct) || !Number.isFinite(maxPct)) return;
+  clampOverflowPercent(minPct, maxPct);
+  applyOverflowFromPercent();
 });
 
-statsRangeMinInput.addEventListener('input', () => {
-  if (!statsHistogramRange) return;
-  const nextMin = Number(statsRangeMinInput.value);
-  const nextMax = Number(statsRangeMaxInput.value);
-  if (!Number.isFinite(nextMin) || !Number.isFinite(nextMax)) return;
-  clampHistogramRange(nextMin, nextMax);
-  renderStatisticsHistogram(statsValuesCache);
+statsOverflowMinAbs.addEventListener('input', () => {
+  applyOverflowFromAbsolute();
 });
 
-statsRangeMaxInput.addEventListener('input', () => {
-  if (!statsHistogramRange) return;
-  const nextMin = Number(statsRangeMinInput.value);
-  const nextMax = Number(statsRangeMaxInput.value);
-  if (!Number.isFinite(nextMin) || !Number.isFinite(nextMax)) return;
-  clampHistogramRange(nextMin, nextMax);
-  renderStatisticsHistogram(statsValuesCache);
+statsOverflowMaxAbs.addEventListener('input', () => {
+  applyOverflowFromAbsolute();
 });
 
 // No longer needed - legend toggle removed from settings

--- a/viz/src/svg/filter.svg
+++ b/viz/src/svg/filter.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+<path d="M28.4,42.7h-8.8c-0.4,0-0.9-0.2-1.2-0.5C18.1,41.9,18,41.5,18,41V24L6.2,7.9C6,7.7,5.9,7.4,5.9,7.1c0-0.3,0-0.6,0.2-0.9
+	C6.2,6,6.4,5.7,6.7,5.6c0.3-0.2,0.6-0.2,0.9-0.2h32.9c0.3,0,0.6,0.1,0.9,0.2c0.3,0.2,0.5,0.4,0.6,0.7c0.1,0.3,0.2,0.6,0.2,0.9
+	c0,0.3-0.1,0.6-0.3,0.8L30,24v17c0,0.4-0.2,0.9-0.5,1.2C29.2,42.5,28.8,42.7,28.4,42.7z M21.3,39.4h5.5V23.5c0-0.3,0.1-0.7,0.3-1
+	L37.2,8.6H10.8L21,22.5c0.2,0.3,0.3,0.6,0.3,1L21.3,39.4z"/>
+</svg>


### PR DESCRIPTION
### Motivation
- Provide an on-map Statistics window so users can compute basic descriptive stats and a histogram for a numeric field scoped by a categorical selection, matching the existing windowed UI behavior.

### Description
- Add a toolbar toggle button and new window markup in `viz/index.html` for a `Statistics` panel with two sections: `Category` (field + value, includes an `Everything` option) and `Statistic` (numeric field + results and histogram). 
- Add a `.histogram-bar` CSS rule in `viz/index.html` for simple histogram rendering.
- Implement panel state, population, and behavior in `viz/src/main.ts` including DOM references, show/hide/drag positioning consistent with other windows, and event wiring to update when layers/data change.
- Implement statistics computation and rendering functions in `viz/src/main.ts` that compute parcel count (% of total), median, mean, standard deviation, coefficient of dispersion (COD %), selected percentiles, and a 10-bin histogram, and refresh automatically on selections.

### Testing
- Started the dev server with `npm run dev` and used a Playwright script to open `http://127.0.0.1:4173/viz/`, toggle the statistics panel, and capture a screenshot; the script ran successfully and produced `artifacts/statistics-panel.png`.
- No automated unit tests were added; runtime smoke test above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697a3e7782f48326a5fecb53b75468fd)