### PR TITLE
Prevent duplicate Back button in categorical modal

### DIFF
--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -3777,8 +3777,15 @@ function openCategoricalFieldChooserModal(opts: {
   };
   
   // Add a "Back" button to return to numeric modal
+  const existingBackButton = categoricalModalOverlay.querySelector<HTMLButtonElement>(
+    'button[data-role="back-to-numeric-fields"]'
+  );
+  if (existingBackButton) {
+    existingBackButton.remove();
+  }
   const backButton = document.createElement('button');
   backButton.textContent = 'Back to Numeric Fields';
+  backButton.dataset.role = 'back-to-numeric-fields';
   backButton.onclick = () => {
     categoricalModalOverlay.classList.remove('show');
     openNumericFieldChooserModal({ 


### PR DESCRIPTION
### Motivation
- Fix an issue where repeated navigation between the categorical and numeric field chooser modals accumulated duplicate "Back to Numeric Fields" buttons in the categorical modal.

### Description
- In `viz/src/main.ts` remove any existing back button on the `categoricalModalOverlay` before creating a new one and mark the button with `data-role="back-to-numeric-fields"` to ensure a single instance is present and to keep DOM insertion idempotent.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697bdc407dcc832682632ccfe8712395)