### PR TITLE
Simplify viz layer and filter buttons

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -62,6 +62,12 @@
       flex-shrink: 0;
     }
 
+    #controls .eye-button {
+      border: none;
+      background: none;
+      padding: 2px;
+    }
+
     .eye-button img {
       width: 16px;
       height: 16px;
@@ -114,14 +120,14 @@
       gap: 4px;
     }
 
-    .layer-action-btn {
-      border: 1px solid #e5e7eb;
-      background: #f9fafb;
-      border-radius: 6px;
-      padding: 2px 6px;
-      font-size: 11px;
+    #controls .layer-action-btn {
+      border: none;
+      background: none;
+      border-radius: 0;
+      padding: 0 2px;
+      font-size: 12px;
       cursor: pointer;
-      color: #374151;
+      color: #111827;
     }
 
     .layer-action-btn:disabled {
@@ -507,18 +513,19 @@
     }
 
     .filter-control-btn {
-      border: 1px solid #e5e7eb;
-      background: #f9fafb;
-      border-radius: 6px;
-      padding: 2px 6px;
-      font-size: 11px;
+      border: none;
+      background: none;
+      border-radius: 0;
+      padding: 0;
+      font-size: 12px;
       cursor: pointer;
+      color: #111827;
     }
 
     .filter-delete-btn {
-      width: 18px;
-      height: 18px;
-      border-radius: 50%;
+      width: auto;
+      height: auto;
+      border-radius: 0;
       padding: 0;
       font-size: 12px;
       line-height: 1;


### PR DESCRIPTION
### Motivation
- Make the Layers and Filters UI controls visually consistent with the Legend by removing the button chrome and showing only the plain icons/arrows.

### Description
- Adjust CSS in `viz/index.html` to render the eye toggle as an unstyled icon and scope a minimal `#controls .eye-button` rule to the layers panel.
- Replace the styled `.layer-action-btn` appearance with plain inline text/icons scoped under `#controls .layer-action-btn` so up/down arrows and delete show as simple glyphs.
- Remove the visible chrome for filter action buttons by making `.filter-control-btn` and `.filter-delete-btn` unstyled (plain ❌ for delete).

### Testing
- Attempted `npm install` in `viz/` to run a local build, but it failed with a `403 Forbidden` from the npm registry so no build or visual verification could be run.
- No automated unit tests were present or executed for these purely cosmetic CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697be643aae4832685c9d0451a91ffcf)