### PR TITLE
Update statistics panel to support categorical fields

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -235,6 +235,10 @@
     .stats-table td:last-child {
       text-align: right;
     }
+    .stats-table-scroll {
+      max-height: 150px;
+      overflow-y: auto;
+    }
 
     .histogram-bar {
       background: #3b82f6;
@@ -917,63 +921,94 @@
       <div class="divider"></div>
 
       <div id="statisticsSection" class="stats-section" style="display: none;">
-        <select id="statsNumericField">
+        <select id="statsField">
           <option value="" selected disabled>Choose a field</option>
         </select>
-        <div style="display: grid; gap: 6px;">
-          <label style="display:flex; gap:8px; align-items:center;">
-            <input type="radio" name="statsNormMode" id="stats-norm-asis" value="asis" checked />
-            <span>as-is</span>
-          </label>
-          <label style="display:flex; gap:8px; align-items:center;">
-            <input type="radio" name="statsNormMode" id="stats-norm-land" value="perLand" disabled />
-            <span>…per land size <em id="statsNormLandUnit">(unit)</em></span>
-          </label>
-          <label style="display:flex; gap:8px; align-items:center;">
-            <input type="radio" name="statsNormMode" id="stats-norm-bldg" value="perBuilding" disabled />
-            <span>…per building size <em id="statsNormBldgUnit">(unit)</em></span>
-          </label>
-        </div>
-        <div class="divider"></div>
-        <div id="statsResults" style="display: grid; gap: 6px;">
-          <table class="stats-table">
-            <thead>
-              <tr>
-                <th>Statistic</th>
-                <th>Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr><td>Parcel count</td><td><span id="statsParcelCount">—</span></td></tr>
-              <tr><td>Median</td><td><span id="statsMedian">—</span></td></tr>
-              <tr><td>Mean</td><td><span id="statsMean">—</span></td></tr>
-              <tr><td>Standard deviation</td><td><span id="statsStdDev">—</span></td></tr>
-              <tr><td>Coefficient of dispersion</td><td><span id="statsCod">—</span></td></tr>
-            </tbody>
-          </table>
-          <div class="divider"></div>
-          <div>
+        <div id="statsDetails" style="display: none; gap: 6px;">
+          <div id="statsNumericBlock" style="display: grid; gap: 6px;">
+            <div id="statsNormalizationControls" style="display: grid; gap: 6px;">
+              <label style="display:flex; gap:8px; align-items:center;">
+                <input type="radio" name="statsNormMode" id="stats-norm-asis" value="asis" checked />
+                <span>as-is</span>
+              </label>
+              <label style="display:flex; gap:8px; align-items:center;">
+                <input type="radio" name="statsNormMode" id="stats-norm-land" value="perLand" disabled />
+                <span>…per land size <em id="statsNormLandUnit">(unit)</em></span>
+              </label>
+              <label style="display:flex; gap:8px; align-items:center;">
+                <input type="radio" name="statsNormMode" id="stats-norm-bldg" value="perBuilding" disabled />
+                <span>…per building size <em id="statsNormBldgUnit">(unit)</em></span>
+              </label>
+            </div>
+            <div class="divider"></div>
+            <div id="statsResults" style="display: grid; gap: 6px;">
+              <table class="stats-table">
+                <thead>
+                  <tr>
+                    <th>Statistic</th>
+                    <th>Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr><td>Parcel count</td><td><span id="statsParcelCount">—</span></td></tr>
+                  <tr><td>Median</td><td><span id="statsMedian">—</span></td></tr>
+                  <tr><td>Mean</td><td><span id="statsMean">—</span></td></tr>
+                  <tr><td>Standard deviation</td><td><span id="statsStdDev">—</span></td></tr>
+                  <tr><td>Coefficient of dispersion</td><td><span id="statsCod">—</span></td></tr>
+                </tbody>
+              </table>
+              <div class="divider"></div>
+              <div class="stats-table-scroll">
+                <table class="stats-table">
+                  <thead>
+                    <tr>
+                      <th>Percentile</th>
+                      <th>Value</th>
+                      <th>Count</th>
+                    </tr>
+                  </thead>
+                  <tbody id="statsPercentiles"></tbody>
+                </table>
+              </div>
+              <div class="divider"></div>
+              <div>
+                <strong>Histogram</strong>
+                <div class="stats-range">
+                  <div class="range-values">
+                    <label>Min: <input id="statsOverflowMinPct" type="text" inputmode="decimal" data-step="0.1" /></label>
+                    <label>Max: <input id="statsOverflowMaxPct" type="text" inputmode="decimal" data-step="0.1" /></label>
+                  </div>
+                </div>
+                <div id="statsHistogram" style="display: grid; grid-template-columns: repeat(10, 1fr); gap: 4px; align-items: end; height: 80px; margin-top: 6px;"></div>
+              </div>
+            </div>
+          </div>
+          <div id="statsCategoricalBlock" style="display: none; gap: 6px;">
             <table class="stats-table">
               <thead>
                 <tr>
-                  <th>Percentile</th>
+                  <th>Statistic</th>
                   <th>Value</th>
-                  <th>Count</th>
                 </tr>
               </thead>
-              <tbody id="statsPercentiles"></tbody>
+              <tbody>
+                <tr><td>Parcel count</td><td><span id="statsCategoricalParcelCount">—</span></td></tr>
+                <tr><td>Unique category values</td><td><span id="statsCategoricalUniqueCount">—</span></td></tr>
+                <tr><td>Modal category value</td><td><span id="statsCategoricalModalValue">—</span></td></tr>
+              </tbody>
             </table>
-          </div>
-          <div class="divider"></div>
-          <div>
-            <strong>Histogram</strong>
-            <div class="stats-range">
-              <div class="range-values">
-                <label>Min: <input id="statsOverflowMinPct" type="text" inputmode="decimal" data-step="0.1" /></label>
-                <label>Max: <input id="statsOverflowMaxPct" type="text" inputmode="decimal" data-step="0.1" /></label>
-              </div>
+            <div class="divider"></div>
+            <div class="stats-table-scroll">
+              <table class="stats-table">
+                <thead>
+                  <tr>
+                    <th>Value</th>
+                    <th>Count</th>
+                  </tr>
+                </thead>
+                <tbody id="statsCategoricalValues"></tbody>
+              </table>
             </div>
-            <div id="statsHistogram" style="display: grid; grid-template-columns: repeat(10, 1fr); gap: 4px; align-items: end; height: 80px; margin-top: 6px;"></div>
           </div>
         </div>
       </div>

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -837,7 +837,11 @@ const statsSubjectCategoryControls = document.getElementById('statsSubjectCatego
 const statsSubjectButtons = document.querySelectorAll<HTMLButtonElement>('[data-stats-subject]');
 const statsCategoryFieldSelect = document.getElementById('statsCategoryField') as HTMLSelectElement;
 const statsCategoryValueSelect = document.getElementById('statsCategoryValue') as HTMLSelectElement;
-const statsNumericFieldSelect = document.getElementById('statsNumericField') as HTMLSelectElement;
+const statsFieldSelect = document.getElementById('statsField') as HTMLSelectElement;
+const statsDetails = document.getElementById('statsDetails') as HTMLDivElement;
+const statsNumericBlock = document.getElementById('statsNumericBlock') as HTMLDivElement;
+const statsCategoricalBlock = document.getElementById('statsCategoricalBlock') as HTMLDivElement;
+const statsNormalizationControls = document.getElementById('statsNormalizationControls') as HTMLDivElement;
 const statisticsSection = document.getElementById('statisticsSection') as HTMLDivElement;
 const statsParcelCount = document.getElementById('statsParcelCount') as HTMLSpanElement;
 const statsMedian = document.getElementById('statsMedian') as HTMLSpanElement;
@@ -846,6 +850,10 @@ const statsStdDev = document.getElementById('statsStdDev') as HTMLSpanElement;
 const statsCod = document.getElementById('statsCod') as HTMLSpanElement;
 const statsPercentiles = document.getElementById('statsPercentiles') as HTMLTableSectionElement;
 const statsHistogram = document.getElementById('statsHistogram') as HTMLDivElement;
+const statsCategoricalParcelCount = document.getElementById('statsCategoricalParcelCount') as HTMLSpanElement;
+const statsCategoricalUniqueCount = document.getElementById('statsCategoricalUniqueCount') as HTMLSpanElement;
+const statsCategoricalModalValue = document.getElementById('statsCategoricalModalValue') as HTMLSpanElement;
+const statsCategoricalValues = document.getElementById('statsCategoricalValues') as HTMLTableSectionElement;
 const statsNormAsIs = document.getElementById('stats-norm-asis') as HTMLInputElement;
 const statsNormLand = document.getElementById('stats-norm-land') as HTMLInputElement;
 const statsNormBldg = document.getElementById('stats-norm-bldg') as HTMLInputElement;
@@ -1148,7 +1156,8 @@ let statsSubjectMode: StatsSubjectMode = 'all';
 let statsCategoryValueMap: Array<{ label: string; value: unknown }> = [];
 let statsCategoryField: string | null = null;
 let statsCategoryValueIndices: string[] = [];
-let statsNumericField: string | null = null;
+let statsField: string | null = null;
+let statsFieldType: 'numeric' | 'categorical' | null = null;
 let statsNormalizationMode: 'asis' | 'perLand' | 'perBuilding' = 'asis';
 let statsValuesCache: number[] = [];
 let statsOverflowPct = { min: 5, max: 95 };
@@ -1822,6 +1831,10 @@ function resetStatisticsDisplay() {
   statsHistogram.replaceChildren();
   statsOverflowMinPct.disabled = true;
   statsOverflowMaxPct.disabled = true;
+  statsCategoricalParcelCount.textContent = '—';
+  statsCategoricalUniqueCount.textContent = '—';
+  statsCategoricalModalValue.textContent = '—';
+  statsCategoricalValues.replaceChildren();
 }
 
 function populateStatisticsCategoryFields() {
@@ -1896,30 +1909,44 @@ function populateStatisticsCategoryValues(field: string | null) {
   }
 }
 
-function populateStatisticsNumericFields() {
-  statsNumericFieldSelect.replaceChildren();
+function getStatsFieldType(field: string | null) {
+  if (!field) return null;
+  if (chosenNumericFields.includes(field)) return 'numeric';
+  if (chosenCategoricalFields.includes(field)) return 'categorical';
+  return null;
+}
+
+function populateStatisticsFields() {
+  statsFieldSelect.replaceChildren();
   const placeholder = new Option('Choose a field', '');
   placeholder.disabled = true;
   placeholder.selected = true;
-  statsNumericFieldSelect.appendChild(placeholder);
+  statsFieldSelect.appendChild(placeholder);
 
   if (!currentGeoJSON) {
-    statsNumericFieldSelect.disabled = true;
-    statsNumericField = null;
+    statsFieldSelect.disabled = true;
+    statsField = null;
+    statsFieldType = null;
     return;
   }
 
   const availableNumeric = chosenNumericFields.filter(k =>
     currentGeoJSON?.features?.some(f => f?.properties?.hasOwnProperty(k))
   );
-  availableNumeric.forEach(field => {
-    statsNumericFieldSelect.appendChild(new Option(field, field));
+  const availableCategorical = chosenCategoricalFields.filter(k =>
+    currentGeoJSON?.features?.some(f => f?.properties?.hasOwnProperty(k))
+  );
+  const availableFields = [...availableNumeric, ...availableCategorical];
+  availableFields.forEach(field => {
+    statsFieldSelect.appendChild(new Option(field, field));
   });
-  statsNumericFieldSelect.disabled = availableNumeric.length === 0;
-  if (statsNumericField && availableNumeric.includes(statsNumericField)) {
-    statsNumericFieldSelect.value = statsNumericField;
+  statsFieldSelect.disabled = availableFields.length === 0;
+  if (statsField && availableFields.includes(statsField)) {
+    statsFieldSelect.value = statsField;
+    statsFieldType = getStatsFieldType(statsField);
   } else {
-    statsNumericField = null;
+    statsField = null;
+    statsFieldType = null;
   }
 }
 
@@ -2065,12 +2092,18 @@ function renderStatisticsHistogram(values: number[]) {
 }
 
 function updateStatisticsResults() {
-  if (!currentGeoJSON || !statsNumericField) {
+  if (!currentGeoJSON || !statsField) {
     statsValuesCache = [];
     resetStatisticsDisplay();
     return;
   }
   if (statsSubjectMode === 'category' && (!statsCategoryField || statsCategoryValueIndices.length === 0)) {
+    statsValuesCache = [];
+    resetStatisticsDisplay();
+    return;
+  }
+  statsFieldType = getStatsFieldType(statsField);
+  if (!statsFieldType) {
     statsValuesCache = [];
     resetStatisticsDisplay();
     return;
@@ -2102,60 +2135,108 @@ function updateStatisticsResults() {
   const totalCount = currentGeoJSON.features.length;
   const selectionCount = selection.length;
   const percent = totalCount > 0 ? (selectionCount / totalCount) * 100 : 0;
-  statsParcelCount.textContent = `${selectionCount.toLocaleString()} (${percent.toFixed(1)}%)`;
+  const parcelText = `${selectionCount.toLocaleString()} (${percent.toFixed(1)}%)`;
+  statsParcelCount.textContent = parcelText;
+  statsCategoricalParcelCount.textContent = parcelText;
 
-  const values = selection
-    .map(feature => {
-      const props = (feature.properties as Record<string, unknown> | undefined) ?? {};
-      let base = numOrNull(props[statsNumericField]);
-      if (base === null) return null;
+  if (statsFieldType === 'numeric') {
+    const values = selection
+      .map(feature => {
+        const props = (feature.properties as Record<string, unknown> | undefined) ?? {};
+        let base = numOrNull(props[statsField]);
+        if (base === null) return null;
 
-      if (statsNormalizationMode === 'perLand' && landSizeField) {
-        const denom = numOrNull(props[landSizeField]);
-        if (denom === null || denom <= 0) return null;
-        base = base / denom;
-      } else if (statsNormalizationMode === 'perBuilding' && bldgSizeField) {
-        const denom = numOrNull(props[bldgSizeField]);
-        if (denom === null || denom <= 0) return null;
-        base = base / denom;
+        if (statsNormalizationMode === 'perLand' && landSizeField) {
+          const denom = numOrNull(props[landSizeField]);
+          if (denom === null || denom <= 0) return null;
+          base = base / denom;
+        } else if (statsNormalizationMode === 'perBuilding' && bldgSizeField) {
+          const denom = numOrNull(props[bldgSizeField]);
+          if (denom === null || denom <= 0) return null;
+          base = base / denom;
+        }
+        return base;
+      })
+      .filter((value): value is number => value !== null);
+    statsValuesCache = values;
+
+    const stats = computeStatisticsValues(values);
+    const percentileRows = [
+      { label: 'min', value: stats.min },
+      ...stats.percentiles,
+      { label: 'max', value: stats.max }
+    ];
+    statsMedian.textContent = Number.isFinite(stats.median) ? fmt(stats.median) : '—';
+    statsMean.textContent = Number.isFinite(stats.mean) ? fmt(stats.mean) : '—';
+    statsStdDev.textContent = Number.isFinite(stats.stdDev) ? fmt(stats.stdDev) : '—';
+    statsCod.textContent = Number.isFinite(stats.cod) ? `${fmt(stats.cod)}%` : '—';
+
+    statsPercentiles.replaceChildren();
+    const sortedValues = values.slice().sort((a, b) => a - b);
+    percentileRows.forEach(item => {
+      const row = document.createElement('tr');
+      const labelCell = document.createElement('td');
+      labelCell.textContent = item.label;
+      const valueCell = document.createElement('td');
+      valueCell.textContent = Number.isFinite(item.value) ? fmt(item.value) : '—';
+      const countCell = document.createElement('td');
+      if (Number.isFinite(item.value)) {
+        const cutoff = item.value;
+        const count = sortedValues.filter(v => v <= cutoff).length;
+        countCell.textContent = count.toLocaleString();
+      } else {
+        countCell.textContent = '—';
       }
-      return base;
-    })
-    .filter((value): value is number => value !== null);
-  statsValuesCache = values;
+      row.append(labelCell, valueCell, countCell);
+      statsPercentiles.appendChild(row);
+    });
 
-  const stats = computeStatisticsValues(values);
-  const percentileRows = [
-    { label: 'min', value: stats.min },
-    ...stats.percentiles,
-    { label: 'max', value: stats.max }
-  ];
-  statsMedian.textContent = Number.isFinite(stats.median) ? fmt(stats.median) : '—';
-  statsMean.textContent = Number.isFinite(stats.mean) ? fmt(stats.mean) : '—';
-  statsStdDev.textContent = Number.isFinite(stats.stdDev) ? fmt(stats.stdDev) : '—';
-  statsCod.textContent = Number.isFinite(stats.cod) ? `${fmt(stats.cod)}%` : '—';
+    renderStatisticsHistogram(values);
+    return;
+  }
 
+  statsValuesCache = [];
+  statsMedian.textContent = '—';
+  statsMean.textContent = '—';
+  statsStdDev.textContent = '—';
+  statsCod.textContent = '—';
   statsPercentiles.replaceChildren();
-  const sortedValues = values.slice().sort((a, b) => a - b);
-  percentileRows.forEach(item => {
-    const row = document.createElement('tr');
-    const labelCell = document.createElement('td');
-    labelCell.textContent = item.label;
-    const valueCell = document.createElement('td');
-    valueCell.textContent = Number.isFinite(item.value) ? fmt(item.value) : '—';
-    const countCell = document.createElement('td');
-    if (Number.isFinite(item.value)) {
-      const cutoff = item.value;
-      const count = sortedValues.filter(v => v <= cutoff).length;
-      countCell.textContent = count.toLocaleString();
-    } else {
-      countCell.textContent = '—';
-    }
-    row.append(labelCell, valueCell, countCell);
-    statsPercentiles.appendChild(row);
+  statsHistogram.replaceChildren();
+  statsOverflowMinPct.disabled = true;
+  statsOverflowMaxPct.disabled = true;
+
+  const counts = new Map<string, number>();
+  selection.forEach(feature => {
+    const props = (feature.properties as Record<string, unknown> | undefined) ?? {};
+    const raw = props[statsField];
+    if (raw === null || raw === undefined || raw === '') return;
+    const key = String(raw);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
   });
 
-  renderStatisticsHistogram(values);
+  statsCategoricalUniqueCount.textContent = counts.size.toLocaleString();
+  const entries = Array.from(counts.entries()).map(([label, count]) => ({ label, count }));
+  entries.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.label.localeCompare(b.label);
+  });
+  if (entries.length > 0) {
+    const modal = entries[0];
+    statsCategoricalModalValue.textContent = `${modal.label} (${modal.count.toLocaleString()})`;
+  } else {
+    statsCategoricalModalValue.textContent = '—';
+  }
+
+  statsCategoricalValues.replaceChildren();
+  entries.forEach(entry => {
+    const row = document.createElement('tr');
+    const valueCell = document.createElement('td');
+    valueCell.textContent = entry.label;
+    const countCell = document.createElement('td');
+    countCell.textContent = entry.count.toLocaleString();
+    row.append(valueCell, countCell);
+    statsCategoricalValues.appendChild(row);
+  });
 }
 
 function updateStatisticsSubjectControls() {
@@ -2182,9 +2263,32 @@ function setStatsSubjectMode(mode: StatsSubjectMode) {
 function updateStatisticsSectionVisibility() {
   const shouldShow = statsSubjectMode !== 'category' || statsCategoryValueIndices.length > 0;
   statisticsSection.style.display = shouldShow ? 'grid' : 'none';
-  if (shouldShow) {
-    populateStatisticsNumericFields();
+  if (!shouldShow) {
+    statsDetails.style.display = 'none';
+    statsNumericBlock.style.display = 'none';
+    statsCategoricalBlock.style.display = 'none';
+    return;
   }
+  populateStatisticsFields();
+  const hasField = Boolean(statsField);
+  statsDetails.style.display = hasField ? 'grid' : 'none';
+  if (!hasField) {
+    statsFieldType = null;
+    statsNumericBlock.style.display = 'none';
+    statsCategoricalBlock.style.display = 'none';
+    return;
+  }
+  statsFieldType = getStatsFieldType(statsField);
+  if (!statsFieldType) {
+    statsNumericBlock.style.display = 'none';
+    statsCategoricalBlock.style.display = 'none';
+    statsNormalizationControls.style.display = 'none';
+    return;
+  }
+  const isNumeric = statsFieldType === 'numeric';
+  statsNumericBlock.style.display = isNumeric ? 'grid' : 'none';
+  statsCategoricalBlock.style.display = isNumeric ? 'none' : 'grid';
+  statsNormalizationControls.style.display = isNumeric ? 'grid' : 'none';
 }
 
 function refreshStatisticsPanel() {
@@ -2195,7 +2299,7 @@ function refreshStatisticsPanel() {
   updateStatisticsSubjectControls();
   updateStatisticsSectionVisibility();
 
-  if (statsNumericField) {
+  if (statsField) {
     updateStatisticsResults();
   } else {
     resetStatisticsDisplay();
@@ -5899,16 +6003,22 @@ statsCategoryValueSelect.addEventListener('change', () => {
     .map(option => option.value)
     .filter(value => value);
   updateStatisticsSectionVisibility();
-  if (statsCategoryValueIndices.length > 0 && statsNumericField) {
+  if (statsCategoryValueIndices.length > 0 && statsField) {
     updateStatisticsResults();
     return;
   }
   resetStatisticsDisplay();
 });
 
-statsNumericFieldSelect.addEventListener('change', () => {
-  statsNumericField = statsNumericFieldSelect.value || null;
-  updateStatisticsResults();
+statsFieldSelect.addEventListener('change', () => {
+  statsField = statsFieldSelect.value || null;
+  statsFieldType = getStatsFieldType(statsField);
+  updateStatisticsSectionVisibility();
+  if (statsField) {
+    updateStatisticsResults();
+  } else {
+    resetStatisticsDisplay();
+  }
 });
 
 document.querySelectorAll<HTMLInputElement>('input[name="statsNormMode"]').forEach(radio => {


### PR DESCRIPTION
### Motivation
- Make the Statistics UI hide results until a concrete field is selected and allow any field (numeric or categorical) to be chosen instead of only numeric fields.
- Preserve existing numeric statistics behavior when a numeric field is selected and provide an alternate categorical statistics presentation when a categorical field is selected.

### Description
- Replaced the numeric-only selector with a unified `statsField` selector and added state for `statsFieldType` in `viz/src/main.ts`, and updated listeners to drive the new selector logic.
- Added `statsDetails` container with two blocks: `statsNumericBlock` (existing numeric stats, percentiles and histogram) and `statsCategoricalBlock` (categorical summary table and a scrollable value/count table), and a `.stats-table-scroll` CSS helper in `viz/index.html` to constrain and scroll long categorical lists.
- Implemented categorical computations in `updateStatisticsResults()` to compute parcel count, unique category count, modal value (with count), and a descending-sorted value/count table; numeric flow remains unchanged and reuses existing percentile/histogram logic.
- Updated show/hide logic so everything below the subject section is blank/hidden until a field is selected and the UI toggles between numeric vs categorical displays as appropriate; changed relevant DOM ids and hookups (`statsNumericField` → `statsField`, etc.).

### Testing
- Attempted `npm install` in the `viz` folder to run the app, but the install failed with an npm registry `403 Forbidden` error when fetching `geoparquet`, so the dev server and runtime verification were not executed.
- No automated unit or integration tests were run as part of this change due to the inability to build the `viz` dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697c0a1085ec8326a97138c11aaa00cd)