### PR TITLE
Update Land Schedule layout and simplify unit handling

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -1080,47 +1080,45 @@
       </button>
     </div>
     <div id="landScheduleContent" style="padding: 12px; display: grid; gap: 12px;">
-      <fieldset class="land-schedule-section">
-        <label>Market Area</label>
+      <div class="land-schedule-section">
+        <div class="land-schedule-subtitle">Market Area</div>
         <div class="land-schedule-row">
           <select id="landScheduleFieldSelect">
             <option value="" selected disabled>Choose a field</option>
           </select>
         </div>
         <div id="landScheduleValueRow" class="land-schedule-row" style="display: none;">
-          <label>Schedule for: <span id="landScheduleFieldLabel"></span> =</label>
+          <label><span id="landScheduleFieldLabel"></span>:</label>
           <select id="landScheduleValueSelect"></select>
         </div>
-      </fieldset>
+      </div>
 
       <div class="divider"></div>
 
       <div id="landScheduleValuationSection" style="display: none; gap: 10px;">
         <div class="land-schedule-subtitle">Valuation</div>
         <div class="land-schedule-subtitle" style="margin-top: 6px;">Base lot</div>
-        <div class="land-schedule-row split">
-          <label>Size range:</label>
+        <div class="land-schedule-row">
+          <div class="land-schedule-subtitle" style="font-weight: 500;">Size range</div>
           <div class="land-schedule-row split" style="gap: 8px;">
-            <label>min: <input id="landScheduleBaseMin" type="number" inputmode="decimal" /></label>
-            <label>max: <input id="landScheduleBaseMax" type="number" inputmode="decimal" /></label>
+            <label>min <input id="landScheduleBaseMin" type="number" inputmode="decimal" /></label>
+            <label>max <input id="landScheduleBaseMax" type="number" inputmode="decimal" /></label>
           </div>
         </div>
-        <div class="land-schedule-row inline">
-          <label>Value:</label>
-          <input id="landScheduleBaseValue" type="number" inputmode="decimal" />
-          <span>per:</span>
-          <select id="landScheduleBasePer">
-            <option value="" selected disabled>Select</option>
-            <option value="lot">lot</option>
-            <option value="area">area</option>
-            <option value="frontage">frontage</option>
-          </select>
-          <div id="landScheduleUnitRow" class="land-schedule-inline-unit" style="display: none;">
-            <span>unit:</span>
-            <select id="landScheduleBaseUnit">
+        <div class="land-schedule-row">
+          <label>value
+            <input id="landScheduleBaseValue" type="number" inputmode="decimal" />
+          </label>
+        </div>
+        <div class="land-schedule-row">
+          <label>per size unit:
+            <select id="landScheduleBasePer">
               <option value="" selected disabled>Select</option>
+              <option value="lot">lot</option>
+              <option value="area">area</option>
+              <option value="frontage">frontage</option>
             </select>
-          </div>
+          </label>
         </div>
       </div>
     </div>

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -887,8 +887,6 @@ const landScheduleBaseMin = document.getElementById('landScheduleBaseMin') as HT
 const landScheduleBaseMax = document.getElementById('landScheduleBaseMax') as HTMLInputElement;
 const landScheduleBaseValue = document.getElementById('landScheduleBaseValue') as HTMLInputElement;
 const landScheduleBasePer = document.getElementById('landScheduleBasePer') as HTMLSelectElement;
-const landScheduleUnitRow = document.getElementById('landScheduleUnitRow') as HTMLDivElement;
-const landScheduleBaseUnit = document.getElementById('landScheduleBaseUnit') as HTMLSelectElement;
 
 const EYE_ICON_OPEN = new URL('./svg/eye.svg', import.meta.url).href;
 const EYE_ICON_CLOSED = new URL('./svg/eye_closed.svg', import.meta.url).href;
@@ -1222,13 +1220,11 @@ type SubjectSelectorControls = {
 };
 
 type LandSchedulePerUnit = 'lot' | 'area' | 'frontage';
-type LandScheduleUnit = 'sqft' | 'acre' | 'sqm' | 'hectare' | 'foot' | 'meter';
 type LandScheduleBaseLot = {
   min: number | null;
   max: number | null;
   value: number | null;
   per: LandSchedulePerUnit | null;
-  unit: LandScheduleUnit | null;
 };
 
 const LAND_SCHEDULE_DEFAULT_KEY = '__default__';
@@ -3851,8 +3847,7 @@ function getLandScheduleEntry(field: string, valueKey: string): LandScheduleBase
       min: null,
       max: null,
       value: null,
-      per: null,
-      unit: null
+      per: null
     };
     fieldMap.set(valueKey, entry);
   }
@@ -3877,26 +3872,6 @@ function setLandScheduleInputValue(input: HTMLInputElement, value: number | null
   input.value = value === null ? '' : String(value);
 }
 
-function updateLandScheduleUnitOptions(per: LandSchedulePerUnit | null) {
-  const placeholder = new Option('Select', '');
-  placeholder.disabled = true;
-  landScheduleBaseUnit.replaceChildren(placeholder);
-  landScheduleBaseUnit.value = '';
-  if (!per || per === 'lot') {
-    landScheduleUnitRow.style.display = 'none';
-    return;
-  }
-
-  const options = per === 'area'
-    ? (['sqft', 'acre', 'sqm', 'hectare'] as LandScheduleUnit[])
-    : (['foot', 'meter'] as LandScheduleUnit[]);
-
-  options.forEach(unit => {
-    landScheduleBaseUnit.appendChild(new Option(unit, unit));
-  });
-  landScheduleUnitRow.style.display = 'inline-flex';
-}
-
 function updateLandScheduleInputsFromStore() {
   if (!currentLandScheduleField || !currentLandScheduleValue) {
     landScheduleValuationSection.style.display = 'none';
@@ -3908,8 +3883,6 @@ function updateLandScheduleInputsFromStore() {
   setLandScheduleInputValue(landScheduleBaseMax, entry.max);
   setLandScheduleInputValue(landScheduleBaseValue, entry.value);
   landScheduleBasePer.value = entry.per ?? '';
-  updateLandScheduleUnitOptions(entry.per);
-  landScheduleBaseUnit.value = entry.unit ?? '';
   landScheduleValuationSection.style.display = 'grid';
   isUpdatingLandScheduleUI = false;
 }
@@ -3921,12 +3894,6 @@ function updateLandScheduleStoreFromInputs() {
   entry.max = parseOptionalNumber(landScheduleBaseMax.value);
   entry.value = parseOptionalNumber(landScheduleBaseValue.value);
   entry.per = (landScheduleBasePer.value as LandSchedulePerUnit) || null;
-  entry.unit = landScheduleBaseUnit.value
-    ? (landScheduleBaseUnit.value as LandScheduleUnit)
-    : null;
-  if (entry.per === 'lot') {
-    entry.unit = null;
-  }
 }
 
 function updateLandScheduleValueOptions() {
@@ -6912,14 +6879,8 @@ landScheduleBaseMin.addEventListener('input', updateLandScheduleStoreFromInputs)
 landScheduleBaseMax.addEventListener('input', updateLandScheduleStoreFromInputs);
 landScheduleBaseValue.addEventListener('input', updateLandScheduleStoreFromInputs);
 landScheduleBasePer.addEventListener('change', () => {
-  const per = (landScheduleBasePer.value as LandSchedulePerUnit) || null;
-  updateLandScheduleUnitOptions(per);
-  if (per === 'lot') {
-    landScheduleBaseUnit.value = '';
-  }
   updateLandScheduleStoreFromInputs();
 });
-landScheduleBaseUnit.addEventListener('change', updateLandScheduleStoreFromInputs);
 
 addFilterButton.addEventListener('click', () => {
   filters.push(createFilterRule());


### PR DESCRIPTION
### Motivation
- Align the Land Schedule panel with the requested UI: present a simple "Market Area" section and rebuild the valuation inputs to a clear "Valuation / Base lot" layout.
- Remove the previous per-unit UI complexity and associated unit state so the base-lot record only stores `min`, `max`, `value`, and `per` as requested.

### Description
- Replace the `fieldset` Market Area block with a plain section using the `land-schedule-subtitle` styling and change the label from `Schedule for: <field> =` to `<field>:` in `viz/index.html`.
- Rebuild the Valuation section in `viz/index.html` to include a `Base lot` subsection with a `Size range` subheader, two numeric inputs (`min` and `max`), a numeric `value` input, and a `per size unit:` dropdown with options `lot`, `area`, and `frontage`.
- Simplify the land-schedule data model and UI sync in `viz/src/main.ts` by removing the `LandScheduleUnit` type, removing DOM references to the removed `landScheduleBaseUnit`/`landScheduleUnitRow`, and deleting `updateLandScheduleUnitOptions` and all unit-specific wiring so the store no longer tracks unit tokens.
- Adjust input sync and event handlers to read/write `min`, `max`, `value`, and `per` only.

### Testing
- Started a local static server with `python -m http.server 8000` to serve `viz/index.html`, which launched successfully.
- Ran automated Playwright attempts to open the page and capture a screenshot to validate the panel, but the Playwright runs timed out and did not complete (failed). 
- No automated unit tests or build/test steps were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d0c241f208326a1387cfda280721a)