### PR TITLE
Adjust land schedule valuation layout

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -597,6 +597,10 @@
       align-items: end;
       margin-right:20px;
     }
+
+    .land-schedule-row.split.land-schedule-fields {
+      align-items: start;
+    }
     
     .land-schedule-row.split input {
       width: 120px;
@@ -604,6 +608,28 @@
 
     .land-schedule-row.split label {
       font-size: 12px;
+    }
+
+    .land-schedule-field {
+      display: grid;
+      gap: 4px;
+      font-size: 12px;
+    }
+
+    .land-schedule-box-title {
+      font-weight: 600;
+      font-size: 12px;
+      color: #333;
+      margin-top: 6px;
+    }
+
+    .land-schedule-box {
+      border: 1px solid #e1e1e1;
+      border-radius: 8px;
+      padding: 10px;
+      display: grid;
+      gap: 8px;
+      background: #fff;
     }
 
     .land-schedule-row.inline {
@@ -1108,26 +1134,36 @@
 
       <div id="landScheduleValuationSection" style="display: none; gap: 10px;">
         <div class="land-schedule-subtitle">Valuation</div>
-        <div class="land-schedule-subtitle" style="margin-top: 6px;">Base lot</div>
-        <div class="land-schedule-row">
-          <div class="land-schedule-subtitle" style="font-weight: 500;">Size range</div>
-          <div class="land-schedule-row split" style="gap: 8px;">
-            <label>Min <input id="landScheduleBaseMin" type="number" inputmode="decimal" /></label>
-            <label>Max <input id="landScheduleBaseMax" type="number" inputmode="decimal" /></label>
+        <div class="land-schedule-box-title">Base lot</div>
+        <div class="land-schedule-box">
+          <div class="land-schedule-row">
+            <div class="land-schedule-subtitle" style="font-weight: 500;">Size range</div>
+            <div class="land-schedule-row split land-schedule-fields" style="gap: 8px;">
+              <label class="land-schedule-field">
+                <span>Min</span>
+                <input id="landScheduleBaseMin" type="number" inputmode="decimal" />
+              </label>
+              <label class="land-schedule-field">
+                <span>Max</span>
+                <input id="landScheduleBaseMax" type="number" inputmode="decimal" />
+              </label>
+            </div>
           </div>
-        </div>
-        <div class="land-schedule-row split" style="gap: 8px;">
-          <label>value
-            <input id="landScheduleBaseValue" type="number" inputmode="decimal" />
-          </label>
-          <label>per size unit:
-            <select id="landScheduleBasePer">
-              <option value="" selected disabled>Select</option>
-              <option value="lot">lot</option>
-              <option value="area">area</option>
-              <option value="frontage">frontage</option>
-            </select>
-          </label>
+          <div class="land-schedule-row split land-schedule-fields" style="gap: 8px;">
+            <label class="land-schedule-field">
+              <span>Value</span>
+              <input id="landScheduleBaseValue" type="number" inputmode="decimal" />
+            </label>
+            <label class="land-schedule-field">
+              <span>Per size unit</span>
+              <select id="landScheduleBasePer">
+                <option value="" selected disabled>Select</option>
+                <option value="lot">lot</option>
+                <option value="area">area</option>
+                <option value="frontage">frontage</option>
+              </select>
+            </label>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation

- Improve the Land Schedule -> Valuation -> Base lot UI so it matches the requested design by boxing the Base lot area and placing field labels above inputs for clarity and consistency.

### Description

- Added layout CSS helpers and a boxed panel: `.land-schedule-box`, `.land-schedule-box-title`, `.land-schedule-field`, and a modifier `.land-schedule-row.split.land-schedule-fields` to support stacked labels and inputs.
- Reworked the Valuation -> Base lot markup to wrap inputs in the new `.land-schedule-box` and moved labels into `<span>` elements above the corresponding `<input>`/`<select>` to stack titles over fields.
- Adjusted sizing/alignment rules for split rows so the Min/Max and Value/Per-size unit fields align vertically as requested.
- All changes are contained in a single file: `viz/index.html`.

### Testing

- Started a local static server with `python -m http.server` and verified `curl -I http://127.0.0.1:8000/viz/index.html` returned `200 OK` which confirms the modified page is being served.
- Ran an automated Playwright script that produced a full-page screenshot of the loaded viz page successfully, but a subsequent Playwright click to open the Land Schedule panel timed out (the page load succeeded while the interactive click failed); screenshot artifact was created by the script.
- No unit tests apply to this UI-only change. All automated checks that were executed are listed above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d20972b24832695370b1b4ebb6151)