### PR TITLE
Scatterplot: add explicit axis extent controls and disable Plotly interactive defaults

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -1091,14 +1091,41 @@
       <div class="divider"></div>
       <div class="stats-section" style="display: grid; gap: 8px;">
         <div style="font-weight: 600; font-size: 12px;">Plot</div>
-        <label style="display: grid; gap: 4px; font-size: 12px;">
-          <span>X:</span>
-          <select id="scatterXField"></select>
-        </label>
-        <label style="display: grid; gap: 4px; font-size: 12px;">
-          <span>Y:</span>
-          <select id="scatterYField"></select>
-        </label>
+        <div style="display: grid; gap: 8px; font-size: 12px;">
+          <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 8px;">
+            <label style="display: flex; align-items: center; gap: 6px; flex: 1 1 160px;">
+              <span style="font-weight: 600;">X:</span>
+              <select id="scatterXField" style="flex: 1;"></select>
+            </label>
+            <label style="display: flex; align-items: center; gap: 4px;">
+              <span class="muted">min:</span>
+              <input id="scatterXMin" type="number" inputmode="decimal" style="width: 86px;" disabled />
+            </label>
+            <label style="display: flex; align-items: center; gap: 4px;">
+              <span class="muted">max:</span>
+              <input id="scatterXMax" type="number" inputmode="decimal" style="width: 86px;" disabled />
+            </label>
+          </div>
+          <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 8px;">
+            <label style="display: flex; align-items: center; gap: 6px; flex: 1 1 160px;">
+              <span style="font-weight: 600;">Y:</span>
+              <select id="scatterYField" style="flex: 1;"></select>
+            </label>
+            <label style="display: flex; align-items: center; gap: 4px;">
+              <span class="muted">min:</span>
+              <input id="scatterYMin" type="number" inputmode="decimal" style="width: 86px;" disabled />
+            </label>
+            <label style="display: flex; align-items: center; gap: 4px;">
+              <span class="muted">max:</span>
+              <input id="scatterYMax" type="number" inputmode="decimal" style="width: 86px;" disabled />
+            </label>
+          </div>
+          <div style="display: flex; justify-content: flex-end;">
+            <button id="scatterResetExtents" type="button" class="toolbar-button" style="height: 28px; padding: 0 10px; font-size: 12px;" disabled>
+              Reset extents
+            </button>
+          </div>
+        </div>
         <div id="scatterPlotEmpty" class="muted" style="display: none;">Select X and Y fields to render the scatterplot.</div>
         <div id="scatterPlot" style="height: 220px; width: 100%;"></div>
       </div>

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -831,6 +831,11 @@ const scatterplotContent = document.getElementById('scatterplotContent') as HTML
 const scatterSubjectSection = document.getElementById('scatterSubjectSection') as HTMLDivElement;
 const scatterXFieldSelect = document.getElementById('scatterXField') as HTMLSelectElement;
 const scatterYFieldSelect = document.getElementById('scatterYField') as HTMLSelectElement;
+const scatterXMinInput = document.getElementById('scatterXMin') as HTMLInputElement;
+const scatterXMaxInput = document.getElementById('scatterXMax') as HTMLInputElement;
+const scatterYMinInput = document.getElementById('scatterYMin') as HTMLInputElement;
+const scatterYMaxInput = document.getElementById('scatterYMax') as HTMLInputElement;
+const scatterResetExtentsButton = document.getElementById('scatterResetExtents') as HTMLButtonElement;
 const scatterPlot = document.getElementById('scatterPlot') as HTMLDivElement;
 const scatterPlotEmpty = document.getElementById('scatterPlotEmpty') as HTMLDivElement;
 const filtersControlsEl = document.getElementById('filtersControls') as HTMLDivElement;
@@ -1211,6 +1216,9 @@ let scatterCategoryField: string | null = null;
 let scatterCategoryValueIndices: string[] = [];
 let scatterXField: string | null = null;
 let scatterYField: string | null = null;
+let scatterRangeIsCustom = false;
+let scatterDefaultRange = { xMin: null as number | null, xMax: null as number | null, yMin: null as number | null, yMax: null as number | null };
+let isUpdatingScatterRangeInputs = false;
 
 type SubjectSelectorControls = {
   buttons: HTMLButtonElement[];
@@ -2695,6 +2703,7 @@ function setScatterSubjectMode(mode: SubjectMode) {
   scatterSubjectMode = mode;
   updateScatterSubjectButtons();
   updateScatterSubjectControls();
+  scatterRangeIsCustom = false;
   updateScatterPlot();
 }
 
@@ -2702,9 +2711,40 @@ function getPlotly(): any | null {
   return (window as any).Plotly ?? null;
 }
 
+function parseScatterRangeInput(input: HTMLInputElement): number | null {
+  const value = input.value.trim();
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function setScatterRangeInputs(range: { xMin: number | null; xMax: number | null; yMin: number | null; yMax: number | null }) {
+  isUpdatingScatterRangeInputs = true;
+  scatterXMinInput.value = range.xMin === null ? '' : String(range.xMin);
+  scatterXMaxInput.value = range.xMax === null ? '' : String(range.xMax);
+  scatterYMinInput.value = range.yMin === null ? '' : String(range.yMin);
+  scatterYMaxInput.value = range.yMax === null ? '' : String(range.yMax);
+  isUpdatingScatterRangeInputs = false;
+}
+
+function setScatterRangeControlsEnabled(enabled: boolean) {
+  scatterXMinInput.disabled = !enabled;
+  scatterXMaxInput.disabled = !enabled;
+  scatterYMinInput.disabled = !enabled;
+  scatterYMaxInput.disabled = !enabled;
+  scatterResetExtentsButton.disabled = !enabled;
+}
+
+function clearScatterRangeControls() {
+  setScatterRangeInputs({ xMin: null, xMax: null, yMin: null, yMax: null });
+  scatterRangeIsCustom = false;
+}
+
 function resetScatterPlot(message: string) {
   scatterPlotEmpty.textContent = message;
   scatterPlotEmpty.style.display = 'block';
+  setScatterRangeControlsEnabled(false);
+  clearScatterRangeControls();
   const plotly = getPlotly();
   if (plotly) {
     plotly.purge(scatterPlot);
@@ -2754,6 +2794,19 @@ function updateScatterPlot() {
   }
 
   scatterPlotEmpty.style.display = 'none';
+  setScatterRangeControlsEnabled(true);
+  const xMinDefault = Math.min(...xValues);
+  const xMaxDefault = Math.max(...xValues);
+  const yMinDefault = Math.min(...yValues);
+  const yMaxDefault = Math.max(...yValues);
+  scatterDefaultRange = { xMin: xMinDefault, xMax: xMaxDefault, yMin: yMinDefault, yMax: yMaxDefault };
+  if (!scatterRangeIsCustom) {
+    setScatterRangeInputs(scatterDefaultRange);
+  }
+  const xMin = scatterRangeIsCustom ? (parseScatterRangeInput(scatterXMinInput) ?? xMinDefault) : xMinDefault;
+  const xMax = scatterRangeIsCustom ? (parseScatterRangeInput(scatterXMaxInput) ?? xMaxDefault) : xMaxDefault;
+  const yMin = scatterRangeIsCustom ? (parseScatterRangeInput(scatterYMinInput) ?? yMinDefault) : yMinDefault;
+  const yMax = scatterRangeIsCustom ? (parseScatterRangeInput(scatterYMaxInput) ?? yMaxDefault) : yMaxDefault;
   const trace = {
     x: xValues,
     y: yValues,
@@ -2764,10 +2817,10 @@ function updateScatterPlot() {
   const layout = {
     margin: { l: 48, r: 16, t: 8, b: 42 },
     height: 220,
-    xaxis: { title: scatterXField },
-    yaxis: { title: scatterYField }
+    xaxis: { title: scatterXField, range: [Math.min(xMin, xMax), Math.max(xMin, xMax)] },
+    yaxis: { title: scatterYField, range: [Math.min(yMin, yMax), Math.max(yMin, yMax)] }
   };
-  const config = { displayModeBar: false, responsive: true };
+  const config = { displayModeBar: false, responsive: true, staticPlot: true };
   plotly.react(scatterPlot, [trace], layout, config);
 }
 
@@ -6950,6 +7003,7 @@ scatterCategoryFieldSelect.addEventListener('change', () => {
   scatterCategoryValueIndices = [];
   populateScatterCategoryValues(scatterCategoryField);
   updateScatterSubjectControls();
+  scatterRangeIsCustom = false;
   updateScatterPlot();
 });
 
@@ -6958,6 +7012,7 @@ scatterCategoryValueSelect.addEventListener('change', () => {
     .map(option => option.value)
     .filter(value => value);
   updateScatterSubjectControls();
+  scatterRangeIsCustom = false;
   updateScatterPlot();
 });
 
@@ -6974,11 +7029,29 @@ statsFieldSelect.addEventListener('change', () => {
 
 scatterXFieldSelect.addEventListener('change', () => {
   scatterXField = scatterXFieldSelect.value || null;
+  scatterRangeIsCustom = false;
   updateScatterPlot();
 });
 
 scatterYFieldSelect.addEventListener('change', () => {
   scatterYField = scatterYFieldSelect.value || null;
+  scatterRangeIsCustom = false;
+  updateScatterPlot();
+});
+
+function handleScatterRangeInput() {
+  if (isUpdatingScatterRangeInputs) return;
+  scatterRangeIsCustom = true;
+  updateScatterPlot();
+}
+
+scatterXMinInput.addEventListener('input', handleScatterRangeInput);
+scatterXMaxInput.addEventListener('input', handleScatterRangeInput);
+scatterYMinInput.addEventListener('input', handleScatterRangeInput);
+scatterYMaxInput.addEventListener('input', handleScatterRangeInput);
+scatterResetExtentsButton.addEventListener('click', () => {
+  scatterRangeIsCustom = false;
+  setScatterRangeInputs(scatterDefaultRange);
   updateScatterPlot();
 });
 


### PR DESCRIPTION
### Motivation
- Improve scatterplot UX by making axis extents visible and editable so users can discover how to set and reset plot ranges.
- Remove implicit Plotly interactive controls so the app shows only the intended controls and behavior.

### Description
- Rework the scatterplot UI in `viz/index.html` to inline X/Y field selectors with `min`/`max` numeric inputs and add a `Reset extents` button, and keep the inputs disabled until data is available.
- Add new DOM hooks and state in `viz/src/main.ts` (`scatterXMin`, `scatterXMax`, `scatterYMin`, `scatterYMax`, `scatterResetExtents`, `scatterRangeIsCustom`, `scatterDefaultRange`) and helper functions `parseScatterRangeInput`, `setScatterRangeInputs`, `setScatterRangeControlsEnabled`, and `clearScatterRangeControls` to manage extent state. 
- Wire the inputs into `updateScatterPlot()` so defaults use data min/max, custom values override axis ranges, and the reset button restores defaults; also clear the custom flag when fields/subject selections change. 
- Disable Plotly’s mode bar and interactive panning/zooming by setting `displayModeBar: false` and `staticPlot: true` in the plot `config` so only the explicit controls affect extents.

### Testing
- Attempted to install dependencies in the `viz` app with `npm install` but the command failed due to an npm registry 403 error, so no automated build or runtime tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d37dea2a88326a11b24dc451f2125)