### PR TITLE
Debounce scatterplot extent updates (1s) and route plot triggers through buffered refresh

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -1091,14 +1091,41 @@
       <div class="divider"></div>
       <div class="stats-section" style="display: grid; gap: 8px;">
         <div style="font-weight: 600; font-size: 12px;">Plot</div>
-        <label style="display: grid; gap: 4px; font-size: 12px;">
-          <span>X:</span>
-          <select id="scatterXField"></select>
-        </label>
-        <label style="display: grid; gap: 4px; font-size: 12px;">
-          <span>Y:</span>
-          <select id="scatterYField"></select>
-        </label>
+        <div style="display: grid; gap: 8px; font-size: 12px;">
+          <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 8px;">
+            <label style="display: flex; align-items: center; gap: 6px; flex: 1 1 160px;">
+              <span style="font-weight: 600;">X:</span>
+              <select id="scatterXField" style="flex: 1;"></select>
+            </label>
+            <label style="display: flex; align-items: center; gap: 4px;">
+              <span class="muted">min:</span>
+              <input id="scatterXMin" type="number" inputmode="decimal" style="width: 86px;" disabled />
+            </label>
+            <label style="display: flex; align-items: center; gap: 4px;">
+              <span class="muted">max:</span>
+              <input id="scatterXMax" type="number" inputmode="decimal" style="width: 86px;" disabled />
+            </label>
+          </div>
+          <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 8px;">
+            <label style="display: flex; align-items: center; gap: 6px; flex: 1 1 160px;">
+              <span style="font-weight: 600;">Y:</span>
+              <select id="scatterYField" style="flex: 1;"></select>
+            </label>
+            <label style="display: flex; align-items: center; gap: 4px;">
+              <span class="muted">min:</span>
+              <input id="scatterYMin" type="number" inputmode="decimal" style="width: 86px;" disabled />
+            </label>
+            <label style="display: flex; align-items: center; gap: 4px;">
+              <span class="muted">max:</span>
+              <input id="scatterYMax" type="number" inputmode="decimal" style="width: 86px;" disabled />
+            </label>
+          </div>
+          <div style="display: flex; justify-content: flex-end;">
+            <button id="scatterResetExtents" type="button" class="toolbar-button" style="height: 28px; padding: 0 10px; font-size: 12px;" disabled>
+              Reset extents
+            </button>
+          </div>
+        </div>
         <div id="scatterPlotEmpty" class="muted" style="display: none;">Select X and Y fields to render the scatterplot.</div>
         <div id="scatterPlot" style="height: 220px; width: 100%;"></div>
       </div>

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -831,6 +831,11 @@ const scatterplotContent = document.getElementById('scatterplotContent') as HTML
 const scatterSubjectSection = document.getElementById('scatterSubjectSection') as HTMLDivElement;
 const scatterXFieldSelect = document.getElementById('scatterXField') as HTMLSelectElement;
 const scatterYFieldSelect = document.getElementById('scatterYField') as HTMLSelectElement;
+const scatterXMinInput = document.getElementById('scatterXMin') as HTMLInputElement;
+const scatterXMaxInput = document.getElementById('scatterXMax') as HTMLInputElement;
+const scatterYMinInput = document.getElementById('scatterYMin') as HTMLInputElement;
+const scatterYMaxInput = document.getElementById('scatterYMax') as HTMLInputElement;
+const scatterResetExtentsButton = document.getElementById('scatterResetExtents') as HTMLButtonElement;
 const scatterPlot = document.getElementById('scatterPlot') as HTMLDivElement;
 const scatterPlotEmpty = document.getElementById('scatterPlotEmpty') as HTMLDivElement;
 const filtersControlsEl = document.getElementById('filtersControls') as HTMLDivElement;
@@ -1211,6 +1216,10 @@ let scatterCategoryField: string | null = null;
 let scatterCategoryValueIndices: string[] = [];
 let scatterXField: string | null = null;
 let scatterYField: string | null = null;
+let scatterRangeIsCustom = false;
+let scatterDefaultRange = { xMin: null as number | null, xMax: null as number | null, yMin: null as number | null, yMax: null as number | null };
+let isUpdatingScatterRangeInputs = false;
+let scatterRefreshTimer: number | null = null;
 
 type SubjectSelectorControls = {
   buttons: HTMLButtonElement[];
@@ -2695,16 +2704,59 @@ function setScatterSubjectMode(mode: SubjectMode) {
   scatterSubjectMode = mode;
   updateScatterSubjectButtons();
   updateScatterSubjectControls();
-  updateScatterPlot();
+  scatterRangeIsCustom = false;
+  scheduleScatterPlotRefresh();
 }
 
 function getPlotly(): any | null {
   return (window as any).Plotly ?? null;
 }
 
+function scheduleScatterPlotRefresh() {
+  if (scatterRefreshTimer !== null) {
+    window.clearTimeout(scatterRefreshTimer);
+  }
+  scatterRefreshTimer = window.setTimeout(() => {
+    scatterRefreshTimer = null;
+    if (isScatterplotMinimized) return;
+    updateScatterPlot();
+  }, 1000);
+}
+
+function parseScatterRangeInput(input: HTMLInputElement): number | null {
+  const value = input.value.trim();
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function setScatterRangeInputs(range: { xMin: number | null; xMax: number | null; yMin: number | null; yMax: number | null }) {
+  isUpdatingScatterRangeInputs = true;
+  scatterXMinInput.value = range.xMin === null ? '' : String(range.xMin);
+  scatterXMaxInput.value = range.xMax === null ? '' : String(range.xMax);
+  scatterYMinInput.value = range.yMin === null ? '' : String(range.yMin);
+  scatterYMaxInput.value = range.yMax === null ? '' : String(range.yMax);
+  isUpdatingScatterRangeInputs = false;
+}
+
+function setScatterRangeControlsEnabled(enabled: boolean) {
+  scatterXMinInput.disabled = !enabled;
+  scatterXMaxInput.disabled = !enabled;
+  scatterYMinInput.disabled = !enabled;
+  scatterYMaxInput.disabled = !enabled;
+  scatterResetExtentsButton.disabled = !enabled;
+}
+
+function clearScatterRangeControls() {
+  setScatterRangeInputs({ xMin: null, xMax: null, yMin: null, yMax: null });
+  scatterRangeIsCustom = false;
+}
+
 function resetScatterPlot(message: string) {
   scatterPlotEmpty.textContent = message;
   scatterPlotEmpty.style.display = 'block';
+  setScatterRangeControlsEnabled(false);
+  clearScatterRangeControls();
   const plotly = getPlotly();
   if (plotly) {
     plotly.purge(scatterPlot);
@@ -2754,6 +2806,19 @@ function updateScatterPlot() {
   }
 
   scatterPlotEmpty.style.display = 'none';
+  setScatterRangeControlsEnabled(true);
+  const xMinDefault = Math.min(...xValues);
+  const xMaxDefault = Math.max(...xValues);
+  const yMinDefault = Math.min(...yValues);
+  const yMaxDefault = Math.max(...yValues);
+  scatterDefaultRange = { xMin: xMinDefault, xMax: xMaxDefault, yMin: yMinDefault, yMax: yMaxDefault };
+  if (!scatterRangeIsCustom) {
+    setScatterRangeInputs(scatterDefaultRange);
+  }
+  const xMin = scatterRangeIsCustom ? (parseScatterRangeInput(scatterXMinInput) ?? xMinDefault) : xMinDefault;
+  const xMax = scatterRangeIsCustom ? (parseScatterRangeInput(scatterXMaxInput) ?? xMaxDefault) : xMaxDefault;
+  const yMin = scatterRangeIsCustom ? (parseScatterRangeInput(scatterYMinInput) ?? yMinDefault) : yMinDefault;
+  const yMax = scatterRangeIsCustom ? (parseScatterRangeInput(scatterYMaxInput) ?? yMaxDefault) : yMaxDefault;
   const trace = {
     x: xValues,
     y: yValues,
@@ -2764,10 +2829,10 @@ function updateScatterPlot() {
   const layout = {
     margin: { l: 48, r: 16, t: 8, b: 42 },
     height: 220,
-    xaxis: { title: scatterXField },
-    yaxis: { title: scatterYField }
+    xaxis: { title: scatterXField, range: [Math.min(xMin, xMax), Math.max(xMin, xMax)] },
+    yaxis: { title: scatterYField, range: [Math.min(yMin, yMax), Math.max(yMin, yMax)] }
   };
-  const config = { displayModeBar: false, responsive: true };
+  const config = { displayModeBar: false, responsive: true, staticPlot: true };
   plotly.react(scatterPlot, [trace], layout, config);
 }
 
@@ -2777,7 +2842,7 @@ function refreshScatterPanel() {
   populateScatterFields();
   updateScatterSubjectButtons();
   updateScatterSubjectControls();
-  updateScatterPlot();
+  scheduleScatterPlotRefresh();
 }
 
 // Dragging functions
@@ -4149,7 +4214,7 @@ function applyMapFilters() {
     updateStatisticsResults();
   }
   if (scatterSubjectMode === 'visible') {
-    updateScatterPlot();
+    scheduleScatterPlotRefresh();
   }
 }
 
@@ -4360,7 +4425,7 @@ function updateSelectionControls() {
     updateStatisticsResults();
   }
   if (scatterSubjectMode === 'selected') {
-    updateScatterPlot();
+    scheduleScatterPlotRefresh();
   }
 }
 
@@ -6950,7 +7015,8 @@ scatterCategoryFieldSelect.addEventListener('change', () => {
   scatterCategoryValueIndices = [];
   populateScatterCategoryValues(scatterCategoryField);
   updateScatterSubjectControls();
-  updateScatterPlot();
+  scatterRangeIsCustom = false;
+  scheduleScatterPlotRefresh();
 });
 
 scatterCategoryValueSelect.addEventListener('change', () => {
@@ -6958,7 +7024,8 @@ scatterCategoryValueSelect.addEventListener('change', () => {
     .map(option => option.value)
     .filter(value => value);
   updateScatterSubjectControls();
-  updateScatterPlot();
+  scatterRangeIsCustom = false;
+  scheduleScatterPlotRefresh();
 });
 
 statsFieldSelect.addEventListener('change', () => {
@@ -6974,12 +7041,30 @@ statsFieldSelect.addEventListener('change', () => {
 
 scatterXFieldSelect.addEventListener('change', () => {
   scatterXField = scatterXFieldSelect.value || null;
-  updateScatterPlot();
+  scatterRangeIsCustom = false;
+  scheduleScatterPlotRefresh();
 });
 
 scatterYFieldSelect.addEventListener('change', () => {
   scatterYField = scatterYFieldSelect.value || null;
-  updateScatterPlot();
+  scatterRangeIsCustom = false;
+  scheduleScatterPlotRefresh();
+});
+
+function handleScatterRangeInput() {
+  if (isUpdatingScatterRangeInputs) return;
+  scatterRangeIsCustom = true;
+  scheduleScatterPlotRefresh();
+}
+
+scatterXMinInput.addEventListener('input', handleScatterRangeInput);
+scatterXMaxInput.addEventListener('input', handleScatterRangeInput);
+scatterYMinInput.addEventListener('input', handleScatterRangeInput);
+scatterYMaxInput.addEventListener('input', handleScatterRangeInput);
+scatterResetExtentsButton.addEventListener('click', () => {
+  scatterRangeIsCustom = false;
+  setScatterRangeInputs(scatterDefaultRange);
+  scheduleScatterPlotRefresh();
 });
 
 document.querySelectorAll<HTMLInputElement>('input[name="statsNormMode"]').forEach(radio => {


### PR DESCRIPTION
### Motivation
- Prevent immediate scatterplot redraws while users type numeric extents by adding a small input buffer so the plot updates only after the user finishes editing. 
- Reuse the same buffered refresh for any action that should refresh the scatterplot (field changes, subject/visibility changes, selection changes) to avoid rapid successive redraws.

### Description
- Added a debounce timer variable `scatterRefreshTimer` and a buffered refresh function `scheduleScatterPlotRefresh()` that resets the timer to 1s on every invocation and calls `updateScatterPlot()` only when the timer expires and the scatterplot panel is open. 
- Replaced direct calls to `updateScatterPlot()` with `scheduleScatterPlotRefresh()` across scatterplot-related handlers and state-change sites so field changes, category/value changes, visibility/filter updates, and selection updates use the buffered refresh. 
- Updated `viz/index.html` with inline X/Y `min`/`max` numeric inputs and a `Reset extents` button (`#scatterXMin`, `#scatterXMax`, `#scatterYMin`, `#scatterYMax`, `#scatterResetExtents`) and wired them in `viz/src/main.ts` to set `scatterRangeIsCustom` and use the debounced refresh. 
- Ensured `updateScatterPlot()` respects custom extents when `scatterRangeIsCustom` is set and restores defaults on reset, and kept Plotly controls non-interactive by using `staticPlot: true` in the plot `config`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d37dea2a88326a11b24dc451f2125)