### PR TITLE
Debounce scatterplot refresh (1s buffer)

### DIFF
--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -1221,6 +1221,7 @@ let scatterRangeIsCustom = false;
 let scatterDefaultRange = { xMin: null as number | null, xMax: null as number | null, yMin: null as number | null, yMax: null as number | null };
 let isUpdatingScatterRangeInputs = false;
 let scatterDataStoreId: string | null = null;
+let scatterPlotRefreshTimer: number | null = null;
 
 type SubjectSelectorControls = {
   buttons: HTMLButtonElement[];
@@ -1952,6 +1953,7 @@ function showScatterplot() {
   scatterplotControlsEl.style.display = 'grid';
   positionScatterplotPanel();
   updateToolbarButtonStates();
+  scheduleScatterPlotRefresh();
 }
 
 function toggleScatterplot() {
@@ -2793,7 +2795,7 @@ function setScatterSubjectMode(mode: SubjectMode) {
   updateScatterSubjectButtons();
   updateScatterSubjectControls();
   scatterRangeIsCustom = false;
-  updateScatterPlot();
+  scheduleScatterPlotRefresh();
 }
 
 function getPlotly(): any | null {
@@ -2919,6 +2921,17 @@ function updateScatterPlot() {
   plotly.react(scatterPlot, [trace], layout, config);
 }
 
+function scheduleScatterPlotRefresh() {
+  if (scatterPlotRefreshTimer !== null) {
+    window.clearTimeout(scatterPlotRefreshTimer);
+  }
+  scatterPlotRefreshTimer = window.setTimeout(() => {
+    scatterPlotRefreshTimer = null;
+    if (isScatterplotMinimized) return;
+    updateScatterPlot();
+  }, 1000);
+}
+
 function refreshScatterPanel() {
   renderScatterDataSourceOptions();
   populateScatterCategoryFields();
@@ -2926,7 +2939,7 @@ function refreshScatterPanel() {
   populateScatterFields();
   updateScatterSubjectButtons();
   updateScatterSubjectControls();
-  updateScatterPlot();
+  scheduleScatterPlotRefresh();
 }
 
 // Dragging functions
@@ -4298,7 +4311,7 @@ function applyMapFilters() {
     updateStatisticsResults();
   }
   if (scatterSubjectMode === 'visible') {
-    updateScatterPlot();
+    scheduleScatterPlotRefresh();
   }
 }
 
@@ -4509,7 +4522,7 @@ function updateSelectionControls() {
     updateStatisticsResults();
   }
   if (scatterSubjectMode === 'selected') {
-    updateScatterPlot();
+    scheduleScatterPlotRefresh();
   }
 }
 
@@ -7110,7 +7123,7 @@ scatterCategoryFieldSelect.addEventListener('change', () => {
   populateScatterCategoryValues(scatterCategoryField);
   updateScatterSubjectControls();
   scatterRangeIsCustom = false;
-  updateScatterPlot();
+  scheduleScatterPlotRefresh();
 });
 
 scatterCategoryValueSelect.addEventListener('change', () => {
@@ -7119,7 +7132,7 @@ scatterCategoryValueSelect.addEventListener('change', () => {
     .filter(value => value);
   updateScatterSubjectControls();
   scatterRangeIsCustom = false;
-  updateScatterPlot();
+  scheduleScatterPlotRefresh();
 });
 
 statsFieldSelect.addEventListener('change', () => {
@@ -7136,19 +7149,19 @@ statsFieldSelect.addEventListener('change', () => {
 scatterXFieldSelect.addEventListener('change', () => {
   scatterXField = scatterXFieldSelect.value || null;
   scatterRangeIsCustom = false;
-  updateScatterPlot();
+  scheduleScatterPlotRefresh();
 });
 
 scatterYFieldSelect.addEventListener('change', () => {
   scatterYField = scatterYFieldSelect.value || null;
   scatterRangeIsCustom = false;
-  updateScatterPlot();
+  scheduleScatterPlotRefresh();
 });
 
 function handleScatterRangeInput() {
   if (isUpdatingScatterRangeInputs) return;
   scatterRangeIsCustom = true;
-  updateScatterPlot();
+  scheduleScatterPlotRefresh();
 }
 
 scatterXMinInput.addEventListener('input', handleScatterRangeInput);
@@ -7158,7 +7171,7 @@ scatterYMaxInput.addEventListener('input', handleScatterRangeInput);
 scatterResetExtentsButton.addEventListener('click', () => {
   scatterRangeIsCustom = false;
   setScatterRangeInputs(scatterDefaultRange);
-  updateScatterPlot();
+  scheduleScatterPlotRefresh();
 });
 
 document.querySelectorAll<HTMLInputElement>('input[name="statsNormMode"]').forEach(radio => {


### PR DESCRIPTION
### Motivation
- Rapid successive input changes triggered immediate scatterplot redraws which caused unnecessary work and UI issues while typing numeric values.
- Introduce a short buffer so the plot only refreshes after the user pauses input for ~1 second.

### Description
- Add `scatterPlotRefreshTimer` and a `scheduleScatterPlotRefresh()` helper which clears any previous timer and sets a 1000ms timeout before calling `updateScatterPlot()`.
- Route scatterplot refresh triggers through `scheduleScatterPlotRefresh()` from UI handlers and update paths including `refreshScatterPanel`, `setScatterSubjectMode`, `showScatterplot`, `applyMapFilters`, `updateSelectionControls`, field/category/value change handlers, range input handlers, and reset extents, instead of calling `updateScatterPlot()` directly.
- `scheduleScatterPlotRefresh()` cancels the pending timer on new triggers and skips refresh if the scatterplot panel is minimized by checking `isScatterplotMinimized`.
- All changes are contained in `viz/src/main.ts` and use a 1 second debounce to implement the buffer behavior.

### Testing
- No automated tests were run for this change.
- Recommend manual verification by opening the scatterplot panel and confirming that changing fields/ranges now defers redraw until ~1s after the last input and that opening the panel schedules an update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d60f537c48326b725b73795c93bb6)