### PR TITLE
Stack scatterplot Data source and Subject with horizontal dividers

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -1087,15 +1087,16 @@
       </button>
     </div>
     <div id="scatterplotContent" style="padding: 12px; display: grid; gap: 12px;">
-      <div style="display: flex; gap: 12px; align-items: stretch;">
-        <div id="scatterDataSourceSection" class="stats-section" style="flex: 1; display: grid; gap: 8px;">
-          <div style="font-weight: 600; font-size: 12px;">Data Source:</div>
+      <div style="display: grid; gap: 12px;">
+        <div id="scatterDataSourceSection" class="stats-section" style="display: grid; gap: 8px;">
+          <div style="font-weight: 600; font-size: 12px;">Data source:</div>
           <select id="scatterDataSourceSelect">
             <option value="" selected disabled>Choose a data source</option>
           </select>
         </div>
-        <div style="width: 1px; background: #e5e5e5;"></div>
-        <div id="scatterSubjectSection" class="stats-section" style="flex: 1;"></div>
+        <div class="divider"></div>
+        <div id="scatterSubjectSection" class="stats-section"></div>
+        <div class="divider"></div>
       </div>
       <div class="divider"></div>
       <div class="stats-section" style="display: grid; gap: 8px;">


### PR DESCRIPTION
### Motivation
- Align the Scatterplot control layout with the requested UI: place `Data source:` on its own row with a horizontal divider underneath, then `Subject:` on its own row with another horizontal divider below.
- Simplify the control layout from a two-column horizontal split to a stacked vertical arrangement for clearer separation of the top section.

### Description
- Updated `viz/index.html` to replace the horizontal `flex` layout for the top Scatterplot controls with a vertical `grid` layout.
- Inserted horizontal dividers (`<div class="divider"></div>`) above and below the `Subject` section and below the `Data source` section to create the requested separators.
- Normalized the label text to `Data source:` to match the requested styling.

### Testing
- Launched a local static server with `python -m http.server 8000` and loaded `http://127.0.0.1:8000/viz/index.html` to validate the UI change, which rendered successfully.
- Ran a Playwright script to capture a screenshot of the updated Scatterplot layout (`artifacts/scatterplot-layout.png`), and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d70fd9a608326857db84ae2255132)