### PR TITLE
Merge scatterplot data source and subject controls

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -1093,9 +1093,8 @@
           <select id="scatterDataSourceSelect">
             <option value="" selected disabled>Choose a data source</option>
           </select>
+          <div id="scatterSubjectSection" class="stats-section"></div>
         </div>
-        <div class="divider"></div>
-        <div id="scatterSubjectSection" class="stats-section"></div>
         <div class="divider"></div>
       </div>
       <div class="stats-section" style="display: grid; gap: 8px;">

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -849,7 +849,7 @@ const filtersShowButton = document.getElementById('filtersShowButton') as HTMLBu
 const filtersHideButton = document.getElementById('filtersHideButton') as HTMLButtonElement;
 
 const statsSubjectControls = buildSubjectSelector(statsSubjectSection);
-const scatterSubjectControls = buildSubjectSelector(scatterSubjectSection);
+const scatterSubjectControls = buildSubjectSelector(scatterSubjectSection, { title: null });
 
 const statsSubjectButtons = statsSubjectControls.buttons;
 const statsCategoryFieldSelect = statsSubjectControls.categoryFieldSelect;
@@ -2048,16 +2048,24 @@ function resetStatisticsDisplay() {
   statsCategoricalValues.replaceChildren();
 }
 
-function buildSubjectSelector(container: HTMLElement): SubjectSelectorControls {
+type SubjectSelectorOptions = {
+  title?: string | null;
+};
+
+function buildSubjectSelector(container: HTMLElement, options: SubjectSelectorOptions = {}): SubjectSelectorControls {
   container.replaceChildren();
   const subjectBlock = document.createElement('div');
   subjectBlock.style.display = 'grid';
   subjectBlock.style.gap = '6px';
 
-  const title = document.createElement('div');
-  title.style.fontWeight = '600';
-  title.style.fontSize = '12px';
-  title.textContent = 'Subject:';
+  const titleText = options.title ?? 'Subject:';
+  let title: HTMLDivElement | null = null;
+  if (titleText) {
+    title = document.createElement('div');
+    title.style.fontWeight = '600';
+    title.style.fontSize = '12px';
+    title.textContent = titleText;
+  }
 
   const actions = document.createElement('div');
   actions.className = 'filters-actions stats-subject-actions';
@@ -2078,7 +2086,10 @@ function buildSubjectSelector(container: HTMLElement): SubjectSelectorControls {
     buttons.push(button);
   });
 
-  subjectBlock.append(title, actions);
+  if (title) {
+    subjectBlock.append(title);
+  }
+  subjectBlock.append(actions);
 
   const categoryControls = document.createElement('div');
   categoryControls.style.display = 'none';


### PR DESCRIPTION
### Motivation
- The scatterplot UI should present a single "Data source:" block with the data source dropdown above the existing subject mode buttons, and the redundant "Subject:" label and divider should be removed for a cleaner layout.

### Description
- Moved `#scatterSubjectSection` into the `#scatterDataSourceSection` in `viz/index.html` so the subject buttons render just below the `#scatterDataSourceSelect` dropdown and removed the extra divider.
- Updated `buildSubjectSelector` in `viz/src/main.ts` to accept an options object (`SubjectSelectorOptions`) with a `title?: string | null` parameter and render the title only when provided.
- Constructed the scatterplot subject controls with `buildSubjectSelector(scatterSubjectSection, { title: null })` so the subject buttons render without the "Subject:" header.

### Testing
- Attempted `npm install` inside `viz/` to run the dev stack, but it failed with a `403 Forbidden` error fetching the `geoparquet` package from the registry, so no further automated build or runtime tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d7909e13c8326998ee39c7b1ed1e8)