### PR TITLE
Filters: Add Save/Load UI and rename Add filter → Add condition

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -480,6 +480,37 @@
       background: #eef2ff;
     }
 
+    .filters-saved-container {
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+      padding: 16px 12px 12px;
+      background: #fff;
+      position: relative;
+    }
+
+    .filters-saved-tabs {
+      display: flex;
+      gap: 6px;
+      margin-top: -28px;
+      margin-bottom: 10px;
+    }
+
+    .filters-saved-tab {
+      border: 1px solid #ddd;
+      border-bottom: none;
+      background: #f8f8f8;
+      padding: 6px 12px;
+      border-radius: 8px 8px 0 0;
+      cursor: pointer;
+      font-size: 12px;
+    }
+
+    .filters-saved-tab.active {
+      border-color: #3b82f6;
+      background: #fff;
+      box-shadow: none;
+    }
+
     .filters-saved-section {
       display: grid;
       gap: 8px;
@@ -839,18 +870,20 @@
       </button>
     </div>
     <div id="filtersContent" style="padding: 12px; display: grid; gap: 12px;">
-      <div class="filters-saved-section">
-        <div class="filters-actions">
-          <button id="filtersSaveToggle" type="button">Save filter</button>
-          <button id="filtersLoadToggle" type="button">Load filter</button>
+      <div class="filters-saved-container">
+        <div class="filters-saved-tabs">
+          <button id="filtersSaveToggle" class="filters-saved-tab" type="button">Save</button>
+          <button id="filtersLoadToggle" class="filters-saved-tab" type="button">Load</button>
         </div>
-        <div id="filtersSaveControls" class="filters-save-row" style="display: none;">
-          <input id="filtersSaveName" type="text" placeholder="type a name" />
-          <button id="filtersSaveConfirm" type="button" title="Save">💾</button>
-        </div>
-        <div id="filtersSavedStatus" class="filters-saved-status" style="display: none;"></div>
-        <div id="filtersLoadControls" class="filters-load-row" style="display: none;">
-          <select id="filtersLoadSelect"></select>
+        <div class="filters-saved-section">
+          <div id="filtersSaveControls" class="filters-save-row" style="display: none;">
+            <input id="filtersSaveName" type="text" placeholder="type a name" />
+            <button id="filtersSaveConfirm" type="button" title="Save">💾</button>
+          </div>
+          <div id="filtersSavedStatus" class="filters-saved-status" style="display: none;"></div>
+          <div id="filtersLoadControls" class="filters-load-row" style="display: none;">
+            <select id="filtersLoadSelect"></select>
+          </div>
         </div>
       </div>
 

--- a/viz/index.html
+++ b/viz/index.html
@@ -438,6 +438,7 @@
     }
 
     #filtersControls select,
+    #filtersControls input[type="text"],
     #filtersControls input[type="number"] {
       width: 100%;
       padding: 6px 8px;
@@ -477,6 +478,27 @@
       border-color: #3b82f6;
       box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
       background: #eef2ff;
+    }
+
+    .filters-saved-section {
+      display: grid;
+      gap: 8px;
+    }
+
+    .filters-save-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 6px;
+      align-items: center;
+    }
+
+    .filters-load-row {
+      display: grid;
+    }
+
+    .filters-saved-status {
+      font-size: 12px;
+      color: #333;
     }
 
     .stats-subject-actions {
@@ -817,6 +839,23 @@
       </button>
     </div>
     <div id="filtersContent" style="padding: 12px; display: grid; gap: 12px;">
+      <div class="filters-saved-section">
+        <div class="filters-actions">
+          <button id="filtersSaveToggle" type="button">Save filter</button>
+          <button id="filtersLoadToggle" type="button">Load filter</button>
+        </div>
+        <div id="filtersSaveControls" class="filters-save-row" style="display: none;">
+          <input id="filtersSaveName" type="text" placeholder="type a name" />
+          <button id="filtersSaveConfirm" type="button" title="Save">💾</button>
+        </div>
+        <div id="filtersSavedStatus" class="filters-saved-status" style="display: none;"></div>
+        <div id="filtersLoadControls" class="filters-load-row" style="display: none;">
+          <select id="filtersLoadSelect"></select>
+        </div>
+      </div>
+
+      <div class="divider"></div>
+
       <div class="filters-actions">
         <button id="filtersSelectButton" type="button">Select filtered</button>
         <button id="filtersShowButton" type="button">Show filtered</button>
@@ -832,7 +871,7 @@
         </label>
       </div>
       <div id="filtersList" class="filters-list"></div>
-      <button id="addFilterButton" type="button">Add filter</button>
+      <button id="addFilterButton" type="button">Add condition</button>
     </div>
   </div>
 

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -1366,7 +1366,7 @@ function renderSavedFiltersOptions() {
 }
 
 function setSavedFiltersPanelMode(nextMode: 'none' | 'save' | 'load') {
-  savedFiltersPanelMode = savedFiltersPanelMode === nextMode ? 'none' : nextMode;
+  savedFiltersPanelMode = nextMode;
   updateSavedFiltersUIState();
 }
 

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -5882,6 +5882,11 @@ function addExtrusionLayer(layer: LayerState) {
         activePopup = null;
         lastPicked = null;
       }
+
+      const activeElement = document.activeElement;
+      if (isTextInputElement(activeElement) || isTextInputElement(e.target as Element | null)) {
+        return;
+      }
       
       // Hotkey handling
       const key = e.key.toLowerCase();
@@ -5920,6 +5925,34 @@ function showPopup(props: Record<string, any>, lngLat: maplibregl.LngLatLike, pa
   // Add search functionality to the popup
   addPopupSearchFunctionality();
   addPopupEditFunctionality(parcelId);
+}
+
+function isTextInputElement(element: Element | null): boolean {
+  if (!element) return false;
+  if (element instanceof HTMLInputElement) {
+    const nonTextTypes = new Set([
+      'button',
+      'checkbox',
+      'color',
+      'date',
+      'file',
+      'hidden',
+      'image',
+      'radio',
+      'range',
+      'reset',
+      'submit'
+    ]);
+    if (nonTextTypes.has(element.type)) return false;
+    if (element.disabled || element.readOnly) return false;
+    return true;
+  }
+  if (element instanceof HTMLTextAreaElement) {
+    if (element.disabled || element.readOnly) return false;
+    return true;
+  }
+  if (element instanceof HTMLSelectElement) return false;
+  return (element as HTMLElement).isContentEditable;
 }
 
 function addPopupSearchFunctionality() {

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -844,6 +844,14 @@ const filtersContent = document.getElementById('filtersContent') as HTMLDivEleme
 const filtersListEl = document.getElementById('filtersList') as HTMLDivElement;
 const filtersInvertToggle = document.getElementById('filtersInvertToggle') as HTMLInputElement;
 const addFilterButton = document.getElementById('addFilterButton') as HTMLButtonElement;
+const filtersSaveToggle = document.getElementById('filtersSaveToggle') as HTMLButtonElement;
+const filtersLoadToggle = document.getElementById('filtersLoadToggle') as HTMLButtonElement;
+const filtersSaveControls = document.getElementById('filtersSaveControls') as HTMLDivElement;
+const filtersSaveNameInput = document.getElementById('filtersSaveName') as HTMLInputElement;
+const filtersSaveConfirmButton = document.getElementById('filtersSaveConfirm') as HTMLButtonElement;
+const filtersSavedStatus = document.getElementById('filtersSavedStatus') as HTMLDivElement;
+const filtersLoadControls = document.getElementById('filtersLoadControls') as HTMLDivElement;
+const filtersLoadSelect = document.getElementById('filtersLoadSelect') as HTMLSelectElement;
 const filtersSelectButton = document.getElementById('filtersSelectButton') as HTMLButtonElement;
 const filtersShowButton = document.getElementById('filtersShowButton') as HTMLButtonElement;
 const filtersHideButton = document.getElementById('filtersHideButton') as HTMLButtonElement;
@@ -1047,6 +1055,12 @@ type FilterRule = {
   operator: FilterOperator | null;
   value: number | string | string[] | null;
   active: boolean;
+};
+
+type SavedFilterEntry = {
+  name: string;
+  filters: FilterRule[];
+  filterInvert: boolean;
 };
 
 type ParcelFieldPatch = {
@@ -1267,6 +1281,10 @@ let filters: FilterRule[] = [];
 let filterMode: FilterMode = 'none';
 let filterActionMode: FilterActionMode = 'none';
 let filterInvert = false;
+const savedFiltersStore = new Map<string, SavedFilterEntry>();
+let savedFiltersPanelMode: 'none' | 'save' | 'load' = 'none';
+let savedFilterMatchName: string | null = null;
+(window as any).savedFiltersStore = savedFiltersStore;
 
 const NUMERIC_FILTER_OPERATORS: Array<{ value: NumericFilterOperator; label: string }> = [
   { value: 'lt', label: '<' },
@@ -1305,6 +1323,129 @@ function cloneFilters(source: FilterRule[]): FilterRule[] {
     ...filter,
     value: Array.isArray(filter.value) ? [...filter.value] : filter.value
   }));
+}
+
+function serializeFiltersForComparison(source: FilterRule[], invert: boolean): string {
+  return JSON.stringify({
+    invert,
+    rules: source.map(rule => ({
+      field: rule.field,
+      fieldType: rule.fieldType,
+      operator: rule.operator,
+      value: Array.isArray(rule.value) ? [...rule.value] : rule.value,
+      active: rule.active
+    }))
+  });
+}
+
+function getMatchingSavedFilterName(): string | null {
+  const current = serializeFiltersForComparison(filters, filterInvert);
+  for (const [name, entry] of savedFiltersStore.entries()) {
+    const candidate = serializeFiltersForComparison(entry.filters, entry.filterInvert);
+    if (candidate === current) return name;
+  }
+  return null;
+}
+
+function renderSavedFiltersOptions() {
+  if (!filtersLoadSelect) return;
+  filtersLoadSelect.replaceChildren();
+  const placeholder = new Option('Choose a saved filter', '');
+  placeholder.disabled = true;
+  placeholder.selected = true;
+  filtersLoadSelect.appendChild(placeholder);
+  savedFiltersStore.forEach((entry, name) => {
+    filtersLoadSelect.appendChild(new Option(entry.name, name));
+  });
+
+  if (savedFilterMatchName) {
+    filtersLoadSelect.value = savedFilterMatchName;
+  }
+
+  filtersLoadSelect.disabled = savedFiltersStore.size === 0;
+}
+
+function setSavedFiltersPanelMode(nextMode: 'none' | 'save' | 'load') {
+  savedFiltersPanelMode = savedFiltersPanelMode === nextMode ? 'none' : nextMode;
+  updateSavedFiltersUIState();
+}
+
+function updateSavedFiltersUIState() {
+  const hasConditions = filters.length > 0;
+  const hasSaved = savedFiltersStore.size > 0;
+  if (!hasConditions && savedFiltersPanelMode === 'save') {
+    savedFiltersPanelMode = 'none';
+  }
+  if (!hasSaved && savedFiltersPanelMode === 'load') {
+    savedFiltersPanelMode = 'none';
+  }
+
+  savedFilterMatchName = getMatchingSavedFilterName();
+
+  if (filtersSaveToggle) {
+    filtersSaveToggle.disabled = !hasConditions;
+    filtersSaveToggle.classList.toggle('active', savedFiltersPanelMode === 'save');
+  }
+  if (filtersLoadToggle) {
+    filtersLoadToggle.disabled = !hasSaved;
+    filtersLoadToggle.classList.toggle('active', savedFiltersPanelMode === 'load');
+  }
+
+  const showSave = savedFiltersPanelMode === 'save' && hasConditions;
+  const showLoad = savedFiltersPanelMode === 'load' && hasSaved;
+  const hasMatch = Boolean(savedFilterMatchName);
+
+  if (filtersSaveControls) {
+    filtersSaveControls.style.display = showSave && !hasMatch ? 'grid' : 'none';
+  }
+  if (filtersSavedStatus) {
+    filtersSavedStatus.style.display = showSave && hasMatch ? 'block' : 'none';
+    if (showSave && hasMatch) {
+      filtersSavedStatus.textContent = `Saved as: "${savedFilterMatchName}"`;
+    }
+  }
+  if (filtersLoadControls) {
+    filtersLoadControls.style.display = showLoad ? 'grid' : 'none';
+  }
+
+  if (filtersSaveConfirmButton) {
+    const hasName = Boolean(filtersSaveNameInput?.value.trim());
+    filtersSaveConfirmButton.disabled = !showSave || !hasName;
+  }
+
+  if (showLoad) {
+    renderSavedFiltersOptions();
+  }
+}
+
+function saveCurrentFilters(name: string) {
+  const trimmedName = name.trim();
+  if (!trimmedName) return;
+  if (savedFiltersStore.has(trimmedName)) {
+    const overwrite = window.confirm('You already have a filter with this name. Overwrite? Yes/Cancel');
+    if (!overwrite) return;
+  }
+  savedFiltersStore.set(trimmedName, {
+    name: trimmedName,
+    filters: cloneFilters(filters),
+    filterInvert
+  });
+  savedFilterMatchName = trimmedName;
+  updateSavedFiltersUIState();
+}
+
+function applySavedFilter(name: string) {
+  const entry = savedFiltersStore.get(name);
+  if (!entry) return;
+  filters = cloneFilters(entry.filters);
+  filterInvert = entry.filterInvert;
+  if (filtersInvertToggle) {
+    filtersInvertToggle.checked = filterInvert;
+  }
+  renderFiltersList();
+  updateFiltersUIState();
+  applyActiveFilterAction();
+  persistCurrentLayerState();
 }
 
 function createDataStore(file: File, asyncBuffer: AsyncBuffer): DataStore {
@@ -4668,6 +4809,7 @@ function updateFiltersUIState() {
   if (filtersShowButton) filtersShowButton.disabled = !canApply;
   if (filtersHideButton) filtersHideButton.disabled = !canApply;
   updateFilterActionButtons();
+  updateSavedFiltersUIState();
 }
 
 function renderFiltersList() {
@@ -7044,6 +7186,30 @@ landScheduleBasePer.addEventListener('change', () => {
   updateLandScheduleStoreFromInputs();
 });
 
+filtersSaveToggle.addEventListener('click', () => {
+  if (filtersSaveToggle.disabled) return;
+  setSavedFiltersPanelMode('save');
+});
+
+filtersLoadToggle.addEventListener('click', () => {
+  if (filtersLoadToggle.disabled) return;
+  setSavedFiltersPanelMode('load');
+});
+
+filtersSaveNameInput.addEventListener('input', () => {
+  updateSavedFiltersUIState();
+});
+
+filtersSaveConfirmButton.addEventListener('click', () => {
+  saveCurrentFilters(filtersSaveNameInput.value);
+});
+
+filtersLoadSelect.addEventListener('change', () => {
+  const selected = filtersLoadSelect.value;
+  if (!selected) return;
+  applySavedFilter(selected);
+});
+
 addFilterButton.addEventListener('click', () => {
   filters.push(createFilterRule());
   renderFiltersList();
@@ -7067,6 +7233,7 @@ filtersInvertToggle.addEventListener('change', () => {
   filterInvert = filtersInvertToggle.checked;
   applyActiveFilterAction();
   applyMapFilters();
+  updateSavedFiltersUIState();
   persistCurrentLayerState();
 });
 


### PR DESCRIPTION
### Motivation
- Provide users a way to persist and reuse filter definitions from the Filters panel and make the filter creation label clearer by renaming the button to `Add condition`.
- Expose saved filters to the global app so other UI parts can access named filter sets for reuse.

### Description
- Updated the Filters panel UI in `viz/index.html` to add a top section with `Save filter` and `Load filter` toggle buttons, a horizontal divider, the save name input + `💾` button, a "Saved as: \"name\"" status line, and a load dropdown selector, and renamed the bottom button from `Add filter` to `Add condition`.
- Added styling rules for the new saved-filter controls in `viz/index.html` and implemented toggle/visibility state logic in `viz/src/main.ts` to show/hide save/load specific controls based on the toggles and current conditions.
- Implemented an in-memory saved-filter store `savedFiltersStore` and helper functions `saveCurrentFilters`, `applySavedFilter`, `serializeFiltersForComparison`, and UI helpers; the store is exposed as `window.savedFiltersStore` so other parts of the app can access saved filters.
- Implemented name collision handling with a confirmation dialog using `window.confirm` to allow overwriting an existing saved filter, and updated UI so that if the current conditions exactly match a saved filter the status line `Saved as: "X"` is shown and the save input is hidden.

### Testing
- Started the dev server with `npm run dev` and Vite reported the server ready at `/viz/`, which succeeded.
- Attempted an automated UI check with Playwright to capture the Filters panel, but the headless Chromium process crashed / timed out in this environment, so the Playwright screenshot run failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e48e3b24c8326bcc0702043b720e9)