### PR TITLE
Restyle filters save/load controls as tabs

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -483,35 +483,53 @@
     .filters-saved-container {
       border: 1px solid #e5e7eb;
       border-radius: 10px;
-      padding: 16px 12px 12px;
       background: #fff;
-      position: relative;
+      overflow: hidden;
     }
 
     .filters-saved-tabs {
       display: flex;
-      gap: 6px;
-      margin-top: -28px;
-      margin-bottom: 10px;
+      align-items: flex-end;
+      border-bottom: 1px solid #e5e7eb;
+      background: #f8fafc;
+      padding: 0 6px;
+      gap: 0;
     }
 
     .filters-saved-tab {
-      border: 1px solid #ddd;
+      border: 1px solid transparent;
       border-bottom: none;
-      background: #f8f8f8;
-      padding: 6px 12px;
+      background: transparent;
+      padding: 8px 12px;
       border-radius: 8px 8px 0 0;
       cursor: pointer;
       font-size: 12px;
+      margin: 0 2px -1px;
+      color: #4b5563;
+    }
+
+    .filters-saved-tab:hover:not(:disabled) {
+      background: #eef2f7;
     }
 
     .filters-saved-tab.active {
-      border-color: #3b82f6;
+      border-color: #e5e7eb;
       background: #fff;
-      box-shadow: none;
+      color: #111827;
+      font-weight: 600;
+    }
+
+    .filters-saved-tab:disabled {
+      color: #9ca3af;
     }
 
     .filters-saved-section {
+      display: grid;
+      gap: 8px;
+      padding: 12px;
+    }
+
+    .filters-saved-panel {
       display: grid;
       gap: 8px;
     }
@@ -871,18 +889,22 @@
     </div>
     <div id="filtersContent" style="padding: 12px; display: grid; gap: 12px;">
       <div class="filters-saved-container">
-        <div class="filters-saved-tabs">
-          <button id="filtersSaveToggle" class="filters-saved-tab" type="button">Save</button>
-          <button id="filtersLoadToggle" class="filters-saved-tab" type="button">Load</button>
+        <div class="filters-saved-tabs" role="tablist" aria-label="Saved filters">
+          <button id="filtersSaveToggle" class="filters-saved-tab" type="button" role="tab" aria-controls="filtersSavePanel" aria-selected="false">Save</button>
+          <button id="filtersLoadToggle" class="filters-saved-tab" type="button" role="tab" aria-controls="filtersLoadPanel" aria-selected="false">Load</button>
         </div>
         <div class="filters-saved-section">
-          <div id="filtersSaveControls" class="filters-save-row" style="display: none;">
-            <input id="filtersSaveName" type="text" placeholder="type a name" />
-            <button id="filtersSaveConfirm" type="button" title="Save">💾</button>
+          <div id="filtersSavePanel" class="filters-saved-panel" role="tabpanel" aria-labelledby="filtersSaveToggle" style="display: none;">
+            <div id="filtersSaveControls" class="filters-save-row" style="display: none;">
+              <input id="filtersSaveName" type="text" placeholder="type a name" />
+              <button id="filtersSaveConfirm" type="button" title="Save">💾</button>
+            </div>
+            <div id="filtersSavedStatus" class="filters-saved-status" style="display: none;"></div>
           </div>
-          <div id="filtersSavedStatus" class="filters-saved-status" style="display: none;"></div>
-          <div id="filtersLoadControls" class="filters-load-row" style="display: none;">
-            <select id="filtersLoadSelect"></select>
+          <div id="filtersLoadPanel" class="filters-saved-panel" role="tabpanel" aria-labelledby="filtersLoadToggle" style="display: none;">
+            <div id="filtersLoadControls" class="filters-load-row" style="display: none;">
+              <select id="filtersLoadSelect"></select>
+            </div>
           </div>
         </div>
       </div>

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -846,6 +846,8 @@ const filtersInvertToggle = document.getElementById('filtersInvertToggle') as HT
 const addFilterButton = document.getElementById('addFilterButton') as HTMLButtonElement;
 const filtersSaveToggle = document.getElementById('filtersSaveToggle') as HTMLButtonElement;
 const filtersLoadToggle = document.getElementById('filtersLoadToggle') as HTMLButtonElement;
+const filtersSavePanel = document.getElementById('filtersSavePanel') as HTMLDivElement;
+const filtersLoadPanel = document.getElementById('filtersLoadPanel') as HTMLDivElement;
 const filtersSaveControls = document.getElementById('filtersSaveControls') as HTMLDivElement;
 const filtersSaveNameInput = document.getElementById('filtersSaveName') as HTMLInputElement;
 const filtersSaveConfirmButton = document.getElementById('filtersSaveConfirm') as HTMLButtonElement;
@@ -1384,17 +1386,29 @@ function updateSavedFiltersUIState() {
 
   if (filtersSaveToggle) {
     filtersSaveToggle.disabled = !hasConditions;
-    filtersSaveToggle.classList.toggle('active', savedFiltersPanelMode === 'save');
+    const isActive = savedFiltersPanelMode === 'save';
+    filtersSaveToggle.classList.toggle('active', isActive);
+    filtersSaveToggle.setAttribute('aria-selected', String(isActive));
+    filtersSaveToggle.tabIndex = isActive ? 0 : -1;
   }
   if (filtersLoadToggle) {
     filtersLoadToggle.disabled = !hasSaved;
-    filtersLoadToggle.classList.toggle('active', savedFiltersPanelMode === 'load');
+    const isActive = savedFiltersPanelMode === 'load';
+    filtersLoadToggle.classList.toggle('active', isActive);
+    filtersLoadToggle.setAttribute('aria-selected', String(isActive));
+    filtersLoadToggle.tabIndex = isActive ? 0 : -1;
   }
 
   const showSave = savedFiltersPanelMode === 'save' && hasConditions;
   const showLoad = savedFiltersPanelMode === 'load' && hasSaved;
   const hasMatch = Boolean(savedFilterMatchName);
 
+  if (filtersSavePanel) {
+    filtersSavePanel.style.display = showSave ? 'grid' : 'none';
+  }
+  if (filtersLoadPanel) {
+    filtersLoadPanel.style.display = showLoad ? 'grid' : 'none';
+  }
   if (filtersSaveControls) {
     filtersSaveControls.style.display = showSave && !hasMatch ? 'grid' : 'none';
   }


### PR DESCRIPTION
### Motivation
- The Filters panel previously used two stand-alone buttons for Save/Load which behaved like tabs but did not visually or semantically present as a proper tabbed UI, so the UI needed to be refactored to an actual tabbed menu.
- Improve accessibility and clarity by adding proper ARIA tab roles and explicit panels for the Save and Load views while preserving existing save/load behavior.

### Description
- Restyled the saved-filters UI in `viz/index.html` by replacing the two button toggles with a tabbed header and panel structure and updated CSS under `.filters-saved-*` to present a true tab appearance.
- Added `role="tablist"`, `role="tab"`, and `role="tabpanel"` attributes and separate panel containers `#filtersSavePanel` and `#filtersLoadPanel` to the HTML so each view is an accessible panel.
- Updated `viz/src/main.ts` to declare `filtersSavePanel` and `filtersLoadPanel`, set `aria-selected` and `tabIndex` on the tab buttons, and toggle panel visibility in `updateSavedFiltersUIState()` while keeping the original save/load logic intact.
- Modified only `viz/index.html` and `viz/src/main.ts` to implement these changes.

### Testing
- No automated test suite was executed for this change.
- Attempted to run `npm install` in `viz` to start a dev preview, but the install failed with a `403` from the npm registry so a live preview/build could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e508813a4832686d3d17bd91a90d1)