### PR TITLE
Move filters/statistics/scatterplot access into layer rows and simplify filter/subject UI

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -89,7 +89,7 @@
 
     .layer-row {
       display: grid;
-      grid-template-columns: auto auto 1fr auto auto;
+      grid-template-columns: auto auto auto 1fr auto auto;
       gap: 6px;
       align-items: center;
       padding: 4px 6px;
@@ -159,6 +159,10 @@
 
     #controls .layer-tool-btn.is-muted img {
       opacity: 0.35;
+    }
+
+    #controls .layer-tool-btn.is-active img {
+      filter: invert(78%) sepia(82%) saturate(700%) hue-rotate(356deg) brightness(104%) contrast(103%);
     }
 
     .layer-source-name {

--- a/viz/index.html
+++ b/viz/index.html
@@ -162,7 +162,7 @@
     }
 
     #controls .layer-tool-btn.is-active img {
-      filter: invert(78%) sepia(82%) saturate(700%) hue-rotate(356deg) brightness(104%) contrast(103%);
+      filter: invert(19%) sepia(96%) saturate(7079%) hue-rotate(355deg) brightness(100%) contrast(112%);
     }
 
     .layer-source-name {

--- a/viz/index.html
+++ b/viz/index.html
@@ -89,7 +89,7 @@
 
     .layer-row {
       display: grid;
-      grid-template-columns: auto auto 1fr auto auto auto;
+      grid-template-columns: auto auto 1fr auto auto;
       gap: 6px;
       align-items: center;
       padding: 4px 6px;
@@ -121,6 +121,11 @@
       gap: 4px;
     }
 
+    .layer-tools {
+      display: flex;
+      gap: 4px;
+    }
+
     #controls .layer-action-btn {
       border: none;
       background: none;
@@ -134,6 +139,35 @@
     .layer-action-btn:disabled {
       opacity: 0.5;
       cursor: not-allowed;
+    }
+
+    #controls .layer-tool-btn {
+      border: none;
+      background: none;
+      padding: 0;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    #controls .layer-tool-btn img {
+      width: 16px;
+      height: 16px;
+      display: block;
+    }
+
+    #controls .layer-tool-btn.is-muted img {
+      opacity: 0.35;
+    }
+
+    .layer-source-name {
+      font-size: 12px;
+      color: #111827;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      padding: 6px 8px;
     }
 
     .current-layer-header {
@@ -759,24 +793,12 @@
           <img src="./src/svg/settings.svg" alt="Settings" />
         </button>
 
-        <button id="filtersToolButton" class="toolbar-button" title="Filters">
-          <img src="./src/svg/filters.svg" alt="Filters" />
-        </button>
-
         <button id="btnPaintMenu" class="toolbar-button" title="Show/hide paint">
           <img src="./src/svg/paint.svg" alt="Paint" />
         </button>
                
         <button id="legendToolButton" class="toolbar-button" title="Show/hide legend">
           <img src="./src/svg/legend.svg" alt="Legend" />
-        </button>
-
-        <button id="statisticsToolButton" class="toolbar-button" title="Statistics">
-          <img src="./src/svg/chart.svg" alt="Statistics" />
-        </button>
-
-        <button id="scatterplotToolButton" class="toolbar-button" title="Scatterplot">
-          <img src="./src/svg/scatter.svg" alt="Scatterplot" />
         </button>
 
         <button id="landScheduleToolButton" class="toolbar-button" title="Land Schedule">
@@ -911,14 +933,6 @@
             </div>
           </div>
         </div>
-      </div>
-
-      <div class="divider"></div>
-
-      <div class="filters-actions">
-        <button id="filtersSelectButton" type="button">Select filtered</button>
-        <button id="filtersShowButton" type="button">Show filtered</button>
-        <button id="filtersHideButton" type="button">Hide filtered</button>
       </div>
 
       <div class="divider"></div>
@@ -1079,9 +1093,7 @@
     <div id="statisticsContent" style="padding: 12px; display: grid; gap: 12px;">
       <div id="statsLayerSection" class="stats-section" style="display: grid; gap: 8px;">
         <div style="font-weight: 600; font-size: 12px;">Layer:</div>
-        <select id="statsLayerSelect">
-          <option value="" selected disabled>Choose a layer</option>
-        </select>
+        <div id="statsLayerName" class="layer-source-name">Select a layer to view statistics.</div>
       </div>
       <div id="statsSubjectSection" class="stats-section"></div>
 
@@ -1194,9 +1206,7 @@
       <div style="display: grid; gap: 12px;">
         <div id="scatterDataSourceSection" class="stats-section" style="display: grid; gap: 8px;">
           <div style="font-weight: 600; font-size: 12px;">Layer:</div>
-          <select id="scatterLayerSelect">
-            <option value="" selected disabled>Choose a layer</option>
-          </select>
+          <div id="scatterLayerName" class="layer-source-name">Select a layer to view the scatterplot.</div>
           <div id="scatterSubjectSection" class="stats-section"></div>
         </div>
         <div class="divider"></div>

--- a/viz/src/filters.ts
+++ b/viz/src/filters.ts
@@ -9,9 +9,9 @@ import { S, NUMERIC_FILTER_OPERATORS, CATEGORICAL_FILTER_OPERATORS } from './sta
 import { numOrNull } from './utils.number';
 import { updateFiltersPanelLayout } from './windows';
 import type {
-  FilterFieldType, FilterMode, FilterActionMode,
+  FilterFieldType, FilterMode,
   FilterOperator, FilterRule, SavedFilterEntry,
-  ColorMode, LayerState, SubjectSelectorControls
+  ColorMode, LayerState
 } from './types';
 
 /* ------------------------------------------------------------------ */
@@ -31,9 +31,6 @@ let filtersSaveConfirmButton: HTMLButtonElement;
 let filtersSavedStatus: HTMLDivElement;
 let filtersLoadControls: HTMLDivElement;
 let filtersLoadSelect: HTMLSelectElement;
-let filtersSelectButton: HTMLButtonElement;
-let filtersShowButton: HTMLButtonElement;
-let filtersHideButton: HTMLButtonElement;
 
 export function initFilterElements(els: {
   filtersListEl: HTMLDivElement;
@@ -49,9 +46,6 @@ export function initFilterElements(els: {
   filtersSavedStatus: HTMLDivElement;
   filtersLoadControls: HTMLDivElement;
   filtersLoadSelect: HTMLSelectElement;
-  filtersSelectButton: HTMLButtonElement;
-  filtersShowButton: HTMLButtonElement;
-  filtersHideButton: HTMLButtonElement;
 }) {
   filtersListEl = els.filtersListEl;
   filtersInvertToggle = els.filtersInvertToggle;
@@ -66,9 +60,6 @@ export function initFilterElements(els: {
   filtersSavedStatus = els.filtersSavedStatus;
   filtersLoadControls = els.filtersLoadControls;
   filtersLoadSelect = els.filtersLoadSelect;
-  filtersSelectButton = els.filtersSelectButton;
-  filtersShowButton = els.filtersShowButton;
-  filtersHideButton = els.filtersHideButton;
 }
 
 /* ------------------------------------------------------------------ */
@@ -76,45 +67,25 @@ export function initFilterElements(els: {
 /* ------------------------------------------------------------------ */
 
 let _persistCurrentLayerState: () => void;
-let _updateStatisticsSectionVisibility: () => void;
+let _renderLayerList: () => void;
 let _updateStatisticsResults: () => void;
 let _scheduleScatterPlotRefresh: () => void;
 let _getCurrentLayerIds: () => { sourceId: string; layerId: string; errorLayerId: string } | null;
-let _getCurrentSourceId: () => string | null;
 let _clearLegendVisibility: () => void;
-let _clearAllSelections: () => void;
-let _updateSelectionControls: () => void;
-let _getParcelId: (feature: GeoJSON.Feature) => string;
-let _renderSubjectFilterOptionsCallback: (controls: SubjectSelectorControls, selectedName: string | null) => string | null;
-let _statsSubjectControls: SubjectSelectorControls;
-let _scatterSubjectControls: SubjectSelectorControls;
-
 export function initFilterCallbacks(cbs: {
   persistCurrentLayerState: () => void;
-  updateStatisticsSectionVisibility: () => void;
+  renderLayerList: () => void;
   updateStatisticsResults: () => void;
   scheduleScatterPlotRefresh: () => void;
   getCurrentLayerIds: () => { sourceId: string; layerId: string; errorLayerId: string } | null;
-  getCurrentSourceId: () => string | null;
   clearLegendVisibility: () => void;
-  clearAllSelections: () => void;
-  updateSelectionControls: () => void;
-  getParcelId: (feature: GeoJSON.Feature) => string;
-  statsSubjectControls: SubjectSelectorControls;
-  scatterSubjectControls: SubjectSelectorControls;
 }) {
   _persistCurrentLayerState = cbs.persistCurrentLayerState;
-  _updateStatisticsSectionVisibility = cbs.updateStatisticsSectionVisibility;
+  _renderLayerList = cbs.renderLayerList;
   _updateStatisticsResults = cbs.updateStatisticsResults;
   _scheduleScatterPlotRefresh = cbs.scheduleScatterPlotRefresh;
   _getCurrentLayerIds = cbs.getCurrentLayerIds;
-  _getCurrentSourceId = cbs.getCurrentSourceId;
   _clearLegendVisibility = cbs.clearLegendVisibility;
-  _clearAllSelections = cbs.clearAllSelections;
-  _updateSelectionControls = cbs.updateSelectionControls;
-  _getParcelId = cbs.getParcelId;
-  _statsSubjectControls = cbs.statsSubjectControls;
-  _scatterSubjectControls = cbs.scatterSubjectControls;
 }
 
 /* ------------------------------------------------------------------ */
@@ -236,15 +207,6 @@ export function updateSavedFiltersUIState() {
     renderSavedFiltersOptions();
   }
 
-  S.statsFilteredName = renderSubjectFilterOptions(_statsSubjectControls, S.statsFilteredName);
-  S.scatterFilteredName = renderSubjectFilterOptions(_scatterSubjectControls, S.scatterFilteredName);
-  if (S.statsSubjectMode === 'filtered') {
-    _updateStatisticsSectionVisibility();
-    _updateStatisticsResults();
-  }
-  if (S.scatterSubjectMode === 'filtered') {
-    _scheduleScatterPlotRefresh();
-  }
 }
 
 export function saveCurrentFilters(name: string) {
@@ -604,21 +566,14 @@ export function createFilterRule(): FilterRule {
   };
 }
 
-function updateFilterActionButtons() {
-  filtersSelectButton.classList.toggle('active', S.filterActionMode === 'select');
-  filtersShowButton.classList.toggle('active', S.filterActionMode === 'show');
-  filtersHideButton.classList.toggle('active', S.filterActionMode === 'hide');
-}
-
 export function updateFiltersUIState() {
   const hasData = Boolean(S.currentGeoJSON);
   const hasActiveFilters = getActiveFilters().length > 0;
   const canApply = hasData && hasActiveFilters;
   if (addFilterButton) addFilterButton.disabled = false;
-  if (filtersSelectButton) filtersSelectButton.disabled = !canApply;
-  if (filtersShowButton) filtersShowButton.disabled = !canApply;
-  if (filtersHideButton) filtersHideButton.disabled = !canApply;
-  updateFilterActionButtons();
+  if (!canApply) {
+    S.filterMode = 'none';
+  }
   updateSavedFiltersUIState();
 }
 
@@ -802,29 +757,6 @@ export function refreshFiltersUI() {
   updateFiltersUIState();
 }
 
-export function renderSubjectFilterOptions(controls: SubjectSelectorControls, selectedName: string | null): string | null {
-  controls.filterSelect.replaceChildren();
-  const placeholder = new Option('Choose a saved filter', '');
-  placeholder.disabled = true;
-  placeholder.selected = true;
-  controls.filterSelect.appendChild(placeholder);
-
-  S.savedFiltersStore.forEach((entry, name) => {
-    controls.filterSelect.appendChild(new Option(entry.name, name));
-  });
-
-  if (selectedName && S.savedFiltersStore.has(selectedName)) {
-    controls.filterSelect.value = selectedName;
-  } else {
-    selectedName = null;
-  }
-
-  controls.filterSelect.disabled = S.savedFiltersStore.size === 0;
-  controls.filterSelect.style.display = S.savedFiltersStore.size === 0 ? 'none' : 'block';
-  controls.filterEmptyState.style.display = S.savedFiltersStore.size === 0 ? 'block' : 'none';
-  return selectedName;
-}
-
 /* ------------------------------------------------------------------ */
 /*  Filter matching (JS-side evaluation)                              */
 /* ------------------------------------------------------------------ */
@@ -879,69 +811,15 @@ function matchesActiveFilters(feature: GeoJSON.Feature): boolean {
 /*  Filter actions                                                    */
 /* ------------------------------------------------------------------ */
 
-function applyFilteredSelection() {
-  if (!S.currentGeoJSON) return;
-  const activeFilters = getActiveFilters();
-  if (!activeFilters.length) return;
-  const sourceId = _getCurrentSourceId();
-  if (!sourceId) return;
-
-  _clearAllSelections();
-
-  for (const feature of S.currentGeoJSON.features) {
-    if (!matchesActiveFilters(feature)) continue;
-    if (feature.id === undefined) continue;
-    const parcelId = _getParcelId(feature);
-    S.selectedParcels.add(parcelId);
-    S.map.setFeatureState(
-      { source: sourceId, id: feature.id },
-      { selected: true }
-    );
-  }
-  _updateSelectionControls();
-}
-
-function applyFilterMode(mode: FilterMode) {
-  if (!S.currentGeoJSON) return;
-  S.filterMode = mode;
-  if (mode !== 'none') {
+export function applyActiveFilterAction() {
+  const hasActiveFilters = getActiveFilters().length > 0;
+  const nextMode: FilterMode = hasActiveFilters ? 'show' : 'none';
+  S.filterActionMode = 'none';
+  S.filterMode = nextMode;
+  if (nextMode !== 'none') {
     _clearLegendVisibility();
   }
   applyMapFilters();
   updateFiltersUIState();
-  _persistCurrentLayerState();
-}
-
-export function applyActiveFilterAction() {
-  if (S.filterActionMode === 'select') {
-    applyFilteredSelection();
-    return;
-  }
-  if (S.filterActionMode === 'show') {
-    applyFilterMode('show');
-    return;
-  }
-  if (S.filterActionMode === 'hide') {
-    applyFilterMode('hide');
-    return;
-  }
-}
-
-export function setFilterActionMode(nextMode: FilterActionMode) {
-  const next = S.filterActionMode === nextMode ? 'none' : nextMode;
-  S.filterActionMode = next;
-
-  if (next === 'select') {
-    applyFilterMode('none');
-    applyFilteredSelection();
-  } else if (next === 'show' || next === 'hide') {
-    applyFilterMode(next);
-  } else {
-    if (S.filterMode !== 'none') {
-      applyFilterMode('none');
-    }
-  }
-
-  updateFilterActionButtons();
-  _persistCurrentLayerState();
+  _renderLayerList();
 }

--- a/viz/src/layers.ts
+++ b/viz/src/layers.ts
@@ -10,7 +10,7 @@ import { S } from './state';
 import { SOURCE_ID, LAYER_ID, ERROR_LAYER_ID } from './config';
 import type { LayerState, DataStore } from './types';
 import type { AsyncBuffer } from './utils.sanitize';
-import { cloneFilters, isFilterComplete } from './filters';
+import { cloneFilters } from './filters';
 import { refreshLandSchedulePanel } from './land-schedule';
 
 const FILTER_ICON = new URL('./svg/filters.svg', import.meta.url).href;
@@ -709,7 +709,7 @@ export function renderLayerList() {
     const toolsGroup = document.createElement('div');
     toolsGroup.className = 'layer-tools';
 
-    const hasActiveFilters = (layer.filters ?? []).some(filter => isFilterComplete(filter));
+    const hasActiveFilters = (layer.filters ?? []).some(filter => filter.active);
 
     const filterBtn = document.createElement('button');
     filterBtn.type = 'button';

--- a/viz/src/layers.ts
+++ b/viz/src/layers.ts
@@ -706,10 +706,6 @@ export function renderLayerList() {
       applyLayerOrderToMap();
     });
 
-    const actionGroup = document.createElement('div');
-    actionGroup.className = 'layer-actions';
-    actionGroup.append(moveUpBtn, moveDownBtn, deleteBtn);
-
     const toolsGroup = document.createElement('div');
     toolsGroup.className = 'layer-tools';
 
@@ -717,7 +713,7 @@ export function renderLayerList() {
 
     const filterBtn = document.createElement('button');
     filterBtn.type = 'button';
-    filterBtn.className = `layer-tool-btn${hasActiveFilters ? '' : ' is-muted'}`;
+    filterBtn.className = `layer-tool-btn${hasActiveFilters ? ' is-active' : ' is-muted'}`;
     filterBtn.title = 'Filters';
     filterBtn.innerHTML = `<img src="${FILTER_ICON}" alt="Filters" />`;
     filterBtn.addEventListener('click', () => {
@@ -765,9 +761,13 @@ export function renderLayerList() {
       _showScatterplotPanel();
     });
 
-    toolsGroup.append(filterBtn, statsBtn, scatterBtn);
+    toolsGroup.append(statsBtn, scatterBtn);
 
-    row.append(visibilityToggle, currentRadio, nameButton, actionGroup, toolsGroup);
+    const actionGroup = document.createElement('div');
+    actionGroup.className = 'layer-actions';
+    actionGroup.append(moveUpBtn, moveDownBtn, deleteBtn);
+
+    row.append(currentRadio, visibilityToggle, filterBtn, nameButton, toolsGroup, actionGroup);
     _layerList.appendChild(row);
   });
 

--- a/viz/src/layers.ts
+++ b/viz/src/layers.ts
@@ -10,8 +10,12 @@ import { S } from './state';
 import { SOURCE_ID, LAYER_ID, ERROR_LAYER_ID } from './config';
 import type { LayerState, DataStore } from './types';
 import type { AsyncBuffer } from './utils.sanitize';
-import { cloneFilters } from './filters';
+import { cloneFilters, isFilterComplete } from './filters';
 import { refreshLandSchedulePanel } from './land-schedule';
+
+const FILTER_ICON = new URL('./svg/filters.svg', import.meta.url).href;
+const CHART_ICON = new URL('./svg/chart.svg', import.meta.url).href;
+const SCATTER_ICON = new URL('./svg/scatter.svg', import.meta.url).href;
 
 /* ------------------------------------------------------------------ */
 /*  DOM element references (set once via initLayerElements)            */
@@ -80,6 +84,9 @@ let _updateSelectionControls: () => void;
 let _refreshStatisticsPanel: () => void;
 let _refreshScatterPanel: () => void;
 let _refreshFiltersUI: () => void;
+let _showFiltersPanel: () => void;
+let _showStatisticsPanel: () => void;
+let _showScatterplotPanel: () => void;
 let _renderStatsLayerOptions: () => void;
 let _renderScatterLayerOptions: () => void;
 let _addOrUpdateSource: (fc: GeoJSON.FeatureCollection) => void;
@@ -99,6 +106,9 @@ export function initLayerCallbacks(cbs: {
   refreshStatisticsPanel: () => void;
   refreshScatterPanel: () => void;
   refreshFiltersUI: () => void;
+  showFiltersPanel: () => void;
+  showStatisticsPanel: () => void;
+  showScatterplotPanel: () => void;
   renderStatsLayerOptions: () => void;
   renderScatterLayerOptions: () => void;
   addOrUpdateSource: (fc: GeoJSON.FeatureCollection) => void;
@@ -117,6 +127,9 @@ export function initLayerCallbacks(cbs: {
   _refreshStatisticsPanel = cbs.refreshStatisticsPanel;
   _refreshScatterPanel = cbs.refreshScatterPanel;
   _refreshFiltersUI = cbs.refreshFiltersUI;
+  _showFiltersPanel = cbs.showFiltersPanel;
+  _showStatisticsPanel = cbs.showStatisticsPanel;
+  _showScatterplotPanel = cbs.showScatterplotPanel;
   _renderStatsLayerOptions = cbs.renderStatsLayerOptions;
   _renderScatterLayerOptions = cbs.renderScatterLayerOptions;
   _addOrUpdateSource = cbs.addOrUpdateSource;
@@ -693,7 +706,68 @@ export function renderLayerList() {
       applyLayerOrderToMap();
     });
 
-    row.append(visibilityToggle, currentRadio, nameButton, moveUpBtn, moveDownBtn, deleteBtn);
+    const actionGroup = document.createElement('div');
+    actionGroup.className = 'layer-actions';
+    actionGroup.append(moveUpBtn, moveDownBtn, deleteBtn);
+
+    const toolsGroup = document.createElement('div');
+    toolsGroup.className = 'layer-tools';
+
+    const hasActiveFilters = (layer.filters ?? []).some(filter => isFilterComplete(filter));
+
+    const filterBtn = document.createElement('button');
+    filterBtn.type = 'button';
+    filterBtn.className = `layer-tool-btn${hasActiveFilters ? '' : ' is-muted'}`;
+    filterBtn.title = 'Filters';
+    filterBtn.innerHTML = `<img src="${FILTER_ICON}" alt="Filters" />`;
+    filterBtn.addEventListener('click', () => {
+      setCurrentLayer(layerId);
+      _showFiltersPanel();
+    });
+
+    const statsBtn = document.createElement('button');
+    statsBtn.type = 'button';
+    statsBtn.className = 'layer-tool-btn';
+    statsBtn.title = 'Statistics';
+    statsBtn.innerHTML = `<img src="${CHART_ICON}" alt="Statistics" />`;
+    statsBtn.addEventListener('click', () => {
+      const prevStatsLayer = S.statsLayerId;
+      S.statsLayerId = layerId;
+      if (prevStatsLayer !== S.statsLayerId) {
+        S.statsCategoryField = null;
+        S.statsCategoryValueIndices = [];
+        S.statsField = null;
+        S.statsFieldType = null;
+      }
+      _renderStatsLayerOptions();
+      _refreshStatisticsPanel();
+      _showStatisticsPanel();
+    });
+
+    const scatterBtn = document.createElement('button');
+    scatterBtn.type = 'button';
+    scatterBtn.className = 'layer-tool-btn';
+    scatterBtn.title = 'Scatterplot';
+    scatterBtn.innerHTML = `<img src="${SCATTER_ICON}" alt="Scatterplot" />`;
+    scatterBtn.addEventListener('click', () => {
+      const prevScatterLayer = S.scatterLayerId;
+      S.scatterLayerId = layerId;
+      if (prevScatterLayer !== S.scatterLayerId) {
+        S.scatterCategoryField = null;
+        S.scatterCategoryValueIndices = [];
+        S.scatterXField = null;
+        S.scatterYField = null;
+        S.scatterRangeIsCustom = false;
+        S.scatterColorByField = null;
+      }
+      _renderScatterLayerOptions();
+      _refreshScatterPanel();
+      _showScatterplotPanel();
+    });
+
+    toolsGroup.append(filterBtn, statsBtn, scatterBtn);
+
+    row.append(visibilityToggle, currentRadio, nameButton, actionGroup, toolsGroup);
     _layerList.appendChild(row);
   });
 

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -49,10 +49,9 @@ import {
   setSavedFiltersPanelMode, updateSavedFiltersUIState,
   saveCurrentFilters, applySavedFilter,
   getCategoricalValues,
-  applyMapFilters,
   createFilterRule, updateFiltersUIState, renderFiltersList,
   refreshFiltersUI,
-  applyActiveFilterAction, setFilterActionMode,
+  applyActiveFilterAction,
 } from './filters';
 import {
   createWindowManager, initWindowCallbacks, initPositionElements,
@@ -121,7 +120,7 @@ import {
   setCurrentLayer, setLayerVisibility,
   createLayerState, persistCurrentLayerState,
   registerLayer, removeLayer,
-  renderLayerList, renderLayerSelectOptions,
+  renderLayerList,
   getStatsLayer, getScatterLayer, getLayerDataStore, getLayerGeoJSON, getScatterDataStore,
   createDataStore, renderDataStoreList,
 } from './layers';
@@ -327,10 +326,10 @@ const paintContent = document.getElementById('paintContent') as HTMLDivElement;
 const statisticsControlsEl = document.getElementById('statisticsControls') as HTMLDivElement;
 const statisticsContent = document.getElementById('statisticsContent') as HTMLDivElement;
 const statsSubjectSection = document.getElementById('statsSubjectSection') as HTMLDivElement;
-const statsLayerSelect = document.getElementById('statsLayerSelect') as HTMLSelectElement;
+const statsLayerName = document.getElementById('statsLayerName') as HTMLDivElement;
 const scatterplotControlsEl = document.getElementById('scatterplotControls') as HTMLDivElement;
 const scatterplotContent = document.getElementById('scatterplotContent') as HTMLDivElement;
-const scatterLayerSelect = document.getElementById('scatterLayerSelect') as HTMLSelectElement;
+const scatterLayerName = document.getElementById('scatterLayerName') as HTMLDivElement;
 const scatterSubjectSection = document.getElementById('scatterSubjectSection') as HTMLDivElement;
 const scatterXFieldSelect = document.getElementById('scatterXField') as HTMLSelectElement;
 const scatterYFieldSelect = document.getElementById('scatterYField') as HTMLSelectElement;
@@ -360,9 +359,6 @@ const filtersSaveConfirmButton = document.getElementById('filtersSaveConfirm') a
 const filtersSavedStatus = document.getElementById('filtersSavedStatus') as HTMLDivElement;
 const filtersLoadControls = document.getElementById('filtersLoadControls') as HTMLDivElement;
 const filtersLoadSelect = document.getElementById('filtersLoadSelect') as HTMLSelectElement;
-const filtersSelectButton = document.getElementById('filtersSelectButton') as HTMLButtonElement;
-const filtersShowButton = document.getElementById('filtersShowButton') as HTMLButtonElement;
-const filtersHideButton = document.getElementById('filtersHideButton') as HTMLButtonElement;
 
 const statsSubjectControls = buildSubjectSelector(statsSubjectSection);
 const scatterSubjectControls = buildSubjectSelector(scatterSubjectSection, { title: null });
@@ -591,13 +587,10 @@ const minimizeLegend = legendWin.minimize;
 const showLegend = legendWin.show;
 const minimizeStatistics = statisticsWin.minimize;
 const showStatistics = statisticsWin.show;
-const toggleStatistics = statisticsWin.toggle;
 const minimizeScatterplot = scatterplotWin.minimize;
 const showScatterplot = scatterplotWin.show;
-const toggleScatterplot = scatterplotWin.toggle;
 const minimizeFilters = filtersWin.minimize;
 const showFilters = filtersWin.show;
-const toggleFilters = filtersWin.toggle;
 const minimizeLandSchedule = landScheduleWin.minimize;
 const showLandSchedule = landScheduleWin.show;
 const toggleLandSchedule = landScheduleWin.toggle;
@@ -634,23 +627,14 @@ initFilterElements({
   filtersSavedStatus,
   filtersLoadControls,
   filtersLoadSelect,
-  filtersSelectButton,
-  filtersShowButton,
-  filtersHideButton,
 });
 initFilterCallbacks({
   persistCurrentLayerState,
-  updateStatisticsSectionVisibility,
+  renderLayerList,
   updateStatisticsResults,
   scheduleScatterPlotRefresh,
   getCurrentLayerIds,
-  getCurrentSourceId,
   clearLegendVisibility,
-  clearAllSelections,
-  updateSelectionControls,
-  getParcelId,
-  statsSubjectControls,
-  scatterSubjectControls,
 });
 
 // Wire DOM elements and callbacks into the rendering module
@@ -760,7 +744,7 @@ initModalCallbacks({
 
 // Wire DOM elements and callbacks into the statistics module
 initStatisticsElements({
-  statsLayerSelect,
+  statsLayerName,
   statsSubjectControls,
   statsFieldSelect,
   statsDetails,
@@ -791,13 +775,12 @@ initStatisticsCallbacks({
   getStatsLayer,
   getLayerDataStore,
   getLayerGeoJSON,
-  renderLayerSelectOptions,
   getParcelId,
 });
 
 // Wire DOM elements and callbacks into the scatterplot module
 initScatterplotElements({
-  scatterLayerSelect,
+  scatterLayerName,
   scatterSubjectControls,
   scatterXFieldSelect,
   scatterYFieldSelect,
@@ -816,8 +799,6 @@ initScatterplotElements({
 initScatterplotCallbacks({
   getScatterLayer,
   getScatterDataStore,
-  getLayerDataStore,
-  renderLayerSelectOptions,
   getParcelId,
 });
 
@@ -862,6 +843,9 @@ initLayerCallbacks({
   refreshStatisticsPanel,
   refreshScatterPanel,
   refreshFiltersUI,
+  showFiltersPanel: showFilters,
+  showStatisticsPanel: showStatistics,
+  showScatterplotPanel: showScatterplot,
   renderStatsLayerOptions,
   renderScatterLayerOptions,
   addOrUpdateSource,
@@ -1872,47 +1856,10 @@ addFilterButton.addEventListener('click', () => {
   persistCurrentLayerState();
 });
 
-filtersSelectButton.addEventListener('click', () => {
-  setFilterActionMode('select');
-});
-
-filtersShowButton.addEventListener('click', () => {
-  setFilterActionMode('show');
-});
-
-filtersHideButton.addEventListener('click', () => {
-  setFilterActionMode('hide');
-});
-
 filtersInvertToggle.addEventListener('change', () => {
   S.filterInvert = filtersInvertToggle.checked;
   applyActiveFilterAction();
-  applyMapFilters();
-  updateSavedFiltersUIState();
   persistCurrentLayerState();
-});
-
-statsLayerSelect.addEventListener('change', () => {
-  S.statsLayerId = statsLayerSelect.value || null;
-  S.statsCategoryField = null;
-  S.statsCategoryValueIndices = [];
-  S.statsField = null;
-  S.statsFieldType = null;
-  refreshStatisticsPanel();
-  resetStatisticsDisplay();
-});
-
-scatterLayerSelect.addEventListener('change', () => {
-  S.scatterLayerId = scatterLayerSelect.value || null;
-  S.scatterCategoryField = null;
-  S.scatterCategoryValueIndices = [];
-  S.scatterXField = null;
-  S.scatterYField = null;
-  S.scatterRangeIsCustom = false;
-  S.scatterColorByField = null;
-  clearScatterHover();
-  clearScatterSelection();
-  refreshScatterPanel();
 });
 
 statsSubjectButtons.forEach(button => {
@@ -1929,18 +1876,6 @@ scatterSubjectButtons.forEach(button => {
     if (!mode) return;
     setScatterSubjectMode(mode);
   });
-});
-
-statsSubjectControls.filterSelect.addEventListener('change', () => {
-  S.statsFilteredName = statsSubjectControls.filterSelect.value || null;
-  updateStatisticsSectionVisibility();
-  updateStatisticsResults();
-});
-
-scatterSubjectControls.filterSelect.addEventListener('change', () => {
-  S.scatterFilteredName = scatterSubjectControls.filterSelect.value || null;
-  S.scatterRangeIsCustom = false;
-  scheduleScatterPlotRefresh();
 });
 
 statsCategoryFieldSelect.addEventListener('change', () => {
@@ -1991,7 +1926,7 @@ statsFieldSelect.addEventListener('change', () => {
   S.statsField = statsFieldSelect.value || null;
   const layer = getStatsLayer();
   const dataStore = getLayerDataStore(layer);
-  const useDataSource = S.statsSubjectMode === 'category' || S.statsSubjectMode === 'filtered';
+  const useDataSource = S.statsSubjectMode === 'category';
   const numericFields = useDataSource ? dataStore?.chosenNumericFields ?? [] : layer?.chosenNumericFields ?? [];
   const categoricalFields = useDataSource ? dataStore?.chosenCategoricalFields ?? [] : layer?.chosenCategoricalFields ?? [];
   S.statsFieldType = getStatsFieldType(S.statsField, numericFields, categoricalFields);
@@ -2286,11 +2221,8 @@ initToolbarCallbacks({
   showLayers,
   minimizeLayers,
   toggleSettingsMenu,
-  toggleFilters,
   showLegend,
   minimizeLegend,
-  toggleStatistics,
-  toggleScatterplot,
   toggleLandSchedule,
 });
 

--- a/viz/src/scatterplot.ts
+++ b/viz/src/scatterplot.ts
@@ -12,8 +12,6 @@ import { numOrNull } from './utils.number';
 import {
   buildLayerVisibilityExpression,
   evaluateFilterExpression,
-  buildSavedFilterExpression,
-  renderSubjectFilterOptions,
 } from './filters';
 import {
   populateCategoryFields,
@@ -32,7 +30,7 @@ import type {
 /*  DOM element references (set once via initScatterplotElements)      */
 /* ------------------------------------------------------------------ */
 
-let scatterLayerSelect: HTMLSelectElement;
+let scatterLayerName: HTMLDivElement;
 let scatterSubjectControls: SubjectSelectorControls;
 let scatterCategoryFieldSelect: HTMLSelectElement;
 let scatterCategoryValueSelect: HTMLSelectElement;
@@ -51,7 +49,7 @@ let scatterPlot: HTMLDivElement;
 let scatterPlotEmpty: HTMLDivElement;
 
 export function initScatterplotElements(els: {
-  scatterLayerSelect: HTMLSelectElement;
+  scatterLayerName: HTMLDivElement;
   scatterSubjectControls: SubjectSelectorControls;
   scatterXFieldSelect: HTMLSelectElement;
   scatterYFieldSelect: HTMLSelectElement;
@@ -67,7 +65,7 @@ export function initScatterplotElements(els: {
   scatterPlot: HTMLDivElement;
   scatterPlotEmpty: HTMLDivElement;
 }) {
-  scatterLayerSelect = els.scatterLayerSelect;
+  scatterLayerName = els.scatterLayerName;
   scatterSubjectControls = els.scatterSubjectControls;
   scatterCategoryFieldSelect = els.scatterSubjectControls.categoryFieldSelect;
   scatterCategoryValueSelect = els.scatterSubjectControls.categoryValueSelect;
@@ -92,29 +90,15 @@ export function initScatterplotElements(els: {
 
 let _getScatterLayer: () => LayerState | null;
 let _getScatterDataStore: () => DataStore | null;
-let _getLayerDataStore: (layer: LayerState | null) => DataStore | null;
-let _renderLayerSelectOptions: (
-  select: HTMLSelectElement,
-  selectedId: string | null,
-  placeholderText: string
-) => string | null;
 let _getParcelId: (feature: GeoJSON.Feature) => string;
 
 export function initScatterplotCallbacks(cbs: {
   getScatterLayer: () => LayerState | null;
   getScatterDataStore: () => DataStore | null;
-  getLayerDataStore: (layer: LayerState | null) => DataStore | null;
-  renderLayerSelectOptions: (
-    select: HTMLSelectElement,
-    selectedId: string | null,
-    placeholderText: string
-  ) => string | null;
   getParcelId: (feature: GeoJSON.Feature) => string;
 }) {
   _getScatterLayer = cbs.getScatterLayer;
   _getScatterDataStore = cbs.getScatterDataStore;
-  _getLayerDataStore = cbs.getLayerDataStore;
-  _renderLayerSelectOptions = cbs.renderLayerSelectOptions;
   _getParcelId = cbs.getParcelId;
 }
 
@@ -247,7 +231,6 @@ export function updateScatterSubjectControls() {
   if (!layer || !scatterGeoJSON) {
     scatterSubjectControls.buttons.forEach(button => { button.disabled = true; });
     scatterSubjectControls.categoryControls.style.display = 'none';
-    scatterSubjectControls.filterControls.style.display = 'none';
     scatterCategoryFieldSelect.disabled = true;
     scatterCategoryValueSelect.disabled = true;
     return;
@@ -266,7 +249,8 @@ function updateScatterSubjectButtons() {
 }
 
 export function setScatterSubjectMode(mode: SubjectMode) {
-  S.scatterSubjectMode = mode;
+  const allowedModes: SubjectMode[] = ['all', 'visible', 'selected'];
+  S.scatterSubjectMode = allowedModes.includes(mode) ? mode : 'all';
   updateScatterSubjectButtons();
   updateScatterSubjectControls();
   S.scatterRangeIsCustom = false;
@@ -560,8 +544,7 @@ function getScatterSubjectSelection(
   mode: SubjectMode,
   categoryField: string | null,
   categoryValueIndices: string[],
-  categoryValueMap: Array<{ label: string; value: unknown }>,
-  filteredName: string | null
+  categoryValueMap: Array<{ label: string; value: unknown }>
 ): GeoJSON.Feature[] {
   if (mode === 'visible') {
     if (!layerGeoJSON) return [];
@@ -587,14 +570,6 @@ function getScatterSubjectSelection(
       return selectedValues.has(value);
     });
   }
-  if (mode === 'filtered') {
-    if (!dataGeoJSON || !filteredName) return [];
-    const entry = S.savedFiltersStore.get(filteredName);
-    if (!entry) return [];
-    const filterExpr = buildSavedFilterExpression(entry);
-    if (!filterExpr) return [];
-    return dataGeoJSON.features.filter(feature => evaluateFilterExpression(filterExpr, feature));
-  }
   return layerGeoJSON?.features ?? [];
 }
 
@@ -619,14 +594,6 @@ export function updateScatterPlot() {
     resetScatterPlot('Choose category values to render the scatterplot.');
     return;
   }
-  if (S.scatterSubjectMode === 'filtered' && !S.scatterFilteredName) {
-    if (S.savedFiltersStore.size === 0) {
-      resetScatterPlot('No saved filters available for the scatterplot.');
-    } else {
-      resetScatterPlot('Select a saved filter to render the scatterplot.');
-    }
-    return;
-  }
   if (!S.scatterXField || !S.scatterYField) {
     resetScatterPlot('Select X and Y fields to render the scatterplot.');
     return;
@@ -639,8 +606,7 @@ export function updateScatterPlot() {
     S.scatterSubjectMode,
     S.scatterCategoryField,
     S.scatterCategoryValueIndices,
-    S.scatterCategoryValueMap,
-    S.scatterFilteredName
+    S.scatterCategoryValueMap
   );
   const xValues: number[] = [];
   const yValues: number[] = [];
@@ -763,13 +729,35 @@ export function refreshScatterPanel() {
   populateScatterCategoryValues(S.scatterCategoryField);
   populateScatterFields();
   populateScatterColorByFields();
-  S.scatterFilteredName = renderSubjectFilterOptions(scatterSubjectControls, S.scatterFilteredName);
+  const allowedModes: SubjectMode[] = ['all', 'visible', 'selected'];
+  if (!allowedModes.includes(S.scatterSubjectMode)) {
+    S.scatterSubjectMode = 'all';
+  }
   updateScatterSubjectButtons();
   updateScatterSubjectControls();
   scheduleScatterPlotRefresh();
 }
 
+function resolveScatterLayerId(): string | null {
+  if (S.scatterLayerId && S.layers.has(S.scatterLayerId)) {
+    return S.scatterLayerId;
+  }
+  return S.currentLayerId ?? S.layerOrder[0] ?? null;
+}
+
+function getScatterLayerLabel(layerId: string | null): string {
+  if (!layerId) return 'Select a layer to view the scatterplot.';
+  const layer = S.layers.get(layerId);
+  if (!layer) return 'Select a layer to view the scatterplot.';
+  const index = S.layerOrder.indexOf(layerId);
+  const baseName = layer.field ?? `layer ${index + 1}`;
+  const store = S.dataStores.get(layer.dataStoreId);
+  const sourceLabel = store?.file?.name ?? store?.name ?? 'Unknown source';
+  return `${baseName} (${sourceLabel})`;
+}
+
 export function renderScatterLayerOptions() {
-  if (!scatterLayerSelect) return;
-  S.scatterLayerId = _renderLayerSelectOptions(scatterLayerSelect, S.scatterLayerId, 'Choose a layer');
+  if (!scatterLayerName) return;
+  S.scatterLayerId = resolveScatterLayerId();
+  scatterLayerName.textContent = getScatterLayerLabel(S.scatterLayerId);
 }

--- a/viz/src/statistics.ts
+++ b/viz/src/statistics.ts
@@ -10,8 +10,6 @@ import { fmt, percentile, numOrNull } from './utils.number';
 import {
   buildLayerVisibilityExpression,
   evaluateFilterExpression,
-  buildSavedFilterExpression,
-  renderSubjectFilterOptions,
 } from './filters';
 import type {
   SubjectMode,
@@ -26,7 +24,7 @@ import type {
 /* ------------------------------------------------------------------ */
 
 /**
- * Build a subject-mode selector UI (All / Visible / Selected / Category / Filtered)
+ * Build a subject-mode selector UI (All / Visible / Selected)
  * inside the given container. Returns references to the created DOM elements.
  */
 export function buildSubjectSelector(
@@ -54,9 +52,7 @@ export function buildSubjectSelector(
   const modes: Array<{ mode: SubjectMode; label: string }> = [
     { mode: 'all', label: 'All' },
     { mode: 'visible', label: 'Visible' },
-    { mode: 'selected', label: 'Selected' },
-    { mode: 'category', label: 'Category' },
-    { mode: 'filtered', label: 'Filtered' }
+    { mode: 'selected', label: 'Selected' }
   ];
   modes.forEach(({ mode, label }) => {
     const button = document.createElement('button');
@@ -93,25 +89,9 @@ export function buildSubjectSelector(
   categoryValueSelect.appendChild(valuePlaceholder);
 
   categoryControls.append(categoryFieldSelect, categoryValueSelect);
-  const filterControls = document.createElement('div');
-  filterControls.style.display = 'none';
-  filterControls.style.gap = '6px';
-  filterControls.style.marginTop = '8px';
+  container.append(subjectBlock, categoryControls);
 
-  const filterSelect = document.createElement('select');
-  const filterPlaceholder = new Option('Choose a saved filter', '');
-  filterPlaceholder.disabled = true;
-  filterPlaceholder.selected = true;
-  filterSelect.appendChild(filterPlaceholder);
-
-  const filterEmptyState = document.createElement('div');
-  filterEmptyState.className = 'muted';
-  filterEmptyState.textContent = "You haven't saved any filters yet.";
-
-  filterControls.append(filterSelect, filterEmptyState);
-  container.append(subjectBlock, categoryControls, filterControls);
-
-  return { buttons, categoryControls, categoryFieldSelect, categoryValueSelect, filterControls, filterSelect, filterEmptyState };
+  return { buttons, categoryControls, categoryFieldSelect, categoryValueSelect };
 }
 
 export function updateSubjectButtons(controls: SubjectSelectorControls, mode: SubjectMode) {
@@ -127,18 +107,9 @@ export function updateSubjectControls(
   hasFieldSelected: boolean
 ) {
   const isCategory = mode === 'category';
-  const isFiltered = mode === 'filtered';
   controls.categoryControls.style.display = isCategory ? 'grid' : 'none';
   controls.categoryFieldSelect.disabled = !isCategory || !hasFieldOptions;
   controls.categoryValueSelect.disabled = !isCategory || !hasFieldSelected;
-  controls.filterControls.style.display = isFiltered ? 'grid' : 'none';
-  if (!isFiltered) {
-    return;
-  }
-  const hasFilters = S.savedFiltersStore.size > 0;
-  controls.filterSelect.disabled = !hasFilters;
-  controls.filterSelect.style.display = hasFilters ? 'block' : 'none';
-  controls.filterEmptyState.style.display = hasFilters ? 'none' : 'block';
 }
 
 /**
@@ -228,7 +199,7 @@ export function populateCategoryValues(
 /*  DOM element references (set once via initStatisticsElements)       */
 /* ------------------------------------------------------------------ */
 
-let statsLayerSelect: HTMLSelectElement;
+let statsLayerName: HTMLDivElement;
 let statsSubjectControls: SubjectSelectorControls;
 let statsCategoryFieldSelect: HTMLSelectElement;
 let statsCategoryValueSelect: HTMLSelectElement;
@@ -258,7 +229,7 @@ let statsOverflowMinPct: HTMLInputElement;
 let statsOverflowMaxPct: HTMLInputElement;
 
 export function initStatisticsElements(els: {
-  statsLayerSelect: HTMLSelectElement;
+  statsLayerName: HTMLDivElement;
   statsSubjectControls: SubjectSelectorControls;
   statsFieldSelect: HTMLSelectElement;
   statsDetails: HTMLDivElement;
@@ -285,7 +256,7 @@ export function initStatisticsElements(els: {
   statsOverflowMinPct: HTMLInputElement;
   statsOverflowMaxPct: HTMLInputElement;
 }) {
-  statsLayerSelect = els.statsLayerSelect;
+  statsLayerName = els.statsLayerName;
   statsSubjectControls = els.statsSubjectControls;
   statsCategoryFieldSelect = els.statsSubjectControls.categoryFieldSelect;
   statsCategoryValueSelect = els.statsSubjectControls.categoryValueSelect;
@@ -322,28 +293,17 @@ export function initStatisticsElements(els: {
 let _getStatsLayer: () => LayerState | null;
 let _getLayerDataStore: (layer: LayerState | null) => DataStore | null;
 let _getLayerGeoJSON: (layer: LayerState | null) => GeoJSON.FeatureCollection | null;
-let _renderLayerSelectOptions: (
-  select: HTMLSelectElement,
-  selectedId: string | null,
-  placeholderText: string
-) => string | null;
 let _getParcelId: (feature: GeoJSON.Feature) => string;
 
 export function initStatisticsCallbacks(cbs: {
   getStatsLayer: () => LayerState | null;
   getLayerDataStore: (layer: LayerState | null) => DataStore | null;
   getLayerGeoJSON: (layer: LayerState | null) => GeoJSON.FeatureCollection | null;
-  renderLayerSelectOptions: (
-    select: HTMLSelectElement,
-    selectedId: string | null,
-    placeholderText: string
-  ) => string | null;
   getParcelId: (feature: GeoJSON.Feature) => string;
 }) {
   _getStatsLayer = cbs.getStatsLayer;
   _getLayerDataStore = cbs.getLayerDataStore;
   _getLayerGeoJSON = cbs.getLayerGeoJSON;
-  _renderLayerSelectOptions = cbs.renderLayerSelectOptions;
   _getParcelId = cbs.getParcelId;
 }
 
@@ -405,7 +365,7 @@ export function getStatsFieldType(field: string | null, numericFields: string[],
 export function populateStatisticsFields() {
   const layer = _getStatsLayer();
   const dataStore = _getLayerDataStore(layer);
-  const useDataSource = S.statsSubjectMode === 'category' || S.statsSubjectMode === 'filtered';
+  const useDataSource = S.statsSubjectMode === 'category';
   const sourceGeoJSON = useDataSource ? dataStore?.geojson ?? null : _getLayerGeoJSON(layer);
   const numericFields = useDataSource ? dataStore?.chosenNumericFields ?? [] : layer?.chosenNumericFields ?? [];
   const categoricalFields = useDataSource ? dataStore?.chosenCategoricalFields ?? [] : layer?.chosenCategoricalFields ?? [];
@@ -597,7 +557,7 @@ export function getStatsSourceContext() {
 
 export function getStatsNormalizationContext() {
   const { layer, dataStore } = getStatsSourceContext();
-  const useDataSource = S.statsSubjectMode === 'category' || S.statsSubjectMode === 'filtered';
+  const useDataSource = S.statsSubjectMode === 'category';
   return {
     landField: useDataSource ? dataStore?.landSizeField ?? null : layer?.landSizeField ?? null,
     landUnit: useDataSource ? dataStore?.landSizeUnitLabel ?? null : layer?.landSizeUnitLabel ?? null,
@@ -627,8 +587,7 @@ export function getStatsSubjectSelection(
   mode: SubjectMode,
   categoryField: string | null,
   categoryValueIndices: string[],
-  categoryValueMap: Array<{ label: string; value: unknown }>,
-  filteredName: string | null
+  categoryValueMap: Array<{ label: string; value: unknown }>
 ): GeoJSON.Feature[] {
   const { layer, layerGeoJSON, dataGeoJSON } = getStatsSourceContext();
   if (!layer) return [];
@@ -660,20 +619,12 @@ export function getStatsSubjectSelection(
       return selectedValues.has(value);
     });
   }
-  if (mode === 'filtered') {
-    if (!dataGeoJSON || !filteredName) return [];
-    const entry = S.savedFiltersStore.get(filteredName);
-    if (!entry) return [];
-    const filterExpr = buildSavedFilterExpression(entry);
-    if (!filterExpr) return [];
-    return dataGeoJSON.features.filter(feature => evaluateFilterExpression(filterExpr, feature));
-  }
   return layerGeoJSON?.features ?? [];
 }
 
 export function updateStatisticsResults() {
   const { layer, layerGeoJSON, dataGeoJSON, dataStore } = getStatsSourceContext();
-  const useDataSource = S.statsSubjectMode === 'category' || S.statsSubjectMode === 'filtered';
+  const useDataSource = S.statsSubjectMode === 'category';
   const sourceGeoJSON = useDataSource ? dataGeoJSON : layerGeoJSON;
   const numericFields = useDataSource ? dataStore?.chosenNumericFields ?? [] : layer?.chosenNumericFields ?? [];
   const categoricalFields = useDataSource ? dataStore?.chosenCategoricalFields ?? [] : layer?.chosenCategoricalFields ?? [];
@@ -690,11 +641,6 @@ export function updateStatisticsResults() {
     resetStatisticsDisplay();
     return;
   }
-  if (S.statsSubjectMode === 'filtered' && !S.statsFilteredName) {
-    S.statsValuesCache = [];
-    resetStatisticsDisplay();
-    return;
-  }
   S.statsFieldType = getStatsFieldType(S.statsField, numericFields, categoricalFields);
   if (!S.statsFieldType) {
     S.statsValuesCache = [];
@@ -706,8 +652,7 @@ export function updateStatisticsResults() {
     S.statsSubjectMode,
     S.statsCategoryField,
     S.statsCategoryValueIndices,
-    S.statsCategoryValueMap,
-    S.statsFilteredName
+    S.statsCategoryValueMap
   );
 
   const totalCount = sourceGeoJSON.features.length;
@@ -824,7 +769,6 @@ export function updateStatisticsSubjectControls() {
   if (!hasLayerData) {
     statsSubjectControls.buttons.forEach(button => { button.disabled = true; });
     statsSubjectControls.categoryControls.style.display = 'none';
-    statsSubjectControls.filterControls.style.display = 'none';
     statsCategoryFieldSelect.disabled = true;
     statsCategoryValueSelect.disabled = true;
     return;
@@ -843,7 +787,8 @@ function updateStatisticsSubjectButtons() {
 }
 
 export function setStatsSubjectMode(mode: SubjectMode) {
-  S.statsSubjectMode = mode;
+  const allowedModes: SubjectMode[] = ['all', 'visible', 'selected'];
+  S.statsSubjectMode = allowedModes.includes(mode) ? mode : 'all';
   updateStatisticsSubjectButtons();
   updateStatisticsSubjectControls();
   updateStatisticsSectionVisibility();
@@ -851,14 +796,7 @@ export function setStatsSubjectMode(mode: SubjectMode) {
 }
 
 export function updateStatisticsSectionVisibility() {
-  const shouldShow = S.statsSubjectMode !== 'category' || S.statsCategoryValueIndices.length > 0;
-  statisticsSection.style.display = shouldShow ? 'grid' : 'none';
-  if (!shouldShow) {
-    statsDetails.style.display = 'none';
-    statsNumericBlock.style.display = 'none';
-    statsCategoricalBlock.style.display = 'none';
-    return;
-  }
+  statisticsSection.style.display = 'grid';
   populateStatisticsFields();
   const hasField = Boolean(S.statsField);
   statsDetails.style.display = hasField ? 'grid' : 'none';
@@ -869,10 +807,8 @@ export function updateStatisticsSectionVisibility() {
     return;
   }
   const layer = _getStatsLayer();
-  const dataStore = _getLayerDataStore(layer);
-  const useDataSource = S.statsSubjectMode === 'category' || S.statsSubjectMode === 'filtered';
-  const numericFields = useDataSource ? dataStore?.chosenNumericFields ?? [] : layer?.chosenNumericFields ?? [];
-  const categoricalFields = useDataSource ? dataStore?.chosenCategoricalFields ?? [] : layer?.chosenCategoricalFields ?? [];
+  const numericFields = layer?.chosenNumericFields ?? [];
+  const categoricalFields = layer?.chosenCategoricalFields ?? [];
   S.statsFieldType = getStatsFieldType(S.statsField, numericFields, categoricalFields);
   if (!S.statsFieldType) {
     statsNumericBlock.style.display = 'none';
@@ -891,7 +827,10 @@ export function refreshStatisticsPanel() {
   populateStatisticsCategoryFields();
   populateStatisticsCategoryValues(S.statsCategoryField);
 
-  S.statsFilteredName = renderSubjectFilterOptions(statsSubjectControls, S.statsFilteredName);
+  const allowedModes: SubjectMode[] = ['all', 'visible', 'selected'];
+  if (!allowedModes.includes(S.statsSubjectMode)) {
+    S.statsSubjectMode = 'all';
+  }
   updateStatisticsSubjectButtons();
   updateStatisticsSubjectControls();
   updateStatisticsSectionVisibility();
@@ -903,7 +842,26 @@ export function refreshStatisticsPanel() {
   }
 }
 
+function resolveStatsLayerId(): string | null {
+  if (S.statsLayerId && S.layers.has(S.statsLayerId)) {
+    return S.statsLayerId;
+  }
+  return S.currentLayerId ?? S.layerOrder[0] ?? null;
+}
+
+function getStatsLayerLabel(layerId: string | null): string {
+  if (!layerId) return 'Select a layer to view statistics.';
+  const layer = S.layers.get(layerId);
+  if (!layer) return 'Select a layer to view statistics.';
+  const index = S.layerOrder.indexOf(layerId);
+  const baseName = layer.field ?? `layer ${index + 1}`;
+  const store = S.dataStores.get(layer.dataStoreId);
+  const sourceLabel = store?.file?.name ?? store?.name ?? 'Unknown source';
+  return `${baseName} (${sourceLabel})`;
+}
+
 export function renderStatsLayerOptions() {
-  if (!statsLayerSelect) return;
-  S.statsLayerId = _renderLayerSelectOptions(statsLayerSelect, S.statsLayerId, 'Choose a layer');
+  if (!statsLayerName) return;
+  S.statsLayerId = resolveStatsLayerId();
+  statsLayerName.textContent = getStatsLayerLabel(S.statsLayerId);
 }

--- a/viz/src/toolbar.ts
+++ b/viz/src/toolbar.ts
@@ -11,22 +11,16 @@ import { updatePaintButtonState } from './windows';
 let _showLayers: () => void = () => {};
 let _minimizeLayers: () => void = () => {};
 let _toggleSettingsMenu: () => void = () => {};
-let _toggleFilters: () => void = () => {};
 let _showLegend: () => void = () => {};
 let _minimizeLegend: () => void = () => {};
-let _toggleStatistics: () => void = () => {};
-let _toggleScatterplot: () => void = () => {};
 let _toggleLandSchedule: () => void = () => {};
 
 export interface ToolbarCallbacks {
   showLayers: () => void;
   minimizeLayers: () => void;
   toggleSettingsMenu: () => void;
-  toggleFilters: () => void;
   showLegend: () => void;
   minimizeLegend: () => void;
-  toggleStatistics: () => void;
-  toggleScatterplot: () => void;
   toggleLandSchedule: () => void;
 }
 
@@ -34,11 +28,8 @@ export function initToolbarCallbacks(cb: ToolbarCallbacks) {
   _showLayers = cb.showLayers;
   _minimizeLayers = cb.minimizeLayers;
   _toggleSettingsMenu = cb.toggleSettingsMenu;
-  _toggleFilters = cb.toggleFilters;
   _showLegend = cb.showLegend;
   _minimizeLegend = cb.minimizeLegend;
-  _toggleStatistics = cb.toggleStatistics;
-  _toggleScatterplot = cb.toggleScatterplot;
   _toggleLandSchedule = cb.toggleLandSchedule;
 }
 
@@ -52,9 +43,6 @@ const panToolButton = document.getElementById('panToolButton') as HTMLButtonElem
 const selectSubmenu = document.getElementById('selectSubmenu') as HTMLDivElement;
 const submenuButtons = document.querySelectorAll('.submenu-button') as NodeListOf<HTMLButtonElement>;
 const legendToolButton = document.getElementById('legendToolButton') as HTMLButtonElement;
-const statisticsToolButton = document.getElementById('statisticsToolButton') as HTMLButtonElement;
-const scatterplotToolButton = document.getElementById('scatterplotToolButton') as HTMLButtonElement;
-const filtersToolButton = document.getElementById('filtersToolButton') as HTMLButtonElement;
 const landScheduleToolButton = document.getElementById('landScheduleToolButton') as HTMLButtonElement;
 const btnPaintMenu = document.getElementById('btnPaintMenu') as HTMLButtonElement;
 
@@ -284,30 +272,6 @@ export function updateToolbarButtonStates() {
     legendToolButton.classList.add('active');
   }
 
-  if (S.isStatisticsMinimized) {
-    statisticsToolButton.classList.add('inactive');
-    statisticsToolButton.classList.remove('active');
-  } else {
-    statisticsToolButton.classList.remove('inactive');
-    statisticsToolButton.classList.add('active');
-  }
-
-  if (S.isScatterplotMinimized) {
-    scatterplotToolButton.classList.add('inactive');
-    scatterplotToolButton.classList.remove('active');
-  } else {
-    scatterplotToolButton.classList.remove('inactive');
-    scatterplotToolButton.classList.add('active');
-  }
-
-  if (S.isFiltersMinimized) {
-    filtersToolButton.classList.add('inactive');
-    filtersToolButton.classList.remove('active');
-  } else {
-    filtersToolButton.classList.remove('inactive');
-    filtersToolButton.classList.add('active');
-  }
-
   if (S.isLandScheduleMinimized) {
     landScheduleToolButton.classList.add('inactive');
     landScheduleToolButton.classList.remove('active');
@@ -397,12 +361,6 @@ export function initializeToolbar() {
     _toggleSettingsMenu();
   });
 
-  filtersToolButton.addEventListener('click', (e) => {
-    e.stopPropagation();
-    closeAllSubmenus();
-    _toggleFilters();
-  });
-
   // Handle pan button click
   panToolButton.addEventListener('click', (e) => {
     e.stopPropagation();
@@ -440,18 +398,6 @@ export function initializeToolbar() {
     } else {
       _minimizeLegend();
     }
-  });
-
-  statisticsToolButton.addEventListener('click', (e) => {
-    e.stopPropagation();
-    closeAllSubmenus();
-    _toggleStatistics();
-  });
-
-  scatterplotToolButton.addEventListener('click', (e) => {
-    e.stopPropagation();
-    closeAllSubmenus();
-    _toggleScatterplot();
   });
 
   landScheduleToolButton.addEventListener('click', (e) => {

--- a/viz/src/types.ts
+++ b/viz/src/types.ts
@@ -36,7 +36,7 @@ export type CategoricalColorMode = 'random' | 'single' | 'colorRamp';
 export type QualityMode = 'fast' | 'high';
 export type UpdateMode = 'applyOnly' | 'recomputeAndAutoScale';
 export type MetricUnitKey = 'centimeters' | 'meters' | 'kilometers';
-export type SubjectMode = 'all' | 'visible' | 'selected' | 'category' | 'filtered';
+export type SubjectMode = 'all' | 'visible' | 'selected' | 'category';
 export type LandSchedulePerUnit = 'lot' | 'area' | 'frontage';
 
 export type LandScheduleBaseLot = {
@@ -109,9 +109,6 @@ export type SubjectSelectorControls = {
   categoryControls: HTMLDivElement;
   categoryFieldSelect: HTMLSelectElement;
   categoryValueSelect: HTMLSelectElement;
-  filterControls: HTMLDivElement;
-  filterSelect: HTMLSelectElement;
-  filterEmptyState: HTMLDivElement;
 };
 
 export type SubjectSelectorOptions = {


### PR DESCRIPTION
### Motivation

- Make layer-focused workflows easier by surfacing Filters / Statistics / Scatterplot actions directly on each layer and reduce duplication in the vertical toolbar.
- Simplify subject/filter UX by removing the special "filtered" subject mode and auto-applying visibility rules when filters exist.

### Description

- Added per-layer action buttons for Filters, Statistics, and Scatterplot in the layer list and wired them to focus the clicked layer and open the corresponding panel (changes in `viz/src/layers.ts` and `viz/index.html`).
- Removed toolbar buttons and callbacks for Filters / Statistics / Scatterplot and adjusted `viz/src/toolbar.ts` and `viz/src/main.ts` to use the new layer-driven panel show callbacks.
- Replaced the statistics and scatterplot layer `<select>` controls with read-only layer labels and made the panels resolve a sensible default layer (changes in `viz/src/statistics.ts`, `viz/src/scatterplot.ts`, and `viz/index.html`).
- Simplified filtering behavior by removing filter action mode UI and the saved-filter-driven subject controls; filters now auto-apply in "show" mode when active filters exist and the codebase drops the `filtered` SubjectMode variant (changes in `viz/src/filters.ts`, `viz/src/types.ts`, and related call sites across `viz/src/*`).

### Testing

- Started a local static server from `viz/` and verified `index.html` was served (HTTP 200 response). 
- Attempted an automated UI smoke check with Playwright to capture a screenshot of the layer controls, but the Playwright run timed out and failed. 
- No unit tests or build steps were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69815d37a3d8832683fa4017b4e09fce)