### PR TITLE
Add resizable, pinnable (docked) menus to VIZ panels

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -24,6 +24,16 @@
       pointer-events: auto;
     }
 
+    #pinnedResizeHandle {
+      position: absolute;
+      left: calc(64px + var(--pinned-width) - 4px);
+      top: 0;
+      bottom: 0;
+      width: 8px;
+      cursor: ew-resize;
+      z-index: 13;
+    }
+
     .pinned-column {
       display: flex;
       flex-direction: column;
@@ -49,6 +59,14 @@
       right: auto !important;
       transform: none !important;
       margin: 0;
+    }
+
+    .viz-window.is-pinned .window-resize-edge {
+      display: none;
+    }
+
+    .viz-window.is-pinned .window-resize-handle {
+      cursor: ns-resize;
     }
 
     .window-actions {
@@ -855,6 +873,7 @@
     <div id="app">
       <div id="map"></div>
       <div id="pinnedPanels"></div>
+      <div id="pinnedResizeHandle" aria-hidden="true"></div>
       
       <!-- Vertical Toolbar -->
       <div id="verticalToolbar">

--- a/viz/index.html
+++ b/viz/index.html
@@ -6,11 +6,94 @@
   <title>geovizwiz</title>
   <link rel="icon" href="data:,">
   <style>
-    :root { --panel:#fff; --shadow:0 6px 24px rgba(0,0,0,.12); --gap:10px; }
+    :root { --panel:#fff; --shadow:0 6px 24px rgba(0,0,0,.12); --gap:10px; --pinned-width: 0px; }
     *, *::before, *::after { box-sizing: border-box; }
 
     html, body, #app { height: 100%; margin: 0; font-family: system-ui, sans-serif; }
-    #map { position: absolute; left: 64px; top: 0; right: 0; bottom: 0; }
+    #map { position: absolute; left: calc(64px + var(--pinned-width)); top: 0; right: 0; bottom: 0; }
+
+    #pinnedPanels {
+      position: absolute;
+      left: 64px;
+      top: 0;
+      bottom: 0;
+      display: flex;
+      gap: 8px;
+      padding: 10px 8px;
+      z-index: 12;
+      pointer-events: auto;
+    }
+
+    .pinned-column {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      height: 100%;
+    }
+
+    .viz-window {
+      min-width: 240px;
+      min-height: 160px;
+    }
+
+    .viz-window.is-pinned {
+      position: relative !important;
+      left: auto !important;
+      top: auto !important;
+      right: auto !important;
+      transform: none !important;
+      margin: 0;
+    }
+
+    .window-actions {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .window-pin {
+      border: none;
+      background: none;
+      cursor: pointer;
+      font-size: 14px;
+      color: #666;
+      padding: 2px;
+      width: 20px;
+      height: 20px;
+      border-radius: 3px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .window-pin img {
+      width: 14px;
+      height: 14px;
+      display: block;
+    }
+
+    .window-resize-handle {
+      position: absolute;
+      right: 6px;
+      bottom: 6px;
+      width: 14px;
+      height: 14px;
+      cursor: nwse-resize;
+      opacity: 0.6;
+      background:
+        linear-gradient(135deg, transparent 50%, rgba(0,0,0,0.15) 50%) bottom right / 6px 6px no-repeat,
+        linear-gradient(135deg, transparent 50%, rgba(0,0,0,0.2) 50%) center / 6px 6px no-repeat,
+        linear-gradient(135deg, transparent 50%, rgba(0,0,0,0.25) 50%) top left / 6px 6px no-repeat;
+    }
+
+    .window-resize-edge {
+      position: absolute;
+      right: 0;
+      top: 34px;
+      bottom: 6px;
+      width: 6px;
+      cursor: ew-resize;
+    }
 
     .window-header:hover {
       background: rgba(240, 240, 240, 0.9);
@@ -765,6 +848,7 @@
   <body>
     <div id="app">
       <div id="map"></div>
+      <div id="pinnedPanels"></div>
       
       <!-- Vertical Toolbar -->
       <div id="verticalToolbar">
@@ -831,14 +915,19 @@
       </div>
 
 
-      <div id="controls" style="position: absolute; top: 10px; left: 80px; width: min(calc(92vw - 80px), 420px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: grid; gap: var(--gap); z-index: 10; cursor: move;">
+      <div id="controls" class="viz-window" style="position: absolute; top: 10px; left: 80px; width: min(calc(92vw - 80px), 420px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: grid; gap: var(--gap); z-index: 10; cursor: move;">
       <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
         <div style="font-weight: 600; font-size: 13px;">Layers</div>
-        <button id="btnMinimizeLayers" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-			<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-				<path d="M7 10l5 5 5-5z"/>
-			</svg>
-		</button>
+        <div class="window-actions">
+          <button id="btnPinLayers" class="window-pin" type="button" title="Pin" aria-pressed="false">
+            <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+          </button>
+          <button id="btnMinimizeLayers" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+			  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+				  <path d="M7 10l5 5 5-5z"/>
+			  </svg>
+		  </button>
+        </div>
       </div>
       <div id="settingsContent" style="padding: 12px;">
       <fieldset id="layerPanel">
@@ -860,17 +949,24 @@
 
       <fieldset id="legend">      </fieldset>
       </div>
+      <div class="window-resize-edge" aria-hidden="true"></div>
+      <div class="window-resize-handle" aria-hidden="true"></div>
     </div>
   </div>
 
-  <div id="settingsControls" style="position: absolute; top: 10px; left: 520px; width: min(calc(92vw - 80px), 320px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: grid; gap: var(--gap); z-index: 10; cursor: move;">
+  <div id="settingsControls" class="viz-window" style="position: absolute; top: 10px; left: 520px; width: min(calc(92vw - 80px), 320px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: grid; gap: var(--gap); z-index: 10; cursor: move;">
     <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
       <div style="font-weight: 600; font-size: 13px;">Settings</div>
-      <button id="btnMinimizeSettingsMenu" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M7 10l5 5 5-5z"/>
-        </svg>
-      </button>
+      <div class="window-actions">
+        <button id="btnPinSettings" class="window-pin" type="button" title="Pin" aria-pressed="false">
+          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+        </button>
+        <button id="btnMinimizeSettingsMenu" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M7 10l5 5 5-5z"/>
+          </svg>
+        </button>
+      </div>
     </div>
     <div id="settingsMenuContent" style="padding: 12px; display: grid; gap: 10px;">
       <fieldset>
@@ -906,16 +1002,23 @@
         </div>
       </fieldset>
     </div>
+    <div class="window-resize-edge" aria-hidden="true"></div>
+    <div class="window-resize-handle" aria-hidden="true"></div>
   </div>
 
-  <div id="filtersControls" style="position: absolute; top: 10px; left: 860px; width: min(calc(92vw - 80px), 360px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
+  <div id="filtersControls" class="viz-window" style="position: absolute; top: 10px; left: 860px; width: min(calc(92vw - 80px), 360px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
     <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
       <div style="font-weight: 600; font-size: 13px;">Filters</div>
-      <button id="btnMinimizeFilters" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M7 10l5 5 5-5z"/>
-        </svg>
-      </button>
+      <div class="window-actions">
+        <button id="btnPinFilters" class="window-pin" type="button" title="Pin" aria-pressed="false">
+          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+        </button>
+        <button id="btnMinimizeFilters" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M7 10l5 5 5-5z"/>
+          </svg>
+        </button>
+      </div>
     </div>
     <div id="filtersContent" style="padding: 12px; display: grid; gap: 12px;">
       <div class="filters-saved-container">
@@ -950,16 +1053,23 @@
       <div id="filtersList" class="filters-list"></div>
       <button id="addFilterButton" type="button">Add condition</button>
     </div>
+    <div class="window-resize-edge" aria-hidden="true"></div>
+    <div class="window-resize-handle" aria-hidden="true"></div>
   </div>
 
-  <div id="paintControls" style="position: absolute; top: 10px; left: 80px; width: min(calc(92vw - 80px), 360px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: grid; gap: var(--gap); z-index: 10; cursor: move;">
+  <div id="paintControls" class="viz-window" style="position: absolute; top: 10px; left: 80px; width: min(calc(92vw - 80px), 360px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: grid; gap: var(--gap); z-index: 10; cursor: move;">
     <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
       <div style="font-weight: 600; font-size: 13px;">Paint</div>
-      <button id="btnMinimizePaint" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M7 10l5 5 5-5z"/>
-        </svg>
-      </button>
+      <div class="window-actions">
+        <button id="btnPinPaint" class="window-pin" type="button" title="Pin" aria-pressed="false">
+          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+        </button>
+        <button id="btnMinimizePaint" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M7 10l5 5 5-5z"/>
+          </svg>
+        </button>
+      </div>
     </div>
     <div id="paintContent" style="padding: 12px; display: grid; gap: 10px;">
       <!-- Numeric field options -->
@@ -1083,16 +1193,23 @@
         </div>
       </fieldset>
     </div>
+    <div class="window-resize-edge" aria-hidden="true"></div>
+    <div class="window-resize-handle" aria-hidden="true"></div>
   </div>
 
-  <div id="statisticsControls" style="position: absolute; top: 10px; left: 900px; background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
+  <div id="statisticsControls" class="viz-window" style="position: absolute; top: 10px; left: 900px; background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
     <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
       <div style="font-weight: 600; font-size: 13px;">Statistics</div>
-      <button id="btnMinimizeStatistics" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M7 10l5 5 5-5z"/>
-        </svg>
-      </button>
+      <div class="window-actions">
+        <button id="btnPinStatistics" class="window-pin" type="button" title="Pin" aria-pressed="false">
+          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+        </button>
+        <button id="btnMinimizeStatistics" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M7 10l5 5 5-5z"/>
+          </svg>
+        </button>
+      </div>
     </div>
     <div id="statisticsContent" style="padding: 12px; display: grid; gap: 12px;">
       <div id="statsLayerSection" class="stats-section" style="display: grid; gap: 8px;">
@@ -1195,16 +1312,23 @@
         </div>
       </div>
     </div>
+    <div class="window-resize-edge" aria-hidden="true"></div>
+    <div class="window-resize-handle" aria-hidden="true"></div>
   </div>
 
-  <div id="scatterplotControls" style="position: absolute; top: 10px; left: 900px; width: min(calc(92vw - 80px), 520px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
+  <div id="scatterplotControls" class="viz-window" style="position: absolute; top: 10px; left: 900px; width: min(calc(92vw - 80px), 520px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
     <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
       <div style="font-weight: 600; font-size: 13px;">Scatterplot</div>
-      <button id="btnMinimizeScatterplot" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M7 10l5 5 5-5z"/>
-        </svg>
-      </button>
+      <div class="window-actions">
+        <button id="btnPinScatterplot" class="window-pin" type="button" title="Pin" aria-pressed="false">
+          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+        </button>
+        <button id="btnMinimizeScatterplot" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M7 10l5 5 5-5z"/>
+          </svg>
+        </button>
+      </div>
     </div>
     <div id="scatterplotContent" style="padding: 12px; display: grid; gap: 12px;">
       <div style="display: grid; gap: 12px;">
@@ -1275,16 +1399,23 @@
         <div id="scatterPlot" style="height: 220px; width: 100%;"></div>
       </div>
     </div>
+    <div class="window-resize-edge" aria-hidden="true"></div>
+    <div class="window-resize-handle" aria-hidden="true"></div>
   </div>
 
-  <div id="landScheduleControls" style="position: absolute; top: 10px; left: 1220px; width: min(calc(92vw - 80px), 360px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
+  <div id="landScheduleControls" class="viz-window" style="position: absolute; top: 10px; left: 1220px; width: min(calc(92vw - 80px), 360px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
     <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
       <div style="font-weight: 600; font-size: 13px;">Land Schedule</div>
-      <button id="btnMinimizeLandSchedule" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M7 10l5 5 5-5z"/>
-        </svg>
-      </button>
+      <div class="window-actions">
+        <button id="btnPinLandSchedule" class="window-pin" type="button" title="Pin" aria-pressed="false">
+          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+        </button>
+        <button id="btnMinimizeLandSchedule" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M7 10l5 5 5-5z"/>
+          </svg>
+        </button>
+      </div>
     </div>
     <div id="landScheduleContent" style="padding: 12px; display: grid; gap: 12px;">
       <div class="land-schedule-section">
@@ -1339,6 +1470,8 @@
         </div>
       </div>
     </div>
+    <div class="window-resize-edge" aria-hidden="true"></div>
+    <div class="window-resize-handle" aria-hidden="true"></div>
   </div>
 
   <!-- Modal 1: Numeric field chooser -->
@@ -1442,7 +1575,7 @@
   <script src="https://cdn.plot.ly/plotly-2.30.0.min.js"></script>
 
   <!-- Floating Legend -->
-  <div id="floatingLegend" style="
+  <div id="floatingLegend" class="viz-window" style="
     position: absolute;
     top: 140px;
     right: 20px;
@@ -1469,30 +1602,37 @@
       cursor: move;
     ">
       <div style="font-weight: 600; font-size: 13px;" id="legendTitle">Legend</div>
-      <button id="btnMinimizeLegend" style="
-        border: none;
-        background: none;
-        cursor: pointer;
-        font-size: 14px;
-        color: #666;
-        padding: 2px;
-        width: 20px;
-        height: 20px;
-        border-radius: 3px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      " title="Minimize">
-			<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-				<path d="M7 10l5 5 5-5z"/>
-			</svg>
-	  </button>
+      <div class="window-actions">
+        <button id="btnPinLegend" class="window-pin" type="button" title="Pin" aria-pressed="false">
+          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+        </button>
+        <button id="btnMinimizeLegend" style="
+          border: none;
+          background: none;
+          cursor: pointer;
+          font-size: 14px;
+          color: #666;
+          padding: 2px;
+          width: 20px;
+          height: 20px;
+          border-radius: 3px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        " title="Minimize">
+			  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+				  <path d="M7 10l5 5 5-5z"/>
+			  </svg>
+	    </button>
+      </div>
     </div>
     <div id="legendContent" style="
       padding: 8px;
       max-height: calc(70vh - 40px);
       overflow-y: auto;
     "></div>
+    <div class="window-resize-edge" aria-hidden="true"></div>
+    <div class="window-resize-handle" aria-hidden="true"></div>
   </div>
 
 

--- a/viz/index.html
+++ b/viz/index.html
@@ -24,21 +24,22 @@
       pointer-events: auto;
     }
 
-    #pinnedResizeHandle {
-      position: absolute;
-      left: calc(64px + var(--pinned-width) - 4px);
-      top: 0;
-      bottom: 0;
-      width: 8px;
-      cursor: ew-resize;
-      z-index: 13;
-    }
-
     .pinned-column {
       display: flex;
       flex-direction: column;
       gap: 8px;
       height: 100%;
+      position: relative;
+    }
+
+    .pinned-column-resize-handle {
+      position: absolute;
+      right: -4px;
+      top: 0;
+      bottom: 0;
+      width: 8px;
+      cursor: ew-resize;
+      z-index: 2;
     }
 
     .viz-window {
@@ -873,7 +874,6 @@
     <div id="app">
       <div id="map"></div>
       <div id="pinnedPanels"></div>
-      <div id="pinnedResizeHandle" aria-hidden="true"></div>
       
       <!-- Vertical Toolbar -->
       <div id="verticalToolbar">

--- a/viz/index.html
+++ b/viz/index.html
@@ -34,6 +34,12 @@
     .viz-window {
       min-width: 240px;
       min-height: 160px;
+      grid-template-rows: auto 1fr;
+      align-content: start;
+    }
+
+    .window-header {
+      align-self: start;
     }
 
     .viz-window.is-pinned {
@@ -920,7 +926,7 @@
         <div style="font-weight: 600; font-size: 13px;">Layers</div>
         <div class="window-actions">
           <button id="btnPinLayers" class="window-pin" type="button" title="Pin" aria-pressed="false">
-            <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+            <img alt="Pin menu" />
           </button>
           <button id="btnMinimizeLayers" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
 			  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -929,7 +935,7 @@
 		  </button>
         </div>
       </div>
-      <div id="settingsContent" style="padding: 12px;">
+      <div id="settingsContent" data-window-content style="padding: 12px;">
       <fieldset id="layerPanel">
         <div class="layer-add-row">
           <button id="addLayerFromStore" type="button">Add layer</button>
@@ -959,7 +965,7 @@
       <div style="font-weight: 600; font-size: 13px;">Settings</div>
       <div class="window-actions">
         <button id="btnPinSettings" class="window-pin" type="button" title="Pin" aria-pressed="false">
-          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+          <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeSettingsMenu" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -968,7 +974,7 @@
         </button>
       </div>
     </div>
-    <div id="settingsMenuContent" style="padding: 12px; display: grid; gap: 10px;">
+    <div id="settingsMenuContent" data-window-content style="padding: 12px; display: grid; gap: 10px;">
       <fieldset>
         <label>View presets</label>
         <div class="buttons">
@@ -1011,7 +1017,7 @@
       <div style="font-weight: 600; font-size: 13px;">Filters</div>
       <div class="window-actions">
         <button id="btnPinFilters" class="window-pin" type="button" title="Pin" aria-pressed="false">
-          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+          <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeFilters" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -1020,7 +1026,7 @@
         </button>
       </div>
     </div>
-    <div id="filtersContent" style="padding: 12px; display: grid; gap: 12px;">
+    <div id="filtersContent" data-window-content style="padding: 12px; display: grid; gap: 12px;">
       <div class="filters-saved-container">
         <div class="filters-saved-tabs" role="tablist" aria-label="Saved filters">
           <button id="filtersSaveToggle" class="filters-saved-tab" type="button" role="tab" aria-controls="filtersSavePanel" aria-selected="false">Save</button>
@@ -1062,7 +1068,7 @@
       <div style="font-weight: 600; font-size: 13px;">Paint</div>
       <div class="window-actions">
         <button id="btnPinPaint" class="window-pin" type="button" title="Pin" aria-pressed="false">
-          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+          <img alt="Pin menu" />
         </button>
         <button id="btnMinimizePaint" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -1071,7 +1077,7 @@
         </button>
       </div>
     </div>
-    <div id="paintContent" style="padding: 12px; display: grid; gap: 10px;">
+    <div id="paintContent" data-window-content style="padding: 12px; display: grid; gap: 10px;">
       <!-- Numeric field options -->
       <fieldset id="numericOptions">
         <label>Field type: numeric</label>
@@ -1202,7 +1208,7 @@
       <div style="font-weight: 600; font-size: 13px;">Statistics</div>
       <div class="window-actions">
         <button id="btnPinStatistics" class="window-pin" type="button" title="Pin" aria-pressed="false">
-          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+          <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeStatistics" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -1211,7 +1217,7 @@
         </button>
       </div>
     </div>
-    <div id="statisticsContent" style="padding: 12px; display: grid; gap: 12px;">
+    <div id="statisticsContent" data-window-content style="padding: 12px; display: grid; gap: 12px;">
       <div id="statsLayerSection" class="stats-section" style="display: grid; gap: 8px;">
         <div style="font-weight: 600; font-size: 12px;">Layer:</div>
         <div id="statsLayerName" class="layer-source-name">Select a layer to view statistics.</div>
@@ -1321,7 +1327,7 @@
       <div style="font-weight: 600; font-size: 13px;">Scatterplot</div>
       <div class="window-actions">
         <button id="btnPinScatterplot" class="window-pin" type="button" title="Pin" aria-pressed="false">
-          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+          <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeScatterplot" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -1330,7 +1336,7 @@
         </button>
       </div>
     </div>
-    <div id="scatterplotContent" style="padding: 12px; display: grid; gap: 12px;">
+    <div id="scatterplotContent" data-window-content style="padding: 12px; display: grid; gap: 12px;">
       <div style="display: grid; gap: 12px;">
         <div id="scatterDataSourceSection" class="stats-section" style="display: grid; gap: 8px;">
           <div style="font-weight: 600; font-size: 12px;">Layer:</div>
@@ -1408,7 +1414,7 @@
       <div style="font-weight: 600; font-size: 13px;">Land Schedule</div>
       <div class="window-actions">
         <button id="btnPinLandSchedule" class="window-pin" type="button" title="Pin" aria-pressed="false">
-          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+          <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeLandSchedule" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -1417,7 +1423,7 @@
         </button>
       </div>
     </div>
-    <div id="landScheduleContent" style="padding: 12px; display: grid; gap: 12px;">
+    <div id="landScheduleContent" data-window-content style="padding: 12px; display: grid; gap: 12px;">
       <div class="land-schedule-section">
         <div class="land-schedule-subtitle">Market Area field:</div>
         <div class="land-schedule-row">
@@ -1604,7 +1610,7 @@
       <div style="font-weight: 600; font-size: 13px;" id="legendTitle">Legend</div>
       <div class="window-actions">
         <button id="btnPinLegend" class="window-pin" type="button" title="Pin" aria-pressed="false">
-          <img src="./src/svg/thumbtack-tilted.svg" alt="Pin menu" />
+          <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeLegend" style="
           border: none;
@@ -1626,7 +1632,7 @@
 	    </button>
       </div>
     </div>
-    <div id="legendContent" style="
+    <div id="legendContent" data-window-content style="
       padding: 8px;
       max-height: calc(70vh - 40px);
       overflow-y: auto;

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -634,6 +634,7 @@ initPositionElements({
 });
 initWindowDocking({
   pinnedContainer: pinnedPanelsEl,
+  pinnedResizeHandle: document.getElementById('pinnedResizeHandle') as HTMLDivElement,
   appContainer: appEl,
 });
 [

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -420,6 +420,8 @@ const landScheduleBasePer = document.getElementById('landScheduleBasePer') as HT
 const EYE_ICON_OPEN = new URL('./svg/eye.svg', import.meta.url).href;
 const EYE_ICON_CLOSED = new URL('./svg/eye_closed.svg', import.meta.url).href;
 const PENCIL_ICON = new URL('./svg/pencil.svg', import.meta.url).href;
+const PIN_ICON = new URL('./svg/thumbtack.svg', import.meta.url).href;
+const PIN_ICON_TILTED = new URL('./svg/thumbtack-tilted.svg', import.meta.url).href;
 
 function setEyeButtonIcon(button: HTMLButtonElement, isHidden: boolean) {
   const img = button.querySelector('img');
@@ -438,6 +440,14 @@ function createEyeButton(isHidden: boolean, title: string) {
   img.alt = isHidden ? 'Hidden' : 'Visible';
   button.appendChild(img);
   return button;
+}
+
+function initPinButton(button: HTMLButtonElement) {
+  const img = button.querySelector('img');
+  if (!img) return;
+  button.dataset.pinSrc = PIN_ICON;
+  button.dataset.unpinSrc = PIN_ICON_TILTED;
+  img.src = PIN_ICON_TILTED;
 }
 
 // Quality button (create after elements are declared)
@@ -626,6 +636,16 @@ initWindowDocking({
   pinnedContainer: pinnedPanelsEl,
   appContainer: appEl,
 });
+[
+  btnPinLayers,
+  btnPinSettings,
+  btnPinPaint,
+  btnPinFilters,
+  btnPinStatistics,
+  btnPinScatterplot,
+  btnPinLandSchedule,
+  btnPinLegend,
+].forEach(initPinButton);
 registerDockableWindow(controlsEl, btnPinLayers);
 registerDockableWindow(settingsControlsEl, btnPinSettings);
 registerDockableWindow(paintControlsEl, btnPinPaint);

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -634,7 +634,6 @@ initPositionElements({
 });
 initWindowDocking({
   pinnedContainer: pinnedPanelsEl,
-  pinnedResizeHandle: document.getElementById('pinnedResizeHandle') as HTMLDivElement,
   appContainer: appEl,
 });
 [

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -58,6 +58,7 @@ import {
   positionPaintPanel, positionSettingsPanel, positionStatisticsPanel,
   positionScatterplotPanel, positionFiltersPanel, positionLandSchedulePanel,
   updateFiltersPanelLayout, updatePaintButtonState,
+  initWindowDocking, registerDockableWindow, enableWindowResizing,
   makeDraggable, handleMouseMove, handleMouseUp,
   type WindowManager
 } from './windows';
@@ -317,6 +318,8 @@ if (addLayerFromStoreButton) {
 }
 
 // Window elements
+const appEl = document.getElementById('app') as HTMLDivElement;
+const pinnedPanelsEl = document.getElementById('pinnedPanels') as HTMLDivElement;
 const controlsEl = document.getElementById('controls') as HTMLDivElement;
 const settingsContent = document.getElementById('settingsContent') as HTMLDivElement;
 const settingsControlsEl = document.getElementById('settingsControls') as HTMLDivElement;
@@ -359,6 +362,14 @@ const filtersSaveConfirmButton = document.getElementById('filtersSaveConfirm') a
 const filtersSavedStatus = document.getElementById('filtersSavedStatus') as HTMLDivElement;
 const filtersLoadControls = document.getElementById('filtersLoadControls') as HTMLDivElement;
 const filtersLoadSelect = document.getElementById('filtersLoadSelect') as HTMLSelectElement;
+const btnPinLayers = document.getElementById('btnPinLayers') as HTMLButtonElement;
+const btnPinSettings = document.getElementById('btnPinSettings') as HTMLButtonElement;
+const btnPinPaint = document.getElementById('btnPinPaint') as HTMLButtonElement;
+const btnPinFilters = document.getElementById('btnPinFilters') as HTMLButtonElement;
+const btnPinStatistics = document.getElementById('btnPinStatistics') as HTMLButtonElement;
+const btnPinScatterplot = document.getElementById('btnPinScatterplot') as HTMLButtonElement;
+const btnPinLandSchedule = document.getElementById('btnPinLandSchedule') as HTMLButtonElement;
+const btnPinLegend = document.getElementById('btnPinLegend') as HTMLButtonElement;
 
 const statsSubjectControls = buildSubjectSelector(statsSubjectSection);
 const scatterSubjectControls = buildSubjectSelector(scatterSubjectSection, { title: null });
@@ -611,6 +622,26 @@ initPositionElements({
   filtersListEl,
   landScheduleControlsEl,
 });
+initWindowDocking({
+  pinnedContainer: pinnedPanelsEl,
+  appContainer: appEl,
+});
+registerDockableWindow(controlsEl, btnPinLayers);
+registerDockableWindow(settingsControlsEl, btnPinSettings);
+registerDockableWindow(paintControlsEl, btnPinPaint);
+registerDockableWindow(filtersControlsEl, btnPinFilters);
+registerDockableWindow(statisticsControlsEl, btnPinStatistics);
+registerDockableWindow(scatterplotControlsEl, btnPinScatterplot);
+registerDockableWindow(landScheduleControlsEl, btnPinLandSchedule);
+registerDockableWindow(floatingLegend, btnPinLegend);
+enableWindowResizing(controlsEl);
+enableWindowResizing(settingsControlsEl);
+enableWindowResizing(paintControlsEl);
+enableWindowResizing(filtersControlsEl);
+enableWindowResizing(statisticsControlsEl);
+enableWindowResizing(scatterplotControlsEl);
+enableWindowResizing(landScheduleControlsEl);
+enableWindowResizing(floatingLegend);
 
 // Wire DOM elements and callbacks into the filters module
 initFilterElements({

--- a/viz/src/windows.ts
+++ b/viz/src/windows.ts
@@ -57,7 +57,7 @@ let isColumnResizing = false;
 let resizeColumn: HTMLDivElement | null = null;
 let columnResizeStartX = 0;
 let columnResizeStartWidth = 0;
-const columnWidthOverrides = new WeakMap<HTMLDivElement, number>();
+const columnWidthOverrides = new Map<number, number>();
 
 /** Must be called once from main.ts to wire in the callbacks. */
 export function initWindowCallbacks(callbacks: {
@@ -148,6 +148,9 @@ export function createWindowManager(config: WindowConfig): WindowManager {
 
   function show() {
     config.setMinimized(false);
+    if (isPinned(config.controlsEl) && pinnedContainer && !pinnedContainer.contains(config.controlsEl)) {
+      restorePinnedWindow(config.controlsEl);
+    }
     config.contentEl.style.display = display;
     config.controlsEl.style.display = 'grid';
     config.positionFn?.();
@@ -356,7 +359,7 @@ export function handleMouseMove(e: MouseEvent) {
     const dx = e.clientX - columnResizeStartX;
     const minColumnWidth = getColumnMinWidth(resizeColumn);
     const nextWidth = Math.max(minColumnWidth, columnResizeStartWidth + dx);
-    columnWidthOverrides.set(resizeColumn, nextWidth);
+    columnWidthOverrides.set(getColumnIndex(resizeColumn), nextWidth);
     updatePinnedLayout();
     return;
   }
@@ -474,6 +477,10 @@ function getColumnMinWidth(column: HTMLDivElement) {
   return children.reduce((maxWidth, child) => Math.max(maxWidth, getMinWindowWidth(child)), MIN_WINDOW_WIDTH);
 }
 
+function getColumnIndex(column: HTMLDivElement) {
+  return Number(column.dataset.columnIndex ?? 0);
+}
+
 function hasPinnedWindows() {
   if (!pinnedContainer) return false;
   return pinnedContainer.querySelectorAll('.pinned-column > .viz-window').length > 0;
@@ -530,7 +537,8 @@ function pinWindow(element: HTMLElement, column?: HTMLDivElement) {
   if (!targetColumn) {
     targetColumn = createPinnedColumn();
   }
-  targetColumn.appendChild(element);
+  element.dataset.pinnedColumn = `${getColumnIndex(targetColumn)}`;
+  insertWindowInColumn(targetColumn, element);
   updatePinButtonState(element);
   updatePinnedLayout();
 }
@@ -540,6 +548,8 @@ function unpinWindow(element: HTMLElement) {
   if (!isPinned(element)) return;
   const column = element.parentElement;
   setPinnedState(element, false);
+  element.dataset.pinnedColumn = '';
+  element.dataset.pinnedOrder = '';
   element.style.position = 'absolute';
   element.style.left = element.dataset.floatLeft ?? element.style.left;
   element.style.top = element.dataset.floatTop ?? element.style.top;
@@ -573,13 +583,13 @@ function updatePinnedLayout() {
       .filter(child => child.classList.contains('viz-window'))
       .filter(child => window.getComputedStyle(child).display !== 'none');
     if (visibleChildren.length === 0) {
-      columnWidthOverrides.delete(column);
+      columnWidthOverrides.delete(getColumnIndex(column));
       column.remove();
       return;
     }
     column.style.display = 'flex';
     const minColumnWidth = getColumnMinWidth(column);
-    const overrideWidth = columnWidthOverrides.get(column);
+    const overrideWidth = columnWidthOverrides.get(getColumnIndex(column));
     const columnWidth = Math.max(minColumnWidth, overrideWidth ?? minColumnWidth);
     column.style.width = `${columnWidth}px`;
     visibleChildren.forEach(child => {
@@ -593,6 +603,12 @@ function updatePinnedLayout() {
     _updateLegendPosition();
     updateFiltersPanelLayout();
     return;
+  }
+  const columnIndices = new Set(visibleColumns.map(entry => getColumnIndex(entry.column)));
+  for (const key of columnWidthOverrides.keys()) {
+    if (!columnIndices.has(key)) {
+      columnWidthOverrides.delete(key);
+    }
   }
   visibleColumns.forEach((entry, index) => {
     totalWidth += entry.width;
@@ -610,6 +626,8 @@ function createPinnedColumn() {
   if (!pinnedContainer) return null;
   const column = document.createElement('div');
   column.className = 'pinned-column';
+  const nextIndex = getNextColumnIndex();
+  column.dataset.columnIndex = `${nextIndex}`;
   const resizeHandle = document.createElement('div');
   resizeHandle.className = 'pinned-column-resize-handle';
   resizeHandle.setAttribute('aria-hidden', 'true');
@@ -655,6 +673,86 @@ function canColumnFitWindow(
   const nextHeight = element.getBoundingClientRect().height;
   const totalHeight = usedHeight + nextHeight + (visibleChildren.length > 0 ? gapValue : 0);
   return totalHeight <= containerHeight;
+}
+
+function insertWindowInColumn(column: HTMLDivElement, element: HTMLElement) {
+  const desiredOrder = Number(element.dataset.pinnedOrder ?? '');
+  const windows = Array.from(column.children)
+    .filter((child): child is HTMLElement => child instanceof HTMLElement)
+    .filter(child => child.classList.contains('viz-window'));
+  if (Number.isNaN(desiredOrder)) {
+    element.dataset.pinnedOrder = `${windows.length}`;
+    column.appendChild(element);
+    return;
+  }
+  const sorted = windows.sort((a, b) => {
+    const orderA = Number(a.dataset.pinnedOrder ?? 0);
+    const orderB = Number(b.dataset.pinnedOrder ?? 0);
+    return orderA - orderB;
+  });
+  const target = sorted.find(child => Number(child.dataset.pinnedOrder ?? 0) > desiredOrder);
+  if (target) {
+    column.insertBefore(element, target);
+  } else {
+    column.appendChild(element);
+  }
+}
+
+function restorePinnedWindow(element: HTMLElement) {
+  if (!pinnedContainer) return;
+  let targetColumn: HTMLDivElement | null = null;
+  const storedColumnIndex = Number(element.dataset.pinnedColumn ?? '');
+  if (!Number.isNaN(storedColumnIndex)) {
+    targetColumn = getOrCreateColumnByIndex(storedColumnIndex);
+  }
+  if (!targetColumn || !canColumnFitWindow(targetColumn, element)) {
+    targetColumn = findColumnForWindow(element);
+  }
+  if (!targetColumn) {
+    targetColumn = createPinnedColumn();
+  }
+  element.dataset.pinnedColumn = `${getColumnIndex(targetColumn)}`;
+  insertWindowInColumn(targetColumn, element);
+  updatePinnedLayout();
+}
+
+function getNextColumnIndex() {
+  if (!pinnedContainer) return 0;
+  const indices = Array.from(pinnedContainer.querySelectorAll('.pinned-column'))
+    .map(column => Number((column as HTMLDivElement).dataset.columnIndex ?? 0));
+  if (indices.length === 0) return 0;
+  return Math.max(...indices) + 1;
+}
+
+function getOrCreateColumnByIndex(index: number) {
+  if (!pinnedContainer) return null;
+  const existing = Array.from(pinnedContainer.querySelectorAll('.pinned-column'))
+    .find(column => Number((column as HTMLDivElement).dataset.columnIndex ?? 0) === index) as HTMLDivElement | undefined;
+  if (existing) return existing;
+  const column = document.createElement('div');
+  column.className = 'pinned-column';
+  column.dataset.columnIndex = `${index}`;
+  const resizeHandle = document.createElement('div');
+  resizeHandle.className = 'pinned-column-resize-handle';
+  resizeHandle.setAttribute('aria-hidden', 'true');
+  resizeHandle.addEventListener('mousedown', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    isColumnResizing = true;
+    resizeColumn = column;
+    columnResizeStartX = event.clientX;
+    columnResizeStartWidth = column.getBoundingClientRect().width;
+    document.body.style.userSelect = 'none';
+  });
+  column.appendChild(resizeHandle);
+  const columns = Array.from(pinnedContainer.querySelectorAll('.pinned-column')) as HTMLDivElement[];
+  const insertBefore = columns.find(existingColumn => getColumnIndex(existingColumn) > index);
+  if (insertBefore) {
+    pinnedContainer.insertBefore(column, insertBefore);
+  } else {
+    pinnedContainer.appendChild(column);
+  }
+  return column;
 }
 
 function getDockRightEdge() {

--- a/viz/src/windows.ts
+++ b/viz/src/windows.ts
@@ -41,7 +41,6 @@ const MIN_WINDOW_WIDTH = 240;
 const MIN_WINDOW_HEIGHT = 160;
 
 let pinnedContainer: HTMLDivElement | null = null;
-let pinnedResizeHandle: HTMLDivElement | null = null;
 let appContainer: HTMLElement | null = null;
 let dockableWindows: DockableWindow[] = [];
 let isResizing = false;
@@ -54,10 +53,11 @@ let resizeStartHeight = 0;
 let resizeMinHeight = MIN_WINDOW_HEIGHT;
 let lastMouseX = 0;
 let lastMouseY = 0;
-let isDockResizing = false;
-let dockResizeStartX = 0;
-let dockResizeStartWidth = 0;
-let dockWidthOverride: number | null = null;
+let isColumnResizing = false;
+let resizeColumn: HTMLDivElement | null = null;
+let columnResizeStartX = 0;
+let columnResizeStartWidth = 0;
+const columnWidthOverrides = new WeakMap<HTMLDivElement, number>();
 
 /** Must be called once from main.ts to wire in the callbacks. */
 export function initWindowCallbacks(callbacks: {
@@ -70,22 +70,10 @@ export function initWindowCallbacks(callbacks: {
 
 export function initWindowDocking(config: {
   pinnedContainer: HTMLDivElement;
-  pinnedResizeHandle: HTMLDivElement;
   appContainer: HTMLElement;
 }) {
   pinnedContainer = config.pinnedContainer;
-  pinnedResizeHandle = config.pinnedResizeHandle;
   appContainer = config.appContainer;
-  pinnedResizeHandle.addEventListener('mousedown', (event) => {
-    if (!pinnedContainer) return;
-    if (!hasPinnedWindows()) return;
-    event.preventDefault();
-    event.stopPropagation();
-    isDockResizing = true;
-    dockResizeStartX = event.clientX;
-    dockResizeStartWidth = getDockWidth();
-    document.body.style.userSelect = 'none';
-  });
   updatePinnedLayout();
   window.addEventListener('resize', () => updatePinnedLayout());
 }
@@ -97,6 +85,10 @@ export function registerDockableWindow(windowEl: HTMLElement, pinButton: HTMLBut
     event.stopPropagation();
     togglePinnedState(windowEl);
   });
+  const minWidth = Math.max(MIN_WINDOW_WIDTH, windowEl.scrollWidth);
+  if (!windowEl.dataset.minWidth) {
+    windowEl.dataset.minWidth = `${minWidth}`;
+  }
   updatePinButtonState(windowEl);
 }
 
@@ -126,7 +118,15 @@ export function enableWindowResizing(windowEl: HTMLElement) {
 
   if (contentEl) {
     const observer = new ResizeObserver(() => {
+      const currentMinWidth = Number(windowEl.dataset.minWidth ?? MIN_WINDOW_WIDTH);
+      if (contentEl.scrollWidth > contentEl.clientWidth) {
+        const nextMinWidth = Math.max(currentMinWidth, contentEl.scrollWidth);
+        windowEl.dataset.minWidth = `${nextMinWidth}`;
+      }
       ensureWindowMinHeight(windowEl);
+      if (isPinned(windowEl)) {
+        updatePinnedLayout();
+      }
     });
     observer.observe(contentEl);
   }
@@ -352,11 +352,11 @@ export function handleMouseMove(e: MouseEvent) {
   lastMouseX = e.clientX;
   lastMouseY = e.clientY;
 
-  if (isDockResizing && pinnedContainer) {
-    const dx = e.clientX - dockResizeStartX;
-    const minDockWidth = getMinDockWidth();
-    const nextWidth = Math.max(minDockWidth, dockResizeStartWidth + dx);
-    dockWidthOverride = nextWidth;
+  if (isColumnResizing && resizeColumn) {
+    const dx = e.clientX - columnResizeStartX;
+    const minColumnWidth = getColumnMinWidth(resizeColumn);
+    const nextWidth = Math.max(minColumnWidth, columnResizeStartWidth + dx);
+    columnWidthOverrides.set(resizeColumn, nextWidth);
     updatePinnedLayout();
     return;
   }
@@ -416,8 +416,9 @@ export function handleMouseUp() {
     resizeTarget = null;
     document.body.style.userSelect = '';
   }
-  if (isDockResizing) {
-    isDockResizing = false;
+  if (isColumnResizing) {
+    isColumnResizing = false;
+    resizeColumn = null;
     document.body.style.userSelect = '';
   }
 
@@ -460,28 +461,22 @@ function ensureWindowMinHeight(element: HTMLElement) {
 }
 
 function getMinWindowWidth(element: HTMLElement) {
-  return Math.max(MIN_WINDOW_WIDTH, element.scrollWidth);
+  const storedMin = Number(element.dataset.minWidth ?? MIN_WINDOW_WIDTH);
+  return Math.max(MIN_WINDOW_WIDTH, storedMin);
+}
+
+function getColumnMinWidth(column: HTMLDivElement) {
+  const children = Array.from(column.children)
+    .filter((child): child is HTMLElement => child instanceof HTMLElement)
+    .filter(child => child.classList.contains('viz-window'))
+    .filter(child => window.getComputedStyle(child).display !== 'none');
+  if (children.length === 0) return MIN_WINDOW_WIDTH;
+  return children.reduce((maxWidth, child) => Math.max(maxWidth, getMinWindowWidth(child)), MIN_WINDOW_WIDTH);
 }
 
 function hasPinnedWindows() {
   if (!pinnedContainer) return false;
   return pinnedContainer.querySelectorAll('.pinned-column > .viz-window').length > 0;
-}
-
-function getMinDockWidth() {
-  const pinnedWindows = dockableWindows
-    .map(entry => entry.element)
-    .filter(element => isPinned(element) && window.getComputedStyle(element).display !== 'none');
-  if (pinnedWindows.length === 0) return 0;
-  return pinnedWindows.reduce((maxWidth, element) => Math.max(maxWidth, getMinWindowWidth(element)), MIN_WINDOW_WIDTH);
-}
-
-function getDockWidth() {
-  const minDockWidth = getMinDockWidth();
-  if (dockWidthOverride !== null) {
-    return Math.max(minDockWidth, dockWidthOverride);
-  }
-  return minDockWidth;
 }
 
 function isPinned(element: HTMLElement) {
@@ -525,15 +520,12 @@ function pinWindow(element: HTMLElement, column?: HTMLDivElement) {
   element.style.position = 'relative';
   setPinnedState(element, true);
 
-  let targetColumn = column;
+  let targetColumn = column ?? findColumnForWindow(element);
   if (!targetColumn) {
-    targetColumn = document.createElement('div');
-    targetColumn.className = 'pinned-column';
-    pinnedContainer.appendChild(targetColumn);
+    targetColumn = createPinnedColumn();
   }
   targetColumn.appendChild(element);
   updatePinButtonState(element);
-  dockWidthOverride = dockWidthOverride ?? getMinDockWidth();
   updatePinnedLayout();
 }
 
@@ -568,7 +560,6 @@ function updatePinnedLayout() {
   const paddingRight = parseFloat(containerStyles.paddingRight || '0');
   const gapValue = parseFloat(containerStyles.columnGap || containerStyles.gap || `${PINNED_GAP_FALLBACK}`);
   let totalWidth = paddingLeft + paddingRight;
-  const dockWidth = getDockWidth();
   const visibleColumns: Array<{ column: HTMLDivElement; width: number }> = [];
   columns.forEach((column) => {
     const children = Array.from(column.children) as HTMLElement[];
@@ -579,7 +570,9 @@ function updatePinnedLayout() {
       return;
     }
     column.style.display = 'flex';
-    const columnWidth = Math.max(MIN_WINDOW_WIDTH, dockWidth);
+    const minColumnWidth = getColumnMinWidth(column);
+    const overrideWidth = columnWidthOverrides.get(column);
+    const columnWidth = Math.max(minColumnWidth, overrideWidth ?? minColumnWidth);
     column.style.width = `${columnWidth}px`;
     visibleChildren.forEach(child => {
       child.style.width = `${columnWidth}px`;
@@ -593,19 +586,53 @@ function updatePinnedLayout() {
     }
   });
   document.documentElement.style.setProperty('--pinned-width', `${totalWidth}px`);
-  updatePinnedResizeHandle();
   ensureFloatingWindowsClearDock();
   _updateLegendPosition();
   updateFiltersPanelLayout();
 }
 
-function updatePinnedResizeHandle() {
-  if (!pinnedResizeHandle) return;
-  if (!hasPinnedWindows()) {
-    pinnedResizeHandle.style.display = 'none';
-    return;
+function createPinnedColumn() {
+  if (!pinnedContainer) return null;
+  const column = document.createElement('div');
+  column.className = 'pinned-column';
+  const resizeHandle = document.createElement('div');
+  resizeHandle.className = 'pinned-column-resize-handle';
+  resizeHandle.setAttribute('aria-hidden', 'true');
+  resizeHandle.addEventListener('mousedown', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    isColumnResizing = true;
+    resizeColumn = column;
+    columnResizeStartX = event.clientX;
+    columnResizeStartWidth = column.getBoundingClientRect().width;
+    document.body.style.userSelect = 'none';
+  });
+  column.appendChild(resizeHandle);
+  pinnedContainer.appendChild(column);
+  return column;
+}
+
+function findColumnForWindow(element: HTMLElement) {
+  if (!pinnedContainer) return null;
+  const columns = Array.from(pinnedContainer.querySelectorAll('.pinned-column')) as HTMLDivElement[];
+  const containerHeight = pinnedContainer.getBoundingClientRect().height;
+  const gapValue = parseFloat(window.getComputedStyle(pinnedContainer).gap || `${PINNED_GAP_FALLBACK}`);
+  for (const column of columns) {
+    const visibleChildren = Array.from(column.children)
+      .filter((child): child is HTMLElement => child instanceof HTMLElement)
+      .filter(child => child.classList.contains('viz-window'))
+      .filter(child => window.getComputedStyle(child).display !== 'none');
+    if (visibleChildren.length === 0) {
+      return column;
+    }
+    const usedHeight = visibleChildren.reduce((sum, child) => sum + child.getBoundingClientRect().height, 0)
+      + gapValue * Math.max(0, visibleChildren.length - 1);
+    const nextHeight = element.getBoundingClientRect().height;
+    if (usedHeight + nextHeight <= containerHeight) {
+      return column;
+    }
   }
-  pinnedResizeHandle.style.display = 'block';
+  return null;
 }
 
 function getDockRightEdge() {

--- a/viz/src/windows.ts
+++ b/viz/src/windows.ts
@@ -520,7 +520,13 @@ function pinWindow(element: HTMLElement, column?: HTMLDivElement) {
   element.style.position = 'relative';
   setPinnedState(element, true);
 
-  let targetColumn = column ?? findColumnForWindow(element);
+  let targetColumn = column;
+  if (targetColumn && !canColumnFitWindow(targetColumn, element)) {
+    targetColumn = null;
+  }
+  if (!targetColumn) {
+    targetColumn = findColumnForWindow(element);
+  }
   if (!targetColumn) {
     targetColumn = createPinnedColumn();
   }
@@ -563,10 +569,12 @@ function updatePinnedLayout() {
   const visibleColumns: Array<{ column: HTMLDivElement; width: number }> = [];
   columns.forEach((column) => {
     const children = Array.from(column.children) as HTMLElement[];
-    const visibleChildren = children.filter(child => window.getComputedStyle(child).display !== 'none');
+    const visibleChildren = children
+      .filter(child => child.classList.contains('viz-window'))
+      .filter(child => window.getComputedStyle(child).display !== 'none');
     if (visibleChildren.length === 0) {
-      column.style.display = 'none';
-      column.style.width = '0px';
+      columnWidthOverrides.delete(column);
+      column.remove();
       return;
     }
     column.style.display = 'flex';
@@ -579,6 +587,13 @@ function updatePinnedLayout() {
     });
     visibleColumns.push({ column, width: columnWidth });
   });
+  if (visibleColumns.length === 0) {
+    document.documentElement.style.setProperty('--pinned-width', '0px');
+    ensureFloatingWindowsClearDock();
+    _updateLegendPosition();
+    updateFiltersPanelLayout();
+    return;
+  }
   visibleColumns.forEach((entry, index) => {
     totalWidth += entry.width;
     if (index < visibleColumns.length - 1) {
@@ -618,21 +633,28 @@ function findColumnForWindow(element: HTMLElement) {
   const containerHeight = pinnedContainer.getBoundingClientRect().height;
   const gapValue = parseFloat(window.getComputedStyle(pinnedContainer).gap || `${PINNED_GAP_FALLBACK}`);
   for (const column of columns) {
-    const visibleChildren = Array.from(column.children)
-      .filter((child): child is HTMLElement => child instanceof HTMLElement)
-      .filter(child => child.classList.contains('viz-window'))
-      .filter(child => window.getComputedStyle(child).display !== 'none');
-    if (visibleChildren.length === 0) {
-      return column;
-    }
-    const usedHeight = visibleChildren.reduce((sum, child) => sum + child.getBoundingClientRect().height, 0)
-      + gapValue * Math.max(0, visibleChildren.length - 1);
-    const nextHeight = element.getBoundingClientRect().height;
-    if (usedHeight + nextHeight <= containerHeight) {
+    if (canColumnFitWindow(column, element, containerHeight, gapValue)) {
       return column;
     }
   }
   return null;
+}
+
+function canColumnFitWindow(
+  column: HTMLDivElement,
+  element: HTMLElement,
+  containerHeight = pinnedContainer?.getBoundingClientRect().height ?? 0,
+  gapValue = parseFloat(window.getComputedStyle(pinnedContainer ?? document.body).gap || `${PINNED_GAP_FALLBACK}`)
+) {
+  const visibleChildren = Array.from(column.children)
+    .filter((child): child is HTMLElement => child instanceof HTMLElement)
+    .filter(child => child.classList.contains('viz-window'))
+    .filter(child => window.getComputedStyle(child).display !== 'none');
+  const usedHeight = visibleChildren.reduce((sum, child) => sum + child.getBoundingClientRect().height, 0)
+    + gapValue * Math.max(0, visibleChildren.length - 1);
+  const nextHeight = element.getBoundingClientRect().height;
+  const totalHeight = usedHeight + nextHeight + (visibleChildren.length > 0 ? gapValue : 0);
+  return totalHeight <= containerHeight;
 }
 
 function getDockRightEdge() {

--- a/viz/src/windows.ts
+++ b/viz/src/windows.ts
@@ -34,13 +34,14 @@ type DockableWindow = {
   pinButton: HTMLButtonElement;
 };
 
-type ResizeMode = 'both' | 'x';
+type ResizeMode = 'both' | 'x' | 'y';
 
 const PINNED_GAP_FALLBACK = 8;
 const MIN_WINDOW_WIDTH = 240;
 const MIN_WINDOW_HEIGHT = 160;
 
 let pinnedContainer: HTMLDivElement | null = null;
+let pinnedResizeHandle: HTMLDivElement | null = null;
 let appContainer: HTMLElement | null = null;
 let dockableWindows: DockableWindow[] = [];
 let isResizing = false;
@@ -53,6 +54,10 @@ let resizeStartHeight = 0;
 let resizeMinHeight = MIN_WINDOW_HEIGHT;
 let lastMouseX = 0;
 let lastMouseY = 0;
+let isDockResizing = false;
+let dockResizeStartX = 0;
+let dockResizeStartWidth = 0;
+let dockWidthOverride: number | null = null;
 
 /** Must be called once from main.ts to wire in the callbacks. */
 export function initWindowCallbacks(callbacks: {
@@ -65,10 +70,22 @@ export function initWindowCallbacks(callbacks: {
 
 export function initWindowDocking(config: {
   pinnedContainer: HTMLDivElement;
+  pinnedResizeHandle: HTMLDivElement;
   appContainer: HTMLElement;
 }) {
   pinnedContainer = config.pinnedContainer;
+  pinnedResizeHandle = config.pinnedResizeHandle;
   appContainer = config.appContainer;
+  pinnedResizeHandle.addEventListener('mousedown', (event) => {
+    if (!pinnedContainer) return;
+    if (!hasPinnedWindows()) return;
+    event.preventDefault();
+    event.stopPropagation();
+    isDockResizing = true;
+    dockResizeStartX = event.clientX;
+    dockResizeStartWidth = getDockWidth();
+    document.body.style.userSelect = 'none';
+  });
   updatePinnedLayout();
   window.addEventListener('resize', () => updatePinnedLayout());
 }
@@ -86,24 +103,33 @@ export function registerDockableWindow(windowEl: HTMLElement, pinButton: HTMLBut
 export function enableWindowResizing(windowEl: HTMLElement) {
   const handle = windowEl.querySelector('.window-resize-handle') as HTMLElement | null;
   const edge = windowEl.querySelector('.window-resize-edge') as HTMLElement | null;
+  const contentEl = windowEl.querySelector('[data-window-content]') as HTMLElement | null;
 
   const startResize = (mode: ResizeMode) => (event: MouseEvent) => {
+    if (mode === 'x' && isPinned(windowEl)) return;
     event.preventDefault();
     event.stopPropagation();
     isResizing = true;
     resizeTarget = windowEl;
-    resizeMode = mode;
+    resizeMode = (isPinned(windowEl) && mode === 'both') ? 'y' : mode;
     resizeStartX = event.clientX;
     resizeStartY = event.clientY;
     const rect = windowEl.getBoundingClientRect();
     resizeStartWidth = rect.width;
     resizeStartHeight = rect.height;
-    resizeMinHeight = Math.max(MIN_WINDOW_HEIGHT, windowEl.scrollHeight);
+    resizeMinHeight = getMinWindowHeight(windowEl);
     document.body.style.userSelect = 'none';
   };
 
   handle?.addEventListener('mousedown', startResize('both'));
   edge?.addEventListener('mousedown', startResize('x'));
+
+  if (contentEl) {
+    const observer = new ResizeObserver(() => {
+      ensureWindowMinHeight(windowEl);
+    });
+    observer.observe(contentEl);
+  }
 }
 
 export function createWindowManager(config: WindowConfig): WindowManager {
@@ -126,6 +152,7 @@ export function createWindowManager(config: WindowConfig): WindowManager {
     config.controlsEl.style.display = 'grid';
     config.positionFn?.();
     config.onShow?.();
+    ensureWindowMinHeight(config.controlsEl);
     if (isPinned(config.controlsEl)) {
       updatePinnedLayout();
     }
@@ -325,12 +352,27 @@ export function handleMouseMove(e: MouseEvent) {
   lastMouseX = e.clientX;
   lastMouseY = e.clientY;
 
+  if (isDockResizing && pinnedContainer) {
+    const dx = e.clientX - dockResizeStartX;
+    const minDockWidth = getMinDockWidth();
+    const nextWidth = Math.max(minDockWidth, dockResizeStartWidth + dx);
+    dockWidthOverride = nextWidth;
+    updatePinnedLayout();
+    return;
+  }
+
   if (isResizing && resizeTarget) {
     const dx = e.clientX - resizeStartX;
     const dy = e.clientY - resizeStartY;
-    const nextWidth = Math.max(MIN_WINDOW_WIDTH, resizeStartWidth + dx);
-    resizeTarget.style.width = `${nextWidth}px`;
+    if (resizeMode !== 'y') {
+      const nextWidth = Math.max(MIN_WINDOW_WIDTH, resizeStartWidth + dx);
+      resizeTarget.style.width = `${nextWidth}px`;
+    }
     if (resizeMode === 'both') {
+      const nextHeight = Math.max(resizeMinHeight, resizeStartHeight + dy);
+      resizeTarget.style.height = `${nextHeight}px`;
+    }
+    if (resizeMode === 'y') {
       const nextHeight = Math.max(resizeMinHeight, resizeStartHeight + dy);
       resizeTarget.style.height = `${nextHeight}px`;
     }
@@ -340,6 +382,7 @@ export function handleMouseMove(e: MouseEvent) {
     if (isPinned(resizeTarget)) {
       updatePinnedLayout();
     }
+    ensureWindowMinHeight(resizeTarget);
     return;
   }
 
@@ -353,7 +396,8 @@ export function handleMouseMove(e: MouseEvent) {
   const maxX = window.innerWidth - rect.width;
   const maxY = window.innerHeight - rect.height;
 
-  const clampedX = Math.max(0, Math.min(x, maxX));
+  const minX = getDockRightEdge();
+  const clampedX = Math.max(minX, Math.min(x, maxX));
   const clampedY = Math.max(0, Math.min(y, maxY));
 
   S.dragTarget.style.left = `${clampedX}px`;
@@ -372,6 +416,10 @@ export function handleMouseUp() {
     resizeTarget = null;
     document.body.style.userSelect = '';
   }
+  if (isDockResizing) {
+    isDockResizing = false;
+    document.body.style.userSelect = '';
+  }
 
   const releasedTarget = S.dragTarget;
   S.isDragging = false;
@@ -379,6 +427,9 @@ export function handleMouseUp() {
   document.body.style.userSelect = '';
   if (releasedTarget?.id === 'filtersControls') {
     updateFiltersPanelLayout();
+  }
+  if (releasedTarget) {
+    ensureWindowMinHeight(releasedTarget);
   }
   if (releasedTarget && pinnedContainer) {
     const dropColumn = getPinnedDropColumn(lastMouseX, lastMouseY);
@@ -389,6 +440,48 @@ export function handleMouseUp() {
       pinWindow(releasedTarget);
     }
   }
+}
+
+function getMinWindowHeight(element: HTMLElement) {
+  return Math.max(MIN_WINDOW_HEIGHT, element.scrollHeight);
+}
+
+function ensureWindowMinHeight(element: HTMLElement) {
+  const minHeight = getMinWindowHeight(element);
+  if (element.offsetHeight < minHeight) {
+    element.style.height = `${minHeight}px`;
+  }
+  if (element.id === 'filtersControls') {
+    updateFiltersPanelLayout();
+  }
+  if (isPinned(element)) {
+    updatePinnedLayout();
+  }
+}
+
+function getMinWindowWidth(element: HTMLElement) {
+  return Math.max(MIN_WINDOW_WIDTH, element.scrollWidth);
+}
+
+function hasPinnedWindows() {
+  if (!pinnedContainer) return false;
+  return pinnedContainer.querySelectorAll('.pinned-column > .viz-window').length > 0;
+}
+
+function getMinDockWidth() {
+  const pinnedWindows = dockableWindows
+    .map(entry => entry.element)
+    .filter(element => isPinned(element) && window.getComputedStyle(element).display !== 'none');
+  if (pinnedWindows.length === 0) return 0;
+  return pinnedWindows.reduce((maxWidth, element) => Math.max(maxWidth, getMinWindowWidth(element)), MIN_WINDOW_WIDTH);
+}
+
+function getDockWidth() {
+  const minDockWidth = getMinDockWidth();
+  if (dockWidthOverride !== null) {
+    return Math.max(minDockWidth, dockWidthOverride);
+  }
+  return minDockWidth;
 }
 
 function isPinned(element: HTMLElement) {
@@ -440,6 +533,7 @@ function pinWindow(element: HTMLElement, column?: HTMLDivElement) {
   }
   targetColumn.appendChild(element);
   updatePinButtonState(element);
+  dockWidthOverride = dockWidthOverride ?? getMinDockWidth();
   updatePinnedLayout();
 }
 
@@ -474,6 +568,7 @@ function updatePinnedLayout() {
   const paddingRight = parseFloat(containerStyles.paddingRight || '0');
   const gapValue = parseFloat(containerStyles.columnGap || containerStyles.gap || `${PINNED_GAP_FALLBACK}`);
   let totalWidth = paddingLeft + paddingRight;
+  const dockWidth = getDockWidth();
   const visibleColumns: Array<{ column: HTMLDivElement; width: number }> = [];
   columns.forEach((column) => {
     const children = Array.from(column.children) as HTMLElement[];
@@ -484,9 +579,11 @@ function updatePinnedLayout() {
       return;
     }
     column.style.display = 'flex';
-    const maxWidth = visibleChildren.reduce((acc, child) => Math.max(acc, child.getBoundingClientRect().width), 0);
-    const columnWidth = Math.max(MIN_WINDOW_WIDTH, maxWidth);
+    const columnWidth = Math.max(MIN_WINDOW_WIDTH, dockWidth);
     column.style.width = `${columnWidth}px`;
+    visibleChildren.forEach(child => {
+      child.style.width = `${columnWidth}px`;
+    });
     visibleColumns.push({ column, width: columnWidth });
   });
   visibleColumns.forEach((entry, index) => {
@@ -496,8 +593,42 @@ function updatePinnedLayout() {
     }
   });
   document.documentElement.style.setProperty('--pinned-width', `${totalWidth}px`);
+  updatePinnedResizeHandle();
+  ensureFloatingWindowsClearDock();
   _updateLegendPosition();
   updateFiltersPanelLayout();
+}
+
+function updatePinnedResizeHandle() {
+  if (!pinnedResizeHandle) return;
+  if (!hasPinnedWindows()) {
+    pinnedResizeHandle.style.display = 'none';
+    return;
+  }
+  pinnedResizeHandle.style.display = 'block';
+}
+
+function getDockRightEdge() {
+  if (!pinnedContainer) return 0;
+  if (!hasPinnedWindows()) {
+    return 64;
+  }
+  const rect = pinnedContainer.getBoundingClientRect();
+  return rect.right + 10;
+}
+
+function ensureFloatingWindowsClearDock() {
+  const dockRight = getDockRightEdge();
+  dockableWindows.forEach(entry => {
+    const element = entry.element;
+    if (isPinned(element)) return;
+    if (window.getComputedStyle(element).display === 'none') return;
+    const rect = element.getBoundingClientRect();
+    if (rect.left < dockRight) {
+      element.style.left = `${dockRight}px`;
+      element.style.transform = 'none';
+    }
+  });
 }
 
 function isPointInPinnedArea(x: number, y: number) {

--- a/viz/src/windows.ts
+++ b/viz/src/windows.ts
@@ -50,6 +50,7 @@ let resizeStartX = 0;
 let resizeStartY = 0;
 let resizeStartWidth = 0;
 let resizeStartHeight = 0;
+let resizeMinHeight = MIN_WINDOW_HEIGHT;
 let lastMouseX = 0;
 let lastMouseY = 0;
 
@@ -97,6 +98,7 @@ export function enableWindowResizing(windowEl: HTMLElement) {
     const rect = windowEl.getBoundingClientRect();
     resizeStartWidth = rect.width;
     resizeStartHeight = rect.height;
+    resizeMinHeight = Math.max(MIN_WINDOW_HEIGHT, windowEl.scrollHeight);
     document.body.style.userSelect = 'none';
   };
 
@@ -329,7 +331,7 @@ export function handleMouseMove(e: MouseEvent) {
     const nextWidth = Math.max(MIN_WINDOW_WIDTH, resizeStartWidth + dx);
     resizeTarget.style.width = `${nextWidth}px`;
     if (resizeMode === 'both') {
-      const nextHeight = Math.max(MIN_WINDOW_HEIGHT, resizeStartHeight + dy);
+      const nextHeight = Math.max(resizeMinHeight, resizeStartHeight + dy);
       resizeTarget.style.height = `${nextHeight}px`;
     }
     if (resizeTarget.id === 'filtersControls') {
@@ -407,7 +409,9 @@ function updatePinButtonState(element: HTMLElement) {
   const img = entry.pinButton.querySelector('img');
   if (!img) return;
   const pinned = isPinned(element);
-  img.src = pinned ? './src/svg/thumbtack.svg' : './src/svg/thumbtack-tilted.svg';
+  const pinnedSrc = entry.pinButton.dataset.pinSrc;
+  const unpinnedSrc = entry.pinButton.dataset.unpinSrc;
+  img.src = pinned ? (pinnedSrc ?? './src/svg/thumbtack.svg') : (unpinnedSrc ?? './src/svg/thumbtack-tilted.svg');
   img.alt = pinned ? 'Unpin menu' : 'Pin menu';
   entry.pinButton.setAttribute('aria-pressed', String(pinned));
   entry.pinButton.title = pinned ? 'Unpin' : 'Pin';

--- a/viz/src/windows.ts
+++ b/viz/src/windows.ts
@@ -148,12 +148,13 @@ export function createWindowManager(config: WindowConfig): WindowManager {
 
   function show() {
     config.setMinimized(false);
-    if (isPinned(config.controlsEl) && pinnedContainer && !pinnedContainer.contains(config.controlsEl)) {
-      restorePinnedWindow(config.controlsEl);
-    }
     config.contentEl.style.display = display;
     config.controlsEl.style.display = 'grid';
-    config.positionFn?.();
+    if (isPinned(config.controlsEl) && pinnedContainer && !pinnedContainer.contains(config.controlsEl)) {
+      restorePinnedWindow(config.controlsEl);
+    } else {
+      config.positionFn?.();
+    }
     config.onShow?.();
     ensureWindowMinHeight(config.controlsEl);
     if (isPinned(config.controlsEl)) {

--- a/viz/src/windows.ts
+++ b/viz/src/windows.ts
@@ -29,6 +29,30 @@ export type WindowManager = {
 let _updateToolbarButtonStates: () => void = () => {};
 let _updateLegendPosition: () => void = () => {};
 
+type DockableWindow = {
+  element: HTMLElement;
+  pinButton: HTMLButtonElement;
+};
+
+type ResizeMode = 'both' | 'x';
+
+const PINNED_GAP_FALLBACK = 8;
+const MIN_WINDOW_WIDTH = 240;
+const MIN_WINDOW_HEIGHT = 160;
+
+let pinnedContainer: HTMLDivElement | null = null;
+let appContainer: HTMLElement | null = null;
+let dockableWindows: DockableWindow[] = [];
+let isResizing = false;
+let resizeTarget: HTMLElement | null = null;
+let resizeMode: ResizeMode = 'both';
+let resizeStartX = 0;
+let resizeStartY = 0;
+let resizeStartWidth = 0;
+let resizeStartHeight = 0;
+let lastMouseX = 0;
+let lastMouseY = 0;
+
 /** Must be called once from main.ts to wire in the callbacks. */
 export function initWindowCallbacks(callbacks: {
   updateToolbarButtonStates: () => void;
@@ -36,6 +60,48 @@ export function initWindowCallbacks(callbacks: {
 }) {
   _updateToolbarButtonStates = callbacks.updateToolbarButtonStates;
   _updateLegendPosition = callbacks.updateLegendPosition;
+}
+
+export function initWindowDocking(config: {
+  pinnedContainer: HTMLDivElement;
+  appContainer: HTMLElement;
+}) {
+  pinnedContainer = config.pinnedContainer;
+  appContainer = config.appContainer;
+  updatePinnedLayout();
+  window.addEventListener('resize', () => updatePinnedLayout());
+}
+
+export function registerDockableWindow(windowEl: HTMLElement, pinButton: HTMLButtonElement) {
+  dockableWindows.push({ element: windowEl, pinButton });
+  pinButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    togglePinnedState(windowEl);
+  });
+  updatePinButtonState(windowEl);
+}
+
+export function enableWindowResizing(windowEl: HTMLElement) {
+  const handle = windowEl.querySelector('.window-resize-handle') as HTMLElement | null;
+  const edge = windowEl.querySelector('.window-resize-edge') as HTMLElement | null;
+
+  const startResize = (mode: ResizeMode) => (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    isResizing = true;
+    resizeTarget = windowEl;
+    resizeMode = mode;
+    resizeStartX = event.clientX;
+    resizeStartY = event.clientY;
+    const rect = windowEl.getBoundingClientRect();
+    resizeStartWidth = rect.width;
+    resizeStartHeight = rect.height;
+    document.body.style.userSelect = 'none';
+  };
+
+  handle?.addEventListener('mousedown', startResize('both'));
+  edge?.addEventListener('mousedown', startResize('x'));
 }
 
 export function createWindowManager(config: WindowConfig): WindowManager {
@@ -46,6 +112,9 @@ export function createWindowManager(config: WindowConfig): WindowManager {
     config.contentEl.style.display = 'none';
     config.controlsEl.style.display = 'none';
     config.onMinimize?.();
+    if (isPinned(config.controlsEl)) {
+      updatePinnedLayout();
+    }
     _updateToolbarButtonStates();
   }
 
@@ -55,6 +124,9 @@ export function createWindowManager(config: WindowConfig): WindowManager {
     config.controlsEl.style.display = 'grid';
     config.positionFn?.();
     config.onShow?.();
+    if (isPinned(config.controlsEl)) {
+      updatePinnedLayout();
+    }
     _updateToolbarButtonStates();
   }
 
@@ -91,6 +163,7 @@ export function initPositionElements(elements: PositionElements) {
 
 export function positionPaintPanel() {
   if (!els.controlsEl || !els.paintControlsEl) return;
+  if (isPinned(els.paintControlsEl)) return;
   if (els.paintControlsEl.dataset.userPositioned === 'true') return;
   const rect = els.controlsEl.getBoundingClientRect();
   if (rect.width === 0 && rect.height === 0) return;
@@ -102,6 +175,7 @@ export function positionPaintPanel() {
 
 export function positionSettingsPanel() {
   if (!els.controlsEl || !els.settingsControlsEl) return;
+  if (isPinned(els.settingsControlsEl)) return;
   if (els.settingsControlsEl.dataset.userPositioned === 'true') return;
   const rect = els.controlsEl.getBoundingClientRect();
   if (rect.width === 0 && rect.height === 0) return;
@@ -113,6 +187,7 @@ export function positionSettingsPanel() {
 
 export function positionStatisticsPanel() {
   if (!els.statisticsControlsEl) return;
+  if (isPinned(els.statisticsControlsEl)) return;
   if (els.statisticsControlsEl.dataset.userPositioned === 'true') return;
   const anchor = (!S.isSettingsMenuMinimized && els.settingsControlsEl) ? els.settingsControlsEl : els.controlsEl;
   if (!anchor) return;
@@ -126,6 +201,7 @@ export function positionStatisticsPanel() {
 
 export function positionScatterplotPanel() {
   if (!els.scatterplotControlsEl) return;
+  if (isPinned(els.scatterplotControlsEl)) return;
   if (els.scatterplotControlsEl.dataset.userPositioned === 'true') return;
   const anchor = (!S.isStatisticsMinimized && els.statisticsControlsEl)
     ? els.statisticsControlsEl
@@ -143,6 +219,7 @@ export function positionScatterplotPanel() {
 
 export function positionFiltersPanel() {
   if (!els.filtersControlsEl) return;
+  if (isPinned(els.filtersControlsEl)) return;
   if (els.filtersControlsEl.dataset.userPositioned === 'true') return;
   const anchor = (!S.isScatterplotMinimized && els.scatterplotControlsEl)
     ? els.scatterplotControlsEl
@@ -179,6 +256,7 @@ export function updateFiltersPanelLayout() {
 
 export function positionLandSchedulePanel() {
   if (!els.landScheduleControlsEl) return;
+  if (isPinned(els.landScheduleControlsEl)) return;
   if (els.landScheduleControlsEl.dataset.userPositioned === 'true') return;
   const anchor = (!S.isFiltersMinimized && els.filtersControlsEl)
     ? els.filtersControlsEl
@@ -222,8 +300,14 @@ export function makeDraggable(element: HTMLElement) {
   if (!header) return;
 
   header.addEventListener('mousedown', (e) => {
+    const target = e.target as HTMLElement;
+    if (target.closest('button')) return;
+    if (target.closest('.window-resize-handle') || target.closest('.window-resize-edge')) return;
     S.isDragging = true;
     S.dragTarget = element;
+    if (isPinned(element)) {
+      unpinWindow(element);
+    }
     element.dataset.userPositioned = 'true';
     const rect = element.getBoundingClientRect();
     S.dragOffset.x = e.clientX - rect.left;
@@ -236,6 +320,27 @@ export function makeDraggable(element: HTMLElement) {
 }
 
 export function handleMouseMove(e: MouseEvent) {
+  lastMouseX = e.clientX;
+  lastMouseY = e.clientY;
+
+  if (isResizing && resizeTarget) {
+    const dx = e.clientX - resizeStartX;
+    const dy = e.clientY - resizeStartY;
+    const nextWidth = Math.max(MIN_WINDOW_WIDTH, resizeStartWidth + dx);
+    resizeTarget.style.width = `${nextWidth}px`;
+    if (resizeMode === 'both') {
+      const nextHeight = Math.max(MIN_WINDOW_HEIGHT, resizeStartHeight + dy);
+      resizeTarget.style.height = `${nextHeight}px`;
+    }
+    if (resizeTarget.id === 'filtersControls') {
+      updateFiltersPanelLayout();
+    }
+    if (isPinned(resizeTarget)) {
+      updatePinnedLayout();
+    }
+    return;
+  }
+
   if (!S.isDragging || !S.dragTarget) return;
 
   const x = e.clientX - S.dragOffset.x;
@@ -260,6 +365,12 @@ export function handleMouseMove(e: MouseEvent) {
 }
 
 export function handleMouseUp() {
+  if (isResizing) {
+    isResizing = false;
+    resizeTarget = null;
+    document.body.style.userSelect = '';
+  }
+
   const releasedTarget = S.dragTarget;
   S.isDragging = false;
   S.dragTarget = null;
@@ -267,4 +378,135 @@ export function handleMouseUp() {
   if (releasedTarget?.id === 'filtersControls') {
     updateFiltersPanelLayout();
   }
+  if (releasedTarget && pinnedContainer) {
+    const dropColumn = getPinnedDropColumn(lastMouseX, lastMouseY);
+    const dropInPinnedArea = isPointInPinnedArea(lastMouseX, lastMouseY);
+    if (dropColumn) {
+      pinWindow(releasedTarget, dropColumn);
+    } else if (dropInPinnedArea) {
+      pinWindow(releasedTarget);
+    }
+  }
+}
+
+function isPinned(element: HTMLElement) {
+  return element.dataset.pinned === 'true';
+}
+
+function togglePinnedState(element: HTMLElement) {
+  if (isPinned(element)) {
+    unpinWindow(element);
+  } else {
+    pinWindow(element);
+  }
+}
+
+function updatePinButtonState(element: HTMLElement) {
+  const entry = dockableWindows.find(win => win.element === element);
+  if (!entry) return;
+  const img = entry.pinButton.querySelector('img');
+  if (!img) return;
+  const pinned = isPinned(element);
+  img.src = pinned ? './src/svg/thumbtack.svg' : './src/svg/thumbtack-tilted.svg';
+  img.alt = pinned ? 'Unpin menu' : 'Pin menu';
+  entry.pinButton.setAttribute('aria-pressed', String(pinned));
+  entry.pinButton.title = pinned ? 'Unpin' : 'Pin';
+}
+
+function pinWindow(element: HTMLElement, column?: HTMLDivElement) {
+  if (!pinnedContainer || !appContainer) return;
+  if (isPinned(element)) return;
+  const rect = element.getBoundingClientRect();
+  element.dataset.floatLeft = element.style.left || `${rect.left}px`;
+  element.dataset.floatTop = element.style.top || `${rect.top}px`;
+  element.dataset.floatRight = element.style.right || '';
+  element.dataset.floatTransform = element.style.transform || '';
+  element.style.left = '';
+  element.style.top = '';
+  element.style.right = '';
+  element.style.transform = 'none';
+  element.style.position = 'relative';
+  setPinnedState(element, true);
+
+  let targetColumn = column;
+  if (!targetColumn) {
+    targetColumn = document.createElement('div');
+    targetColumn.className = 'pinned-column';
+    pinnedContainer.appendChild(targetColumn);
+  }
+  targetColumn.appendChild(element);
+  updatePinButtonState(element);
+  updatePinnedLayout();
+}
+
+function unpinWindow(element: HTMLElement) {
+  if (!appContainer) return;
+  if (!isPinned(element)) return;
+  const column = element.parentElement;
+  setPinnedState(element, false);
+  element.style.position = 'absolute';
+  element.style.left = element.dataset.floatLeft ?? element.style.left;
+  element.style.top = element.dataset.floatTop ?? element.style.top;
+  element.style.right = element.dataset.floatRight ?? '';
+  element.style.transform = element.dataset.floatTransform ?? 'none';
+  appContainer.appendChild(element);
+  if (column?.classList.contains('pinned-column') && column.children.length === 0) {
+    column.remove();
+  }
+  updatePinButtonState(element);
+  updatePinnedLayout();
+}
+
+function setPinnedState(element: HTMLElement, pinned: boolean) {
+  element.dataset.pinned = pinned ? 'true' : 'false';
+  element.classList.toggle('is-pinned', pinned);
+}
+
+function updatePinnedLayout() {
+  if (!pinnedContainer) return;
+  const columns = Array.from(pinnedContainer.querySelectorAll('.pinned-column')) as HTMLDivElement[];
+  const containerStyles = window.getComputedStyle(pinnedContainer);
+  const paddingLeft = parseFloat(containerStyles.paddingLeft || '0');
+  const paddingRight = parseFloat(containerStyles.paddingRight || '0');
+  const gapValue = parseFloat(containerStyles.columnGap || containerStyles.gap || `${PINNED_GAP_FALLBACK}`);
+  let totalWidth = paddingLeft + paddingRight;
+  const visibleColumns: Array<{ column: HTMLDivElement; width: number }> = [];
+  columns.forEach((column) => {
+    const children = Array.from(column.children) as HTMLElement[];
+    const visibleChildren = children.filter(child => window.getComputedStyle(child).display !== 'none');
+    if (visibleChildren.length === 0) {
+      column.style.display = 'none';
+      column.style.width = '0px';
+      return;
+    }
+    column.style.display = 'flex';
+    const maxWidth = visibleChildren.reduce((acc, child) => Math.max(acc, child.getBoundingClientRect().width), 0);
+    const columnWidth = Math.max(MIN_WINDOW_WIDTH, maxWidth);
+    column.style.width = `${columnWidth}px`;
+    visibleColumns.push({ column, width: columnWidth });
+  });
+  visibleColumns.forEach((entry, index) => {
+    totalWidth += entry.width;
+    if (index < visibleColumns.length - 1) {
+      totalWidth += gapValue;
+    }
+  });
+  document.documentElement.style.setProperty('--pinned-width', `${totalWidth}px`);
+  _updateLegendPosition();
+  updateFiltersPanelLayout();
+}
+
+function isPointInPinnedArea(x: number, y: number) {
+  if (!pinnedContainer) return false;
+  const rect = pinnedContainer.getBoundingClientRect();
+  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+}
+
+function getPinnedDropColumn(x: number, y: number) {
+  if (!pinnedContainer) return null;
+  const columns = Array.from(pinnedContainer.querySelectorAll('.pinned-column')) as HTMLDivElement[];
+  return columns.find(column => {
+    const rect = column.getBoundingClientRect();
+    return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+  }) ?? null;
 }


### PR DESCRIPTION
### Motivation
- Improve the VIZ app window chrome so panels can be pinned into the toolbar sidebar and resized by the user to better fit workflow needs.
- Prevent pinned panels from overlapping the map canvas by making them part of the chrome and pushing the map to the right via a shared pinned width variable.
- Provide a consistent affordance (thumbtack icon + lower-right resize grip / right-edge drag) across all existing windows including the floating legend.

### Description
- Added docking/pinning and resize plumbing in `viz/src/windows.ts` including `initWindowDocking`, `registerDockableWindow`, `enableWindowResizing`, pin/unpin logic, pinned layout calculation, and minimum width/height constants (`MIN_WINDOW_WIDTH`, `MIN_WINDOW_HEIGHT`).
- Updated `viz/src/main.ts` to expose the new DOM handles, initialize docking with `initWindowDocking`, register panels via `registerDockableWindow`, and enable resizing with `enableWindowResizing` for each window and the floating legend.
- Modified `viz/index.html` to add the pinned panels container (`#pinnedPanels`), per-window pin buttons (thumbtack/titled states), resize handles (`.window-resize-handle`, `.window-resize-edge`), shared CSS (`--pinned-width`) and map offset so pinned columns push the map right; also added `viz-window` class and small header chrome changes.
- Kept existing draggable behavior but avoid interfering with resize/pin UI and automatically unpin a window when its header is dragged.

### Testing
- Attempted `npm install` in `viz/` to run the dev build, but the install failed with a 403 Forbidden error when fetching `geoparquet`, so a dev server build/run could not be executed. (Automated install failed.)
- No other automated tests are present; local static inspections and TypeScript-aware edits were performed and the changes were committed to the repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69817bddb35c8326b0752ee0b8eab8e0)