### PR TITLE
Add adjustments panel to Land Schedule (UI, state, serialization, filters)

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -1075,6 +1075,73 @@
       gap: 8px;
     }
 
+    .land-adjustment-card {
+      border: 1px solid #e1e1e1;
+      border-radius: 10px;
+      padding: 10px;
+      background: #fff;
+      display: grid;
+      gap: 8px;
+    }
+
+    .land-adjustment-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .land-adjustment-header label {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      flex: 1;
+    }
+
+    .land-adjustment-delete {
+      border: none;
+      background: none;
+      color: #444;
+      width: 22px;
+      height: 22px;
+      border-radius: 5px;
+      cursor: pointer;
+    }
+
+    .land-adjustment-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+    }
+
+    .land-adjustment-row > span {
+      min-width: 72px;
+      font-weight: 600;
+    }
+
+    .land-adjustment-row select,
+    .land-adjustment-row input {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .land-adjustment-value {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex: 1;
+    }
+
+    .land-adjustment-value.is-multiply input {
+      text-align: center;
+    }
+
+    .land-adjustment-value-suffix {
+      font-weight: 600;
+      color: #374151;
+    }
+
     .land-schedule-curve {
       display: grid;
       gap: 6px;
@@ -1695,6 +1762,19 @@
               <div id="landScheduleCurveChart" class="land-schedule-curve-chart"></div>
             </div>
           </div>
+        </div>
+      </div>
+
+      <div class="divider"></div>
+
+      <div id="landScheduleAdjustmentsSection" class="land-schedule-section">
+        <div class="land-schedule-section-header">
+          <button id="landScheduleAdjustmentsToggle" class="land-schedule-collapse-toggle" type="button" title="Collapse Adjustments">▼</button>
+          <div class="land-schedule-subtitle">Adjustments</div>
+        </div>
+        <div id="landScheduleAdjustmentsContent" style="display: grid; gap: 10px;">
+          <div id="landScheduleAdjustmentsContainer" style="display: grid; gap: 10px;"></div>
+          <button id="landScheduleAddAdjustment" type="button" class="land-schedule-button">add adjustment</button>
         </div>
       </div>
     </div>

--- a/viz/index.html
+++ b/viz/index.html
@@ -1098,6 +1098,14 @@
       flex: 1;
     }
 
+    .land-adjustment-header .land-table-filter {
+      flex: 0 0 auto;
+    }
+
+    .land-adjustment-header .land-table-filter img {
+      opacity: 1;
+    }
+
     .land-adjustment-delete {
       border: none;
       background: none;
@@ -1120,6 +1128,10 @@
       font-weight: 600;
     }
 
+    .land-adjustment-row select {
+      min-width: 140px;
+    }
+
     .land-adjustment-row select,
     .land-adjustment-row input {
       flex: 1;
@@ -1131,6 +1143,10 @@
       align-items: center;
       gap: 6px;
       flex: 1;
+    }
+
+    .land-adjustment-value input {
+      min-width: 90px;
     }
 
     .land-adjustment-value.is-multiply input {

--- a/viz/src/land-schedule.ts
+++ b/viz/src/land-schedule.ts
@@ -591,20 +591,6 @@ function renderLandScheduleAdjustments(entry: LandScheduleEntry) {
     });
     nameLabel.appendChild(nameInput);
 
-    const deleteBtn = document.createElement('button');
-    deleteBtn.type = 'button';
-    deleteBtn.className = 'land-adjustment-delete';
-    deleteBtn.textContent = '×';
-    deleteBtn.title = 'Delete adjustment';
-    deleteBtn.addEventListener('click', () => {
-      entry.adjustments = entry.adjustments.filter(item => item.id !== adjustment.id);
-      renderLandScheduleAdjustments(entry);
-    });
-
-    header.append(nameLabel, deleteBtn);
-
-    const conditionsRow = document.createElement('div');
-    conditionsRow.className = 'land-adjustment-row';
     const conditionsBtn = document.createElement('button');
     conditionsBtn.type = 'button';
     conditionsBtn.className = 'land-table-filter';
@@ -627,7 +613,18 @@ function renderLandScheduleAdjustments(entry: LandScheduleEntry) {
       });
       showFiltersPanel?.();
     });
-    conditionsRow.appendChild(conditionsBtn);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'land-adjustment-delete';
+    deleteBtn.textContent = '❌';
+    deleteBtn.title = 'Delete adjustment';
+    deleteBtn.addEventListener('click', () => {
+      entry.adjustments = entry.adjustments.filter(item => item.id !== adjustment.id);
+      renderLandScheduleAdjustments(entry);
+    });
+
+    header.append(nameLabel, conditionsBtn, deleteBtn);
 
     const operationRow = document.createElement('div');
     operationRow.className = 'land-adjustment-row';
@@ -640,19 +637,6 @@ function renderLandScheduleAdjustments(entry: LandScheduleEntry) {
     operationSelect.value = adjustment.operation;
     operationRow.append(operationLabel, operationSelect);
 
-    const unitRow = document.createElement('div');
-    unitRow.className = 'land-adjustment-row';
-    const unitLabel = document.createElement('span');
-    unitLabel.textContent = 'Size unit:';
-    const unitSelect = document.createElement('select');
-    ADJUSTMENT_UNIT_OPTIONS.forEach(option => {
-      unitSelect.appendChild(new Option(option.label, option.value));
-    });
-    unitSelect.value = adjustment.sizeUnit;
-    unitRow.append(unitLabel, unitSelect);
-
-    const valueRow = document.createElement('div');
-    valueRow.className = 'land-adjustment-row';
     const valueLabel = document.createElement('span');
     valueLabel.textContent = 'Value:';
     const valueWrap = document.createElement('div');
@@ -665,7 +649,18 @@ function renderLandScheduleAdjustments(entry: LandScheduleEntry) {
     valueSuffix.className = 'land-adjustment-value-suffix';
     valueSuffix.textContent = 'x';
     valueWrap.append(valueInput, valueSuffix);
-    valueRow.append(valueLabel, valueWrap);
+    operationRow.append(valueLabel, valueWrap);
+
+    const unitRow = document.createElement('div');
+    unitRow.className = 'land-adjustment-row';
+    const unitLabel = document.createElement('span');
+    unitLabel.textContent = 'Size unit:';
+    const unitSelect = document.createElement('select');
+    ADJUSTMENT_UNIT_OPTIONS.forEach(option => {
+      unitSelect.appendChild(new Option(option.label, option.value));
+    });
+    unitSelect.value = adjustment.sizeUnit;
+    unitRow.append(unitLabel, unitSelect);
 
     const syncValueUI = () => {
       const isMultiply = adjustment.operation === 'multiply';
@@ -692,7 +687,7 @@ function renderLandScheduleAdjustments(entry: LandScheduleEntry) {
 
     syncValueUI();
 
-    card.append(header, conditionsRow, operationRow, unitRow, valueRow);
+    card.append(header, operationRow, unitRow);
     landScheduleAdjustmentsContainer.appendChild(card);
   });
 }

--- a/viz/src/land-schedule.ts
+++ b/viz/src/land-schedule.ts
@@ -8,6 +8,9 @@ import { getCategoricalValues } from './filters';
 import { setFiltersContext, cloneFilters, invalidateFiltersContextIf } from './filters';
 import type {
   FilterRule,
+  LandScheduleAdjustment,
+  LandScheduleAdjustmentOperation,
+  LandScheduleAdjustmentSizeUnit,
   LandScheduleEntry,
   LandScheduleRow,
   LandScheduleTable,
@@ -22,6 +25,17 @@ const UNIT_OPTIONS: Array<{ value: LandScheduleUnit; label: string; header: stri
   { value: 'sqm', label: 'area (sqm)', header: 'sqm' },
   { value: 'hectare', label: 'area (hectare)', header: 'hectare' },
   { value: 'm', label: 'frontage (m)', header: 'm' },
+];
+
+const ADJUSTMENT_OPERATION_OPTIONS: Array<{ value: LandScheduleAdjustmentOperation; label: string }> = [
+  { value: 'multiply', label: 'Multiply' },
+  { value: 'add', label: 'Add' },
+];
+
+const ADJUSTMENT_UNIT_OPTIONS: Array<{ value: LandScheduleAdjustmentSizeUnit; label: string }> = [
+  { value: 'area', label: 'Per area (sqft/acre or sqm/hectare)' },
+  { value: 'frontage', label: 'Frontage (feet or meters)' },
+  { value: 'flat', label: 'Flat amount (no unit)' },
 ];
 
 const FILTER_ICON = new URL('./svg/filters.svg', import.meta.url).href;
@@ -39,6 +53,9 @@ let landScheduleAddTableButton: HTMLButtonElement;
 let landScheduleTableContainer: HTMLDivElement;
 let landScheduleCurveChart: HTMLDivElement;
 let landScheduleTablesSection: HTMLDivElement;
+let landScheduleAdjustmentsSection: HTMLDivElement;
+let landScheduleAdjustmentsContainer: HTMLDivElement;
+let landScheduleAddAdjustmentButton: HTMLButtonElement;
 let landScheduleFilterButton: HTMLButtonElement | null = null;
 
 let showFiltersPanel: (() => void) | null = null;
@@ -53,6 +70,9 @@ export function initLandScheduleElements(els: {
   landScheduleTableContainer: HTMLDivElement;
   landScheduleCurveChart: HTMLDivElement;
   landScheduleTablesSection: HTMLDivElement;
+  landScheduleAdjustmentsSection: HTMLDivElement;
+  landScheduleAdjustmentsContainer: HTMLDivElement;
+  landScheduleAddAdjustmentButton: HTMLButtonElement;
 }) {
   landScheduleFieldSelect = els.landScheduleFieldSelect;
   landScheduleValueSelect = els.landScheduleValueSelect;
@@ -63,6 +83,9 @@ export function initLandScheduleElements(els: {
   landScheduleTableContainer = els.landScheduleTableContainer;
   landScheduleCurveChart = els.landScheduleCurveChart;
   landScheduleTablesSection = els.landScheduleTablesSection;
+  landScheduleAdjustmentsSection = els.landScheduleAdjustmentsSection;
+  landScheduleAdjustmentsContainer = els.landScheduleAdjustmentsContainer;
+  landScheduleAddAdjustmentButton = els.landScheduleAddAdjustmentButton;
 }
 
 export function initLandScheduleCallbacks(cbs: { showFiltersPanel?: () => void }) {
@@ -84,6 +107,7 @@ function getLandScheduleEntry(field: string, valueKey: string): LandScheduleEntr
     entry = {
       tables: [],
       activeTableId: null,
+      adjustments: [],
     };
     fieldMap.set(valueKey, entry);
   }
@@ -242,11 +266,21 @@ function hasActiveTableFilters(table: LandScheduleTable) {
   return table.filters.some(filter => filter.active);
 }
 
+function hasActiveAdjustmentFilters(adjustment: LandScheduleAdjustment) {
+  return adjustment.filters.some(filter => filter.active);
+}
+
 function updateLandScheduleFilterButtonState(table: LandScheduleTable | null) {
   if (!landScheduleFilterButton) return;
   const isActive = table ? hasActiveTableFilters(table) : false;
   landScheduleFilterButton.classList.toggle('is-active', isActive);
   landScheduleFilterButton.classList.toggle('is-muted', !isActive);
+}
+
+function updateAdjustmentFilterButtonState(button: HTMLButtonElement, adjustment: LandScheduleAdjustment) {
+  const isActive = hasActiveAdjustmentFilters(adjustment);
+  button.classList.toggle('is-active', isActive);
+  button.classList.toggle('is-muted', !isActive);
 }
 
 function createTableRow(table: LandScheduleTable, rowIndex: number, tbody: HTMLTableSectionElement) {
@@ -536,6 +570,133 @@ function renderActiveTable(entry: LandScheduleEntry) {
   updateLandScheduleCurve(activeTable);
 }
 
+function renderLandScheduleAdjustments(entry: LandScheduleEntry) {
+  landScheduleAdjustmentsContainer.replaceChildren();
+  entry.adjustments = entry.adjustments ?? [];
+
+  entry.adjustments.forEach(adjustment => {
+    const card = document.createElement('div');
+    card.className = 'land-adjustment-card';
+    card.dataset.adjustmentId = adjustment.id;
+
+    const header = document.createElement('div');
+    header.className = 'land-adjustment-header';
+    const nameLabel = document.createElement('label');
+    nameLabel.textContent = 'Name:';
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.value = adjustment.name;
+    nameInput.addEventListener('input', () => {
+      adjustment.name = nameInput.value;
+    });
+    nameLabel.appendChild(nameInput);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'land-adjustment-delete';
+    deleteBtn.textContent = '×';
+    deleteBtn.title = 'Delete adjustment';
+    deleteBtn.addEventListener('click', () => {
+      entry.adjustments = entry.adjustments.filter(item => item.id !== adjustment.id);
+      renderLandScheduleAdjustments(entry);
+    });
+
+    header.append(nameLabel, deleteBtn);
+
+    const conditionsRow = document.createElement('div');
+    conditionsRow.className = 'land-adjustment-row';
+    const conditionsBtn = document.createElement('button');
+    conditionsBtn.type = 'button';
+    conditionsBtn.className = 'land-table-filter';
+    conditionsBtn.title = 'Conditions';
+    conditionsBtn.innerHTML = `<img src="${FILTER_ICON}" alt="Filters" /> Conditions`;
+    updateAdjustmentFilterButtonState(conditionsBtn, adjustment);
+    const adjustmentContextKey = `adj:${S.currentLandScheduleField ?? ''}:${S.currentLandScheduleValue ?? ''}:${adjustment.id}`;
+    conditionsBtn.addEventListener('click', () => {
+      setFiltersContext({
+        type: 'landSchedule',
+        getFilters: () => adjustment.filters,
+        getFilterInvert: () => adjustment.filterInvert,
+        setFilters: (filters: FilterRule[], filterInvert: boolean) => {
+          adjustment.filters = cloneFilters(filters);
+          adjustment.filterInvert = filterInvert;
+          updateAdjustmentFilterButtonState(conditionsBtn, adjustment);
+        },
+        label: `Land schedule adjustment: ${S.currentLandScheduleField ?? '—'} = ${S.currentLandScheduleValue ?? '—'} / ${adjustment.name || 'Untitled adjustment'}`,
+        key: adjustmentContextKey,
+      });
+      showFiltersPanel?.();
+    });
+    conditionsRow.appendChild(conditionsBtn);
+
+    const operationRow = document.createElement('div');
+    operationRow.className = 'land-adjustment-row';
+    const operationLabel = document.createElement('span');
+    operationLabel.textContent = 'Operation:';
+    const operationSelect = document.createElement('select');
+    ADJUSTMENT_OPERATION_OPTIONS.forEach(option => {
+      operationSelect.appendChild(new Option(option.label, option.value));
+    });
+    operationSelect.value = adjustment.operation;
+    operationRow.append(operationLabel, operationSelect);
+
+    const unitRow = document.createElement('div');
+    unitRow.className = 'land-adjustment-row';
+    const unitLabel = document.createElement('span');
+    unitLabel.textContent = 'Size unit:';
+    const unitSelect = document.createElement('select');
+    ADJUSTMENT_UNIT_OPTIONS.forEach(option => {
+      unitSelect.appendChild(new Option(option.label, option.value));
+    });
+    unitSelect.value = adjustment.sizeUnit;
+    unitRow.append(unitLabel, unitSelect);
+
+    const valueRow = document.createElement('div');
+    valueRow.className = 'land-adjustment-row';
+    const valueLabel = document.createElement('span');
+    valueLabel.textContent = 'Value:';
+    const valueWrap = document.createElement('div');
+    valueWrap.className = 'land-adjustment-value';
+    const valueInput = document.createElement('input');
+    valueInput.type = 'number';
+    valueInput.inputMode = 'decimal';
+    valueInput.step = '0.01';
+    const valueSuffix = document.createElement('span');
+    valueSuffix.className = 'land-adjustment-value-suffix';
+    valueSuffix.textContent = 'x';
+    valueWrap.append(valueInput, valueSuffix);
+    valueRow.append(valueLabel, valueWrap);
+
+    const syncValueUI = () => {
+      const isMultiply = adjustment.operation === 'multiply';
+      valueWrap.classList.toggle('is-multiply', isMultiply);
+      valueSuffix.style.display = isMultiply ? 'inline-flex' : 'none';
+      if (isMultiply && adjustment.value === null) {
+        adjustment.value = 1;
+      }
+      setLandScheduleInputValue(valueInput, adjustment.value);
+    };
+
+    operationSelect.addEventListener('change', () => {
+      adjustment.operation = operationSelect.value as LandScheduleAdjustmentOperation;
+      syncValueUI();
+    });
+
+    unitSelect.addEventListener('change', () => {
+      adjustment.sizeUnit = unitSelect.value as LandScheduleAdjustmentSizeUnit;
+    });
+
+    valueInput.addEventListener('input', () => {
+      adjustment.value = parseOptionalNumber(valueInput.value);
+    });
+
+    syncValueUI();
+
+    card.append(header, conditionsRow, operationRow, unitRow, valueRow);
+    landScheduleAdjustmentsContainer.appendChild(card);
+  });
+}
+
 /* ------------------------------------------------------------------ */
 /*  Exported functions                                                */
 /* ------------------------------------------------------------------ */
@@ -572,12 +733,17 @@ export function renderLandScheduleTables() {
   const entry = getCurrentEntry();
   landScheduleTableContainer.replaceChildren();
   landScheduleFilterButton = null;
+  landScheduleAdjustmentsContainer.replaceChildren();
 
   invalidateFiltersContextIf(context => {
     if (context.type !== 'landSchedule') return false;
     if (!entry) return true;
+    const baseKey = `${S.currentLandScheduleField ?? ''}:${S.currentLandScheduleValue ?? ''}:`;
+    if (context.key?.startsWith('adj:')) {
+      return !context.key.startsWith(`adj:${baseKey}`);
+    }
     const activeId = entry.activeTableId ?? '';
-    const expectedKey = `${S.currentLandScheduleField ?? ''}:${S.currentLandScheduleValue ?? ''}:${activeId}`;
+    const expectedKey = `${baseKey}${activeId}`;
     return context.key !== expectedKey;
   });
 
@@ -585,23 +751,28 @@ export function renderLandScheduleTables() {
     landScheduleTablesSection.style.display = 'none';
     landScheduleTableSelectRow.style.display = 'none';
     landScheduleAddTableButton.disabled = true;
+    landScheduleAdjustmentsSection.style.display = 'none';
+    landScheduleAddAdjustmentButton.disabled = true;
     updateLandScheduleCurve(null);
     return;
   }
 
   landScheduleTablesSection.style.display = 'grid';
   landScheduleAddTableButton.disabled = false;
+  landScheduleAdjustmentsSection.style.display = 'grid';
+  landScheduleAddAdjustmentButton.disabled = false;
 
   if (entry.tables.length === 0) {
     landScheduleTableSelectRow.style.display = 'none';
     landScheduleTableContainer.appendChild(landScheduleAddTableButton);
     updateLandScheduleCurve(null);
-    return;
+  } else {
+    landScheduleTableSelectRow.style.display = 'flex';
+    renderTableSelectOptions(entry);
+    renderActiveTable(entry);
   }
 
-  landScheduleTableSelectRow.style.display = 'flex';
-  renderTableSelectOptions(entry);
-  renderActiveTable(entry);
+  renderLandScheduleAdjustments(entry);
 }
 
 export function addLandScheduleTable() {
@@ -620,6 +791,23 @@ export function addLandScheduleTable() {
   entry.tables.push(newTable);
   entry.activeTableId = newTable.id;
   renderLandScheduleTables();
+}
+
+export function addLandScheduleAdjustment() {
+  const entry = getCurrentEntry();
+  if (!entry) return;
+  const nextIndex = entry.adjustments.length + 1;
+  const newAdjustment: LandScheduleAdjustment = {
+    id: `adj-${Date.now()}-${Math.floor(Math.random() * 1000)}`,
+    name: `Adjustment ${nextIndex}`,
+    operation: 'add',
+    sizeUnit: 'flat',
+    value: null,
+    filters: [],
+    filterInvert: false,
+  };
+  entry.adjustments.push(newAdjustment);
+  renderLandScheduleAdjustments(entry);
 }
 
 export function setActiveLandScheduleTable(tableId: string | null) {

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -113,6 +113,7 @@ import {
   getMultiplierValue, getUnitFactor, getOpacityValue,
 } from './rendering';
 import {
+  addLandScheduleAdjustment,
   addLandScheduleTable,
   initLandScheduleCallbacks,
   initLandScheduleElements,
@@ -409,6 +410,11 @@ const landScheduleTablesContent = document.getElementById('landScheduleTablesCon
 const landScheduleCurveToggle = document.getElementById('landScheduleCurveToggle') as HTMLButtonElement;
 const landScheduleCurveContent = document.getElementById('landScheduleCurveContent') as HTMLDivElement;
 const landScheduleCurveChart = document.getElementById('landScheduleCurveChart') as HTMLDivElement;
+const landScheduleAdjustmentsSection = document.getElementById('landScheduleAdjustmentsSection') as HTMLDivElement;
+const landScheduleAdjustmentsToggle = document.getElementById('landScheduleAdjustmentsToggle') as HTMLButtonElement;
+const landScheduleAdjustmentsContent = document.getElementById('landScheduleAdjustmentsContent') as HTMLDivElement;
+const landScheduleAdjustmentsContainer = document.getElementById('landScheduleAdjustmentsContainer') as HTMLDivElement;
+const landScheduleAddAdjustmentButton = document.getElementById('landScheduleAddAdjustment') as HTMLButtonElement;
 
 const EYE_ICON_OPEN = new URL('./svg/eye.svg', import.meta.url).href;
 const EYE_ICON_CLOSED = new URL('./svg/eye_closed.svg', import.meta.url).href;
@@ -520,8 +526,17 @@ const setLandScheduleCurveCollapsed = (collapsed: boolean) => {
   refreshWindowMinHeight(landScheduleControlsEl);
 };
 
+const setLandScheduleAdjustmentsCollapsed = (collapsed: boolean) => {
+  S.isLandScheduleAdjustmentsCollapsed = collapsed;
+  landScheduleAdjustmentsContent.style.display = collapsed ? 'none' : 'grid';
+  landScheduleAdjustmentsToggle.classList.toggle('is-collapsed', collapsed);
+  landScheduleAdjustmentsToggle.title = collapsed ? 'Expand Adjustments' : 'Collapse Adjustments';
+  refreshWindowMinHeight(landScheduleControlsEl);
+};
+
 setLandScheduleTablesCollapsed(S.isLandScheduleTablesCollapsed);
 setLandScheduleCurveCollapsed(S.isLandScheduleCurveCollapsed);
+setLandScheduleAdjustmentsCollapsed(S.isLandScheduleAdjustmentsCollapsed);
 
 landScheduleTablesToggle.addEventListener('click', () => {
   setLandScheduleTablesCollapsed(!S.isLandScheduleTablesCollapsed);
@@ -529,6 +544,10 @@ landScheduleTablesToggle.addEventListener('click', () => {
 
 landScheduleCurveToggle.addEventListener('click', () => {
   setLandScheduleCurveCollapsed(!S.isLandScheduleCurveCollapsed);
+});
+
+landScheduleAdjustmentsToggle.addEventListener('click', () => {
+  setLandScheduleAdjustmentsCollapsed(!S.isLandScheduleAdjustmentsCollapsed);
 });
 
 // Color ramp choices
@@ -884,6 +903,9 @@ initLandScheduleElements({
   landScheduleTableContainer,
   landScheduleCurveChart,
   landScheduleTablesSection,
+  landScheduleAdjustmentsSection,
+  landScheduleAdjustmentsContainer,
+  landScheduleAddAdjustmentButton,
 });
 initLandScheduleCallbacks({
   showFiltersPanel: showFilters,
@@ -1891,6 +1913,10 @@ landScheduleValueSelect.addEventListener('change', () => {
 
 landScheduleAddTableButton.addEventListener('click', () => {
   addLandScheduleTable();
+});
+
+landScheduleAddAdjustmentButton.addEventListener('click', () => {
+  addLandScheduleAdjustment();
 });
 
 landScheduleTableSelect.addEventListener('change', () => {

--- a/viz/src/metadata.ts
+++ b/viz/src/metadata.ts
@@ -9,6 +9,7 @@ import type {
   SerializedDataSource,
   SerializedLayer,
   SerializedLandScheduleEntry,
+  SerializedLandScheduleAdjustment,
   SerializedLandScheduleTable
 } from './types.js';
 import { persistCurrentLayerState, renderDataStoreList, renderLayerList, registerLayer, applyLayerState, applyLayerOrderToMap } from './layers.js';
@@ -89,11 +90,21 @@ function serializeLandSchedules(): SerializedLandScheduleEntry[] {
         filters: cloneFilters(table.filters ?? []),
         filterInvert: table.filterInvert ?? false,
       }));
+      const adjustments: SerializedLandScheduleAdjustment[] = (entry.adjustments ?? []).map(adjustment => ({
+        id: adjustment.id,
+        name: adjustment.name,
+        operation: adjustment.operation,
+        sizeUnit: adjustment.sizeUnit,
+        value: adjustment.value,
+        filters: cloneFilters(adjustment.filters ?? []),
+        filterInvert: adjustment.filterInvert ?? false,
+      }));
       result.push({
         field,
         valueKey,
         tables,
         activeTableId: entry.activeTableId,
+        adjustments,
       });
     });
   });
@@ -276,6 +287,15 @@ export async function loadProjectFile(file: File) {
             filterInvert: table.filterInvert ?? false,
           })),
           activeTableId: entry.activeTableId,
+          adjustments: (entry.adjustments ?? []).map(adjustment => ({
+            id: adjustment.id,
+            name: adjustment.name,
+            operation: adjustment.operation ?? 'add',
+            sizeUnit: adjustment.sizeUnit ?? 'flat',
+            value: adjustment.value ?? null,
+            filters: adjustment.filters.map(f => ({ ...f })),
+            filterInvert: adjustment.filterInvert ?? false,
+          })),
         });
       });
     }

--- a/viz/src/state.ts
+++ b/viz/src/state.ts
@@ -87,6 +87,7 @@ export const S = {
   isLandScheduleMinimized: true,
   isLandScheduleTablesCollapsed: false,
   isLandScheduleCurveCollapsed: false,
+  isLandScheduleAdjustmentsCollapsed: false,
   hiddenLegendItems: new Set<string>(),
 
   // --- Statistics ---

--- a/viz/src/types.ts
+++ b/viz/src/types.ts
@@ -57,6 +57,20 @@ export type LandScheduleRow = {
   value: number | null;
 };
 
+export type LandScheduleAdjustmentOperation = 'multiply' | 'add';
+
+export type LandScheduleAdjustmentSizeUnit = 'area' | 'frontage' | 'flat';
+
+export type LandScheduleAdjustment = {
+  id: string;
+  name: string;
+  operation: LandScheduleAdjustmentOperation;
+  sizeUnit: LandScheduleAdjustmentSizeUnit;
+  value: number | null;
+  filters: FilterRule[];
+  filterInvert: boolean;
+};
+
 export type LandScheduleTable = {
   id: string;
   name: string;
@@ -70,6 +84,7 @@ export type LandScheduleTable = {
 export type LandScheduleEntry = {
   tables: LandScheduleTable[];
   activeTableId: string | null;
+  adjustments: LandScheduleAdjustment[];
 };
 
 export type LandScheduleStore = Map<string, Map<string, LandScheduleEntry>>;
@@ -206,9 +221,20 @@ export type SerializedLandScheduleTable = {
   filterInvert: boolean;
 };
 
+export type SerializedLandScheduleAdjustment = {
+  id: string;
+  name: string;
+  operation: LandScheduleAdjustmentOperation;
+  sizeUnit: LandScheduleAdjustmentSizeUnit;
+  value: number | null;
+  filters: FilterRule[];
+  filterInvert: boolean;
+};
+
 export type SerializedLandScheduleEntry = {
   field: string;
   valueKey: string;
   tables: SerializedLandScheduleTable[];
   activeTableId: string | null;
+  adjustments: SerializedLandScheduleAdjustment[];
 };


### PR DESCRIPTION
### Motivation
- Provide a configurable "Adjustments" area below Land Schedule tables so users can add per-value adjustments with conditions, operation type, size unit and numeric value.
- Integrate adjustments with the existing filters UI so adjustments can be targeted to subsets of parcels, and persist adjustments in project files.

### Description
- Added adjustment types and serialization types in `viz/src/types.ts` including `LandScheduleAdjustment`, `LandScheduleAdjustmentOperation`, `LandScheduleAdjustmentSizeUnit` and matching `SerializedLandScheduleAdjustment` entries.
- Tracked adjustments UI collapse state in `viz/src/state.ts` via `isLandScheduleAdjustmentsCollapsed` and hooked a new collapse toggle behavior in `viz/src/main.ts` with DOM wiring for `landScheduleAdjustments*` elements and the `add adjustment` button.
- Implemented UI markup and styling in `viz/index.html` for the Adjustments section and cards, and added CSS rules for adjustment cards, rows and value modes.
- Implemented adjustment rendering, add/delete behavior, control bindings and filter integration in `viz/src/land-schedule.ts` (new `renderLandScheduleAdjustments`, `addLandScheduleAdjustment`, filter button wiring, operation/unit/value controls, and filter-context key namespaced with `adj:`).
- Persisted adjustments to project files and restored them on load in `viz/src/metadata.ts` by serializing/deserializing adjustment objects alongside tables.

### Testing
- Performed a headless browser smoke attempt by launching a local HTTP server and running a Playwright script to capture a screenshot of the Land Schedule panel, but the Playwright run timed out and the smoke test failed.
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982b2f653c4832694feb48e195dfb58)