### PR TITLE
Fix GeoParquet 3D polygon fallback parsing

### DIFF
--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -1087,6 +1087,65 @@ function toUint8Array(data: unknown): Uint8Array | null {
   return null;
 }
 
+function hexToUint8Array(hex: string): Uint8Array | null {
+  const cleaned = hex.trim().replace(/^0x/i, '');
+  if (!/^[0-9a-fA-F]+$/.test(cleaned) || cleaned.length % 2 !== 0) return null;
+  const bytes = new Uint8Array(cleaned.length / 2);
+  for (let i = 0; i < cleaned.length; i += 2) {
+    bytes[i / 2] = parseInt(cleaned.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function stripZFromPolygonCoords(coords: any): number[][][] | null {
+  if (!Array.isArray(coords)) return null;
+  return coords.map((ring: any) =>
+    Array.isArray(ring)
+      ? ring.map((pt: any) => (Array.isArray(pt) ? [pt[0], pt[1]] : pt))
+      : ring
+  ) as number[][][];
+}
+
+function stripZFromMultiPolygonCoords(coords: any): number[][][][] | null {
+  if (!Array.isArray(coords)) return null;
+  return coords.map((poly: any) =>
+    Array.isArray(poly)
+      ? poly.map((ring: any) =>
+          Array.isArray(ring) ? ring.map((pt: any) => (Array.isArray(pt) ? [pt[0], pt[1]] : pt)) : ring
+        )
+      : poly
+  ) as number[][][][];
+}
+
+function normalizeGeometry(raw: any): GeoJSON.Geometry | null {
+  if (!raw) return null;
+  const geometry = raw?.type === 'Feature' && raw?.geometry ? raw.geometry : raw;
+  if (!geometry?.type || !geometry?.coordinates) return null;
+  if (geometry.type === 'Polygon') {
+    const coords = stripZFromPolygonCoords(geometry.coordinates);
+    if (!coords) return null;
+    return { type: 'Polygon', coordinates: coords };
+  }
+  if (geometry.type === 'MultiPolygon') {
+    const coords = stripZFromMultiPolygonCoords(geometry.coordinates);
+    if (!coords) return null;
+    return { type: 'MultiPolygon', coordinates: coords };
+  }
+  return null;
+}
+
+function parseRowGeometry(raw: any): GeoJSON.Geometry | null {
+  if (!raw) return null;
+  const bytes = toUint8Array(raw) ?? (typeof raw === 'string' ? hexToUint8Array(raw) : null);
+  if (bytes) return parseWkbGeometry2d(bytes);
+  if (typeof raw === 'string') {
+    try {
+      return normalizeGeometry(JSON.parse(raw));
+    } catch {}
+  }
+  return normalizeGeometry(raw);
+}
+
 function parseWkbGeometry2d(data: Uint8Array): GeoJSON.Geometry | null {
   const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
 
@@ -1202,9 +1261,7 @@ async function toGeoJsonFlatteningZ(file: AsyncBuffer): Promise<GeoJSON.FeatureC
 
   const features: GeoJSON.Feature[] = [];
   rows.forEach((row: Record<string, any>, index: number) => {
-    const geomBytes = toUint8Array(row?.[primaryGeom]);
-    if (!geomBytes) return;
-    const geometry = parseWkbGeometry2d(geomBytes);
+    const geometry = parseRowGeometry(row?.[primaryGeom]);
     if (!geometry || (geometry.type !== 'Polygon' && geometry.type !== 'MultiPolygon')) return;
     const properties: Record<string, any> = {};
     for (const [key, value] of Object.entries(row)) {


### PR DESCRIPTION
### Motivation
- The GeoParquet fallback path previously only attempted to parse geometry as raw WKB bytes, which failed when rows contained hex strings or GeoJSON objects and produced empty/errored results for 3D polygons (geometry type 1006).
- We need a robust fallback that accepts WKB, hex-encoded WKB, and GeoJSON-like values and strips Z coordinates from polygon geometries so 3D polygons can be flattened to 2D without throwing.

### Description
- Added `hexToUint8Array` to decode hex-encoded WKB strings to bytes for WKB parsing.
- Added `stripZFromPolygonCoords` and `stripZFromMultiPolygonCoords` to remove Z values from polygon/multipolygon coordinates.
- Added `normalizeGeometry` to coerce GeoJSON-like objects (or Feature wrappers) into valid 2D `Polygon`/`MultiPolygon` geometries with Z stripped.
- Added `parseRowGeometry` to accept a row geometry value and decode it as raw WKB bytes, hex WKB, JSON string, or GeoJSON object and return a normalized 2D geometry; replaced the previous direct WKB-only handling in the fallback `toGeoJsonFlatteningZ` with this function.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698383d6b038832685dc85e68d13fc5c)