### PR TITLE
Harden GeoParquet 3D geometry parsing

### DIFF
--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -1084,6 +1084,12 @@ function toUint8Array(data: unknown): Uint8Array | null {
   if (ArrayBuffer.isView(data)) {
     return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
   }
+  if (Array.isArray(data) && data.every((value) => typeof value === 'number')) {
+    return Uint8Array.from(data);
+  }
+  if (typeof data === 'object' && data !== null && Array.isArray((data as any).data)) {
+    return Uint8Array.from((data as any).data);
+  }
   return null;
 }
 
@@ -1121,12 +1127,12 @@ function normalizeGeometry(raw: any): GeoJSON.Geometry | null {
   if (!raw) return null;
   const geometry = raw?.type === 'Feature' && raw?.geometry ? raw.geometry : raw;
   if (!geometry?.type || !geometry?.coordinates) return null;
-  if (geometry.type === 'Polygon') {
+  if (geometry.type === 'Polygon' || geometry.type === 'PolygonZ') {
     const coords = stripZFromPolygonCoords(geometry.coordinates);
     if (!coords) return null;
     return { type: 'Polygon', coordinates: coords };
   }
-  if (geometry.type === 'MultiPolygon') {
+  if (geometry.type === 'MultiPolygon' || geometry.type === 'MultiPolygonZ') {
     const coords = stripZFromMultiPolygonCoords(geometry.coordinates);
     if (!coords) return null;
     return { type: 'MultiPolygon', coordinates: coords };
@@ -1156,8 +1162,16 @@ function parseWkbGeometry2d(data: Uint8Array): GeoJSON.Geometry | null {
     const littleEndian = byteOrder === 1;
     let type = view.getUint32(offset, littleEndian);
     offset += 4;
-    const hasZ = type >= 1000;
-    if (hasZ) type -= 1000;
+    const hasZFlag = (type & 0x80000000) !== 0;
+    const hasMFlag = (type & 0x40000000) !== 0;
+    const hasSrid = (type & 0x20000000) !== 0;
+    if (hasZFlag || hasMFlag || hasSrid) {
+      type = type & 0x1fffffff;
+    }
+    const hasZ = hasZFlag || type >= 1000;
+    const hasM = hasMFlag;
+    if (type >= 1000) type -= 1000;
+    if (hasSrid) offset += 4;
 
     const readUInt32 = () => {
       const value = view.getUint32(offset, littleEndian);
@@ -1173,6 +1187,7 @@ function parseWkbGeometry2d(data: Uint8Array): GeoJSON.Geometry | null {
       const x = readDouble();
       const y = readDouble();
       if (hasZ) readDouble();
+      if (hasM) readDouble();
       return [x, y];
     };
 


### PR DESCRIPTION
### Motivation
- GeoParquet inputs that include Z/M or use EWKB-style type flags (e.g. geometry type 1006) were producing parser errors and failing to load; the parser needs to accept more buffer-like shapes and EWKB encodings.
- The change aims to robustly support 3D Polygon/MultiPolygon payloads coming from various parquet/WKB encodings so files with Z/M coordinates load correctly.

### Description
- Extended `toUint8Array` to accept plain numeric arrays and objects with a `.data` array so buffer-like values from various readers are handled (`toUint8Array`).
- Made `normalizeGeometry` accept `PolygonZ` and `MultiPolygonZ` typed geometries and strip Z values from coordinates while returning 2D `Polygon`/`MultiPolygon` objects.
- Enhanced `parseWkbGeometry2d` to recognize EWKB-style flags (Z/M/SRID), strip flag bits from the type code, consume an optional SRID field, and correctly ignore Z and M ordinates when building 2D points.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698389ec1a688326a555c51a78a8d1cf)