### PR TITLE
Fix comp-finder criteria/comps section vertical anchoring

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -1336,7 +1336,7 @@
 
     #compFinderContent {
       display: grid;
-      grid-template-rows: auto minmax(0, 1fr);
+      grid-auto-rows: max-content;
       align-content: start;
       min-height: 0;
       height: 100%;


### PR DESCRIPTION
### Motivation
- Prevent large blank vertical gaps between the *Criteria* and *Comps* subsections in the comp-finder so the **Comps** section always appears immediately under **Criteria** in any collapsed/expanded combination.

### Description
- Replace the flexible second grid row for `#compFinderContent` with auto-sized rows by changing `grid-template-rows: auto minmax(0, 1fr)` to `grid-auto-rows: max-content` in `viz/index.html`, ensuring sections size to their content and stack without gaps.

### Testing
- Started a local static server (`python3 -m http.server 8000`) and rendered the comp-finder UI, then captured a verification screenshot with a headless browser (artifact: `artifacts/comp-finder-collapsed.png`), which shows the collapsed layout correctly stacked; this succeeded.
- Attempted `npm --prefix viz run build`, which failed because `vite` is unavailable in the environment; `npm --prefix viz install` also failed due to registry access (`403 Forbidden`), so a full production build could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698cda364bb0832697be2883f3410662)