### PR TITLE
Fix COMP-FINDER categorical criteria to follow selected subject

### DIFF
--- a/viz/src/comp-finder.ts
+++ b/viz/src/comp-finder.ts
@@ -976,6 +976,17 @@ function syncCriteriaFields() {
   extraFields = extraFields.filter((row) => available.has(row.field));
 }
 
+function syncCategoricalCriteriaToSubject() {
+  if (!subject) return;
+  criteria.forEach((row) => {
+    if (row.fieldType !== 'categorical' || !row.field) return;
+    const subjectValue = getFieldValue(subject.feature, row.field);
+    row.value = (subjectValue === null || subjectValue === undefined || subjectValue === '')
+      ? []
+      : [String(subjectValue)];
+  });
+}
+
 function ensureDefaultCriteria(store: DataStore) {
   if (criteria.length > 0 || !subject) return;
   const defaults = [
@@ -1055,6 +1066,7 @@ export function setCompFinderSubject(feature: GeoJSON.Feature, layerId: string) 
 
   ensureDefaultCriteria(store);
   syncCriteriaFields();
+  syncCategoricalCriteriaToSubject();
   renderCriteriaTable();
   resetComps();
   updateMapArtifacts();


### PR DESCRIPTION
### Motivation
- The categorical multi-selector in the COMP-FINDER was not updating when the user selected a new subject, causing the categorical criterion to remain set to the previous subject's value instead of the newly selected subject.

### Description
- Added `syncCategoricalCriteriaToSubject()` to `viz/src/comp-finder.ts` to reset each categorical criterion's `value` to the currently selected subject's field value.
- Call `syncCategoricalCriteriaToSubject()` from `setCompFinderSubject(...)` (after compatibility checks and `syncCriteriaFields()`) so categorical multi-select criteria reflect the newly selected subject immediately.

### Testing
- Attempted to build the viz app with `npm run build` in `viz/`, but the build failed in this environment because `vite` is not installed (`sh: 1: vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ce7ec7a8483268e8ddbba886436b7)