### PR TITLE
Replace VIZ floating menu close chevrons with X icons

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -1937,7 +1937,7 @@
           <button id="btnPinLayers" class="window-pin" type="button" title="Pin" aria-pressed="false">
             <img alt="Pin menu" />
           </button>
-          <button id="btnMinimizeLayers" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+          <button id="btnMinimizeLayers" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Close">
             ❌
 		  </button>
         </div>
@@ -2107,7 +2107,7 @@
         <button id="btnPinSettings" class="window-pin" type="button" title="Pin" aria-pressed="false">
           <img alt="Pin menu" />
         </button>
-        <button id="btnMinimizeSettingsMenu" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+        <button id="btnMinimizeSettingsMenu" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Close">
           ❌
         </button>
       </div>
@@ -2158,7 +2158,7 @@
         <button id="btnPinFilters" class="window-pin" type="button" title="Pin" aria-pressed="false">
           <img alt="Pin menu" />
         </button>
-        <button id="btnMinimizeFilters" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+        <button id="btnMinimizeFilters" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Close">
           ❌
         </button>
       </div>
@@ -2210,7 +2210,7 @@
         <button id="btnPinStatistics" class="window-pin" type="button" title="Pin" aria-pressed="false">
           <img alt="Pin menu" />
         </button>
-        <button id="btnMinimizeStatistics" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+        <button id="btnMinimizeStatistics" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Close">
           ❌
         </button>
       </div>
@@ -2329,7 +2329,7 @@
         <button id="btnPinScatterplot" class="window-pin" type="button" title="Pin" aria-pressed="false">
           <img alt="Pin menu" />
         </button>
-        <button id="btnMinimizeScatterplot" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+        <button id="btnMinimizeScatterplot" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Close">
           ❌
         </button>
       </div>
@@ -2416,7 +2416,7 @@
         <button id="btnPinCompFinder" class="window-pin" type="button" title="Pin" aria-pressed="false">
           <img alt="Pin menu" />
         </button>
-        <button id="btnMinimizeCompFinder" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+        <button id="btnMinimizeCompFinder" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Close">
           ❌
         </button>
       </div>
@@ -2525,7 +2525,7 @@
         <button id="btnPinLandSchedule" class="window-pin" type="button" title="Pin" aria-pressed="false">
           <img alt="Pin menu" />
         </button>
-        <button id="btnMinimizeLandSchedule" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+        <button id="btnMinimizeLandSchedule" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Close">
           ❌
         </button>
       </div>
@@ -2582,7 +2582,7 @@
         <button id="btnPinTimeAdjustment" class="window-pin" type="button" title="Pin" aria-pressed="false">
           <img alt="Pin menu" />
         </button>
-        <button id="btnMinimizeTimeAdjustment" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
+        <button id="btnMinimizeTimeAdjustment" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Close">
           ❌
         </button>
       </div>
@@ -2927,7 +2927,7 @@
           display: flex;
           align-items: center;
           justify-content: center;
-        " title="Minimize">
+        " title="Close">
           ❌
 	    </button>
       </div>

--- a/viz/index.html
+++ b/viz/index.html
@@ -126,6 +126,10 @@
       grid-template-rows: auto;
     }
 
+    .viz-window.is-pinned-collapsed > *:not(.window-header) {
+      display: none !important;
+    }
+
     .viz-window.is-pinned-collapsed .window-resize-handle {
       display: none;
     }

--- a/viz/index.html
+++ b/viz/index.html
@@ -193,6 +193,24 @@
     #controls button:hover,
     #settingsControls button:hover { background: #f0f0f0; }
 
+    #controls .window-header .window-pin,
+    #controls .window-header .window-pin-collapse,
+    #settingsControls .window-header .window-pin,
+    #settingsControls .window-header .window-pin-collapse {
+      border: none;
+      background: none;
+      padding: 2px;
+      border-radius: 3px;
+    }
+
+    #controls .window-header .window-pin:hover,
+    #controls .window-header .window-pin-collapse:hover,
+    #settingsControls .window-header .window-pin:hover,
+    #settingsControls .window-header .window-pin-collapse:hover {
+      background: none;
+      border: none;
+    }
+
     #settingsControls {
       min-width: 400px;
     }
@@ -2902,14 +2920,14 @@
     <div class="window-header" style="
       display: flex;
       align-items: center;
-      justify-content: flex-end;
+      justify-content: flex-start;
       padding: 8px 12px;
       border-bottom: 1px solid #eee;
       background: rgba(248, 248, 248, 0.8);
       border-radius: 8px 8px 0 0;
       cursor: move;
     ">
-      <div style="font-weight: 600; font-size: 13px;" id="legendTitle">Legend</div>
+      <div style="font-weight: 600; font-size: 13px; flex: 1; text-align: center;" id="legendTitle">Legend</div>
       <div class="window-actions">
         <button id="btnPinLegend" class="window-pin" type="button" title="Pin" aria-pressed="false">
           <img alt="Pin menu" />

--- a/viz/index.html
+++ b/viz/index.html
@@ -100,6 +100,36 @@
       justify-content: center;
     }
 
+    .window-pin-collapse {
+      border: none;
+      background: none;
+      cursor: pointer;
+      font-size: 14px;
+      color: #666;
+      padding: 2px;
+      width: 20px;
+      height: 20px;
+      border-radius: 3px;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      flex: 0 0 auto;
+    }
+
+    .viz-window.is-pinned .window-pin-collapse {
+      display: inline-flex;
+    }
+
+    .viz-window.is-pinned-collapsed {
+      min-height: 0;
+      height: auto;
+      grid-template-rows: auto;
+    }
+
+    .viz-window.is-pinned-collapsed .window-resize-handle {
+      display: none;
+    }
+
     .window-pin img {
       width: 14px;
       height: 14px;

--- a/viz/index.html
+++ b/viz/index.html
@@ -2540,6 +2540,25 @@
     </div>
   </div>
 
+  <div id="inspectControls" class="viz-window" style="position: absolute; top: 10px; left: 640px; width: min(calc(92vw - 80px), 460px); min-width: 340px; background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
+    <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
+      <div style="font-weight: 600; font-size: 13px;">Inspect</div>
+      <div class="window-actions">
+        <button id="btnPinInspect" class="window-pin" type="button" title="Pin" aria-pressed="false">
+          <img alt="Pin menu" />
+        </button>
+        <button id="btnMinimizeInspect" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Close">
+          ❌
+        </button>
+      </div>
+    </div>
+    <div id="inspectContent" data-window-content style="padding: 12px; display: block;"></div>
+    <div class="window-resize-edge" aria-hidden="true"></div>
+    <div class="window-resize-handle" aria-hidden="true">
+      <img src="./src/svg/expand.svg" alt="" />
+    </div>
+  </div>
+
   <div id="landScheduleControls" class="viz-window" style="position: absolute; top: 10px; left: 1220px; width: min(calc(92vw - 80px), 520px); min-width: 520px; background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
     <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
       <div style="font-weight: 600; font-size: 13px;">Adjustment Schedule</div>

--- a/viz/index.html
+++ b/viz/index.html
@@ -1908,9 +1908,7 @@
             <img alt="Pin menu" />
           </button>
           <button id="btnMinimizeLayers" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-			  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-				  <path d="M7 10l5 5 5-5z"/>
-			  </svg>
+            ❌
 		  </button>
         </div>
       </div>
@@ -2080,9 +2078,7 @@
           <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeSettingsMenu" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M7 10l5 5 5-5z"/>
-          </svg>
+          ❌
         </button>
       </div>
     </div>
@@ -2133,9 +2129,7 @@
           <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeFilters" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M7 10l5 5 5-5z"/>
-          </svg>
+          ❌
         </button>
       </div>
     </div>
@@ -2187,9 +2181,7 @@
           <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeStatistics" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M7 10l5 5 5-5z"/>
-          </svg>
+          ❌
         </button>
       </div>
     </div>
@@ -2308,9 +2300,7 @@
           <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeScatterplot" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M7 10l5 5 5-5z"/>
-          </svg>
+          ❌
         </button>
       </div>
     </div>
@@ -2397,9 +2387,7 @@
           <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeCompFinder" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M7 10l5 5 5-5z"/>
-          </svg>
+          ❌
         </button>
       </div>
     </div>
@@ -2508,9 +2496,7 @@
           <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeLandSchedule" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M7 10l5 5 5-5z"/>
-          </svg>
+          ❌
         </button>
       </div>
     </div>
@@ -2567,7 +2553,7 @@
           <img alt="Pin menu" />
         </button>
         <button id="btnMinimizeTimeAdjustment" style="border: none; background: none; cursor: pointer; font-size: 14px; color: #666; padding: 2px; width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center;" title="Minimize">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M7 10l5 5 5-5z"/></svg>
+          ❌
         </button>
       </div>
     </div>
@@ -2912,9 +2898,7 @@
           align-items: center;
           justify-content: center;
         " title="Minimize">
-			  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-				  <path d="M7 10l5 5 5-5z"/>
-			  </svg>
+          ❌
 	    </button>
       </div>
     </div>

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -1704,10 +1704,10 @@ function createInspectFocusMarker() {
   markerEl.style.width = '26px';
   markerEl.style.height = '26px';
   markerEl.style.transform = 'translate(-13px, -26px)';
-  markerEl.style.setProperty('--c-outline2', '#4a0f0f');
-  markerEl.style.setProperty('--c-outline1', '#7f1d1d');
+  markerEl.style.setProperty('--c-outline2', '#ffffff');
+  markerEl.style.setProperty('--c-outline1', '#000000');
   markerEl.style.setProperty('--c-middle', '#dc2626');
-  markerEl.style.setProperty('--c-dot', '#ffffff');
+  markerEl.style.setProperty('--c-dot', '#000000');
   markerEl.innerHTML = PIN_SVG_RAW;
   return new maplibregl.Marker({ element: markerEl, anchor: 'bottom' });
 }
@@ -2209,10 +2209,15 @@ function buildPopupHTML(props: Record<string, any>, parcelId: string): string {
   }).join('');
 
   const showInlinePin = !isInspectPinned();
-  const popupMaxWidthStyle = showInlinePin ? 'max-width:min(92vw, 460px);' : 'max-width:none; width:100%;';
+  const popupContainerStyle = showInlinePin
+    ? 'max-width:min(92vw, 460px); font-size:12.5px; line-height:1.35;'
+    : 'max-width:none; width:100%; height:100%; display:flex; flex-direction:column; font-size:12.5px; line-height:1.35;';
+  const popupScrollStyle = showInlinePin
+    ? 'overflow-y:auto; max-height:400px;'
+    : 'overflow-y:auto; max-height:none; flex:1; min-height:0;';
 
   return `
-    <div class="gvw-pop" style="${popupMaxWidthStyle} font-size:12.5px; line-height:1.35;">
+    <div class="gvw-pop" style="${popupContainerStyle}">
       ${showInlinePin ? `<div style="display:flex; align-items:center; justify-content:flex-end; gap:6px; margin-bottom:4px;">
         <button type="button" class="inspect-popup-pin-btn" title="Pin" style="border:none;background:none;cursor:pointer;padding:2px;width:20px;height:20px;border-radius:3px;display:flex;align-items:center;justify-content:center;"><img src="${PIN_ICON_TILTED}" alt="Pin menu" style="width:14px;height:14px;display:block;"></button>
         <button type="button" class="inspect-popup-close-btn" title="Close" style="border:none;background:none;cursor:pointer;font-size:14px;color:#666;padding:2px;width:20px;height:20px;border-radius:3px;display:flex;align-items:center;justify-content:center;">❌</button>
@@ -2220,7 +2225,7 @@ function buildPopupHTML(props: Record<string, any>, parcelId: string): string {
       <div style="display:flex;align-items:center;gap:6px;margin-bottom:6px;">
         <input type="text" id="popupSearch" placeholder="Search fields..." style="flex:1;padding:4px 6px;border:1px solid #ddd;border-radius:4px;font-size:12px;">
       </div>
-      <div style="overflow-y:auto; max-height:400px;">
+      <div style="${popupScrollStyle}">
         <table style="width:100%; border-collapse:collapse; font-size:12px; table-layout:fixed;">
           <colgroup>
           <col span="1" style="width:8%">

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -5,7 +5,7 @@ import type { Expression } from 'maplibre-gl';
 import { toGeoJson } from 'geoparquet';
 import { compressors } from 'hyparquet-compressors';
 import { parquetMetadataAsync, parquetSchema } from 'hyparquet';
-
+import PIN_SVG_RAW from './svg/pin.svg?raw';
 
 // Local imports
 import { OSM_STYLE, SATELLITE_STYLE, HEIGHT_CAP_METERS, HEIGHT_PCTL, COLOR_RAMPS, UNIT_TO_METERS } from './config';
@@ -109,7 +109,6 @@ import {
   buildNumericColorRanges, buildNumericColorExpression,
   buildValueExpression,
   fitToData, setQuality,
-  computeDisplayedMetricFromProps, computeExtrusionHeightMeters,
   scheduleUpdate, chooseBestMetricUnitForMultiplier,
   populateFieldDropdownFromList, detectNumericFieldsFromFeatures,
   getNumericValuesNormalized, computeStatsNormalized,
@@ -1692,6 +1691,33 @@ function buildInspectEmptyHTML() {
   return '<div style="padding: 4px 2px; color:#6b7280; font-size: 12.5px;">select a parcel to inspect it</div>';
 }
 
+function removeInspectFocusMarker() {
+  if (S.inspectFocusMarker) {
+    S.inspectFocusMarker.remove();
+    S.inspectFocusMarker = null;
+  }
+}
+
+function createInspectFocusMarker() {
+  const markerEl = document.createElement('div');
+  markerEl.className = 'inspect-focus-marker';
+  markerEl.style.width = '26px';
+  markerEl.style.height = '26px';
+  markerEl.style.transform = 'translate(-13px, -26px)';
+  markerEl.style.setProperty('--c-outline2', '#4a0f0f');
+  markerEl.style.setProperty('--c-outline1', '#7f1d1d');
+  markerEl.style.setProperty('--c-middle', '#dc2626');
+  markerEl.style.setProperty('--c-dot', '#ffffff');
+  markerEl.innerHTML = PIN_SVG_RAW;
+  return new maplibregl.Marker({ element: markerEl, anchor: 'bottom' });
+}
+
+function syncInspectFocusMarker() {
+  removeInspectFocusMarker();
+  if (!S.lastPicked) return;
+  S.inspectFocusMarker = createInspectFocusMarker().setLngLat(S.lastPicked.lngLat).addTo(S.map);
+}
+
 function renderInspectPinnedContent() {
   if (!isInspectPinned()) return;
   if (!S.lastPicked) {
@@ -1711,6 +1737,7 @@ function clearInspectState() {
     S.activePopup = null;
   }
   S.lastPicked = null;
+  removeInspectFocusMarker();
   if (isInspectPinned() && !S.isInspectMinimized) {
     renderInspectPinnedContent();
   }
@@ -1731,7 +1758,7 @@ function showPopupForLastPicked() {
   }
 
   const popup = new maplibregl.Popup({
-    closeButton: true,
+    closeButton: false,
     closeOnClick: true,
     maxWidth: '460px'
   })
@@ -1744,6 +1771,10 @@ function showPopupForLastPicked() {
     S.activePopup = null;
     if (!suppressPopupCloseClear) {
       S.lastPicked = null;
+      removeInspectFocusMarker();
+      if (isInspectPinned() && !S.isInspectMinimized) {
+        renderInspectPinnedContent();
+      }
     }
   });
 
@@ -1757,6 +1788,7 @@ function showPopup(props: Record<string, any>, lngLat: maplibregl.LngLatLike, pa
   if (!S.isInfoToolActive) return;
 
   S.lastPicked = { props, lngLat, parcelId };
+  syncInspectFocusMarker();
 
   if (isInspectPinned()) {
     showInspect();
@@ -1822,6 +1854,15 @@ function addPopupSearchFunctionality() {
             suppressPopupCloseClear = false;
             S.activePopup = null;
           }
+        });
+      }
+
+      const closeButton = popupElement.querySelector('.inspect-popup-close-btn') as HTMLButtonElement | null;
+      if (closeButton && closeButton.dataset.closeHandlerAttached !== 'true') {
+        closeButton.dataset.closeHandlerAttached = 'true';
+        closeButton.addEventListener('click', (event) => {
+          event.preventDefault();
+          closeInspectMenu();
         });
       }
 
@@ -2134,26 +2175,7 @@ function addPopupEditFunctionality(parcelId: string) {
 /* --- rendering functions → see rendering.ts --- */
 
 
-function currentModeErrorMessage(props: Record<string, any>): string | null {
-  if (S.normalizationMode === 'perLand' && S.landSizeField) {
-    const v = Number((props as any)[S.landSizeField]);
-    if (!Number.isFinite(v) || v <= 0) return '⚠ Invalid land size (≤ 0 or missing)';
-  } else if (S.normalizationMode === 'perBuilding' && S.bldgSizeField) {
-    const v = Number((props as any)[S.bldgSizeField]);
-    if (Number.isFinite(v) && v < 0) return '⚠ Negative building size';
-    if (v === 0) return 'ℹ Building size is 0 — shown flat (not an error)';
-  }
-  return null;
-}
-
 function buildPopupHTML(props: Record<string, any>, parcelId: string): string {
-  const title = props.name ?? props.NAME ?? props.id ?? props.ID ?? '';
-  const metric = computeDisplayedMetricFromProps(props);
-  const heightM = metric != null ? computeExtrusionHeightMeters(metric) : null;
-
-  const unitKey = unitsSelect.value as keyof typeof UNIT_TO_METERS;
-  const unitText = (unitsSelect.options[unitsSelect.selectedIndex]?.text || unitKey);
-
   const fieldsToShow = Array.from(new Set([
     ...S.chosenNumericFields,
     ...S.chosenCategoricalFields,
@@ -2171,71 +2193,39 @@ function buildPopupHTML(props: Record<string, any>, parcelId: string): string {
     const nameStyle = changed ? 'font-weight:700;' : '';
     return `
       <tr data-field="${escapeHtml(k)}" data-field-type="${fieldType}" style="${rowStyle}">
-        <td style="padding:2px 6px; overflow-wrap:anywhere;">
+        <td style="padding:2px 4px; text-align:left; white-space:nowrap; vertical-align:top;">
+          <button type="button" class="popup-edit-btn" title="Edit value" style="background:none;border:none;cursor:pointer;font-size:12px;line-height:1;">✏️</button>
+        </td>
+        <td style="padding:2px 4px; text-align:left; white-space:nowrap; vertical-align:top;">
+          <button type="button" class="popup-reset-btn" title="Reset to original" style="background:none;border:none;cursor:pointer;font-size:12px;line-height:1;${changed ? '' : 'display:none;'}">↩</button>
+        </td>
+        <td style="padding:2px 6px; overflow-wrap:anywhere; vertical-align:top;">
           <code style="white-space:normal;${nameStyle}">${escapeHtml(k)}</code>
         </td>
-        <td style="padding:2px 6px; text-align:right; white-space:nowrap;" data-value-cell>
+        <td style="padding:2px 6px; text-align:right; white-space:normal; overflow-wrap:anywhere;" data-value-cell>
           ${printable}
-        </td>
-        <td style="padding:2px 6px; text-align:right; white-space:nowrap;">
-          <button type="button" class="popup-edit-btn" title="Edit value" style="background:none;border:none;cursor:pointer;font-size:12px;line-height:1;">
-            ✏️
-          </button>
-        </td>
-        <td style="padding:2px 6px; text-align:right; white-space:nowrap;">
-          <button type="button" class="popup-reset-btn" title="Reset to original" style="background:none;border:none;cursor:pointer;font-size:12px;line-height:1;${changed ? '' : 'display:none;'}">↩</button>
         </td>
       </tr>`;
   }).join('');
 
-  const modeLabel =
-    S.normalizationMode === 'perLand' ? `per ${S.landSizeField || 'land size'}` :
-    S.normalizationMode === 'perBuilding' ? `per ${S.bldgSizeField || 'building size'}` :
-    'as-is';
-
-  const metricRow = S.currentFieldType === 'categorical' 
-    ? `<div><strong>Category</strong>: ${S.currentField ? (props[S.currentField] ?? '—') : '—'}</div>`
-    : (metric != null)
-      ? `<div><strong>Display metric (${modeLabel})</strong>: ${fmt(metric)}</div>`
-      : `<div><strong>Display metric</strong>: —</div>`;
-
-  const heightRow = S.currentFieldType === 'categorical'
-    ? `<div><strong>Extrusion height</strong>: Flat (no extrusion for categorical fields)</div>`
-    : !S.is3DMode
-      ? `<div><strong>Extrusion height</strong>: Flat (3D mode disabled)</div>`
-      : (heightM != null)
-        ? `<div><strong>Extrusion height</strong>: ${fmt(heightM / (UNIT_TO_METERS[unitKey] || 1))} ${unitText} (${fmt(heightM)} m)</div>`
-        : `<div><strong>Extrusion height</strong>: —</div>`;
-
-  const errMsg = currentModeErrorMessage(props);
-  const errRow = errMsg ? `<div style="margin-top:4px;color:#b00020;">${errMsg}</div>` : '';
   const showInlinePin = !isInspectPinned();
 
   return `
     <div class="gvw-pop" style="max-width:min(92vw, 460px); font-size:12.5px; line-height:1.35;">
-      <div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
-        <div style="font-weight:600; overflow-wrap:anywhere; flex:1;">${escapeHtml(String(title || 'Inspect'))}</div>
-        ${showInlinePin ? `<button type="button" class="inspect-popup-pin-btn" title="Pin" style="border:none;background:none;cursor:pointer;padding:2px;width:20px;height:20px;display:flex;align-items:center;justify-content:center;"><img src="${PIN_ICON_TILTED}" alt="Pin menu" style="width:14px;height:14px;display:block;"></button>` : ''}
-      </div>
-      ${metricRow}
-      ${heightRow}
-	  ${errRow}
-      ${S.is3DMode && S.currentFieldType === 'numeric' ? 
-        `<div style="margin-top:6px; font-size:12px; color:#666">
-          Multiplier × unit: ${fmt(Number(multInput.value))} × ${unitKey}
-        </div>` : ''}
-      <div style="height:1px;background:#eee;margin:6px 0"></div>
-      <div style="font-weight:600;margin-bottom:2px">Loaded fields</div>
+      ${showInlinePin ? `<div style="display:flex; align-items:center; justify-content:flex-end; gap:6px; margin-bottom:4px;">
+        <button type="button" class="inspect-popup-pin-btn" title="Pin" style="border:none;background:none;cursor:pointer;padding:2px;width:20px;height:20px;border-radius:3px;display:flex;align-items:center;justify-content:center;"><img src="${PIN_ICON_TILTED}" alt="Pin menu" style="width:14px;height:14px;display:block;"></button>
+        <button type="button" class="inspect-popup-close-btn" title="Close" style="border:none;background:none;cursor:pointer;font-size:14px;color:#666;padding:2px;width:20px;height:20px;border-radius:3px;display:flex;align-items:center;justify-content:center;">❌</button>
+      </div>` : ''}
       <div style="display:flex;align-items:center;gap:6px;margin-bottom:6px;">
         <input type="text" id="popupSearch" placeholder="Search fields..." style="flex:1;padding:4px 6px;border:1px solid #ddd;border-radius:4px;font-size:12px;">
       </div>
       <div style="overflow-y:auto; max-height:400px;">
         <table style="width:100%; border-collapse:collapse; font-size:12px; table-layout:fixed;">
           <colgroup>
-          <col span="1" style="width:53%">
-          <col span="1" style="width:29%">
-          <col span="1" style="width:9%">
-          <col span="1" style="width:9%">
+          <col span="1" style="width:8%">
+          <col span="1" style="width:8%">
+          <col span="1" style="width:44%">
+          <col span="1" style="width:40%">
           </colgroup>
           <tbody id="popupFieldsTable">
           ${rows}

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -486,6 +486,7 @@ const btnMinimizeFilters = document.getElementById('btnMinimizeFilters') as HTML
 const btnMinimizeLandSchedule = document.getElementById('btnMinimizeLandSchedule') as HTMLButtonElement;
 const btnMinimizeTimeAdjustment = document.getElementById('btnMinimizeTimeAdjustment') as HTMLButtonElement;
 const btnMinimizeCompFinder = document.getElementById('btnMinimizeCompFinder') as HTMLButtonElement;
+const btnMinimizeInspect = document.getElementById('btnMinimizeInspect') as HTMLButtonElement;
 
 // Floating legend elements
 const floatingLegend = document.getElementById('floatingLegend') as HTMLDivElement;
@@ -496,6 +497,9 @@ const legendContent = document.getElementById('legendContent') as HTMLDivElement
 const compFinderControlsEl = document.getElementById('compFinderControls') as HTMLDivElement;
 const compFinderContent = document.getElementById('compFinderContent') as HTMLDivElement;
 const btnPinCompFinder = document.getElementById('btnPinCompFinder') as HTMLButtonElement;
+const inspectControlsEl = document.getElementById('inspectControls') as HTMLDivElement;
+const inspectContent = document.getElementById('inspectContent') as HTMLDivElement;
+const btnPinInspect = document.getElementById('btnPinInspect') as HTMLButtonElement;
 const compFinderDataSourceSelect = document.getElementById('compFinderDataSource') as HTMLSelectElement;
 const compFinderUseDistance = document.getElementById('compFinderUseDistance') as HTMLInputElement;
 const compFinderDistanceInput = document.getElementById('compFinderDistance') as HTMLInputElement;
@@ -774,6 +778,14 @@ const compFinderWin = createWindowManager({
   controlsEl: compFinderControlsEl,
 });
 
+const inspectWin = createWindowManager({
+  getMinimized: () => S.isInspectMinimized,
+  setMinimized: (v) => { S.isInspectMinimized = v; },
+  contentEl: inspectContent,
+  controlsEl: inspectControlsEl,
+  contentDisplay: 'block',
+});
+
 // Convenience aliases matching the old function names
 const minimizeLayers = layersWin.minimize;
 const showLayers = layersWin.show;
@@ -801,11 +813,34 @@ const showCompFinder = () => {
   compFinderWin.show();
   setCompFinderMenuVisible(true);
 };
+const minimizeInspect = inspectWin.minimize;
+const showInspect = inspectWin.show;
 
 // Wire callbacks and DOM elements into the windows module
 initWindowCallbacks({
   updateToolbarButtonStates,
   updateLegendPosition,
+  onPinnedStateChanged: (element, pinned) => {
+    if (element !== inspectControlsEl) return;
+    if (pinned) {
+      if (S.activePopup) {
+        suppressPopupCloseClear = true;
+        S.activePopup.remove();
+        suppressPopupCloseClear = false;
+        S.activePopup = null;
+      }
+      if (!S.isInspectMinimized) {
+        renderInspectPinnedContent();
+      }
+      return;
+    }
+    if (S.lastPicked) {
+      showPopupForLastPicked();
+      minimizeInspect();
+    } else {
+      minimizeInspect();
+    }
+  },
 });
 initPositionElements({
   controlsEl,
@@ -829,6 +864,7 @@ initWindowDocking({
   btnPinStatistics,
   btnPinScatterplot,
   btnPinCompFinder,
+  btnPinInspect,
   btnPinLandSchedule,
   btnPinTimeAdjustment,
   btnPinLegend,
@@ -839,6 +875,7 @@ registerDockableWindow(filtersControlsEl, btnPinFilters);
 registerDockableWindow(statisticsControlsEl, btnPinStatistics);
 registerDockableWindow(scatterplotControlsEl, btnPinScatterplot);
 registerDockableWindow(compFinderControlsEl, btnPinCompFinder);
+registerDockableWindow(inspectControlsEl, btnPinInspect);
 registerDockableWindow(landScheduleControlsEl, btnPinLandSchedule);
 registerDockableWindow(timeAdjustmentControlsEl, btnPinTimeAdjustment);
 registerDockableWindow(floatingLegend, btnPinLegend);
@@ -848,6 +885,7 @@ enableWindowResizing(filtersControlsEl);
 enableWindowResizing(statisticsControlsEl);
 enableWindowResizing(scatterplotControlsEl);
 enableWindowResizing(compFinderControlsEl);
+enableWindowResizing(inspectControlsEl);
 enableWindowResizing(landScheduleControlsEl);
 enableWindowResizing(timeAdjustmentControlsEl);
 enableWindowResizing(floatingLegend);
@@ -908,6 +946,21 @@ initRenderingCallbacks({
   buildPopupHTML,
   addPopupSearchFunctionality,
   addPopupEditFunctionality,
+  refreshInspectView: () => {
+    if (!S.lastPicked) {
+      if (isInspectPinned() && !S.isInspectMinimized) {
+        renderInspectPinnedContent();
+      }
+      return;
+    }
+    if (isInspectPinned()) {
+      if (!S.isInspectMinimized) {
+        renderInspectPinnedContent();
+      }
+      return;
+    }
+    showPopupForLastPicked();
+  },
   updateCursor,
   isTextInputElement,
   activateTool: (tool: string) => activateTool(tool as 'pan' | 'info' | 'select' | 'comp-finder'),
@@ -1628,24 +1681,97 @@ function clearData() {
   S.parcelPatchMap = new Map();
   hideRenderingToast();
 }
+
+let suppressPopupCloseClear = false;
+
+function isInspectPinned() {
+  return inspectControlsEl.dataset.pinned === 'true';
+}
+
+function buildInspectEmptyHTML() {
+  return '<div style="padding: 4px 2px; color:#6b7280; font-size: 12.5px;">select a parcel to inspect it</div>';
+}
+
+function renderInspectPinnedContent() {
+  if (!isInspectPinned()) return;
+  if (!S.lastPicked) {
+    inspectContent.innerHTML = buildInspectEmptyHTML();
+    return;
+  }
+  inspectContent.innerHTML = buildPopupHTML(S.lastPicked.props, S.lastPicked.parcelId);
+  addPopupSearchFunctionality();
+  addPopupEditFunctionality(S.lastPicked.parcelId);
+}
+
+function clearInspectState() {
+  if (S.activePopup) {
+    suppressPopupCloseClear = true;
+    S.activePopup.remove();
+    suppressPopupCloseClear = false;
+    S.activePopup = null;
+  }
+  S.lastPicked = null;
+  if (isInspectPinned() && !S.isInspectMinimized) {
+    renderInspectPinnedContent();
+  }
+}
+
+function closeInspectMenu() {
+  clearInspectState();
+  minimizeInspect();
+}
+
+function showPopupForLastPicked() {
+  if (!S.lastPicked || isInspectPinned()) return;
+
+  if (S.activePopup) {
+    suppressPopupCloseClear = true;
+    S.activePopup.remove();
+    suppressPopupCloseClear = false;
+  }
+
+  const popup = new maplibregl.Popup({
+    closeButton: true,
+    closeOnClick: true,
+    maxWidth: '460px'
+  })
+    .setLngLat(S.lastPicked.lngLat)
+    .setHTML(buildPopupHTML(S.lastPicked.props, S.lastPicked.parcelId))
+    .addTo(S.map);
+
+  popup.on('close', () => {
+    if (S.activePopup !== popup) return;
+    S.activePopup = null;
+    if (!suppressPopupCloseClear) {
+      S.lastPicked = null;
+    }
+  });
+
+  S.activePopup = popup;
+  addPopupSearchFunctionality();
+  addPopupEditFunctionality(S.lastPicked.parcelId);
+}
+
 function showPopup(props: Record<string, any>, lngLat: maplibregl.LngLatLike, parcelId: string) {
   // Only show popup if info tool is active
   if (!S.isInfoToolActive) return;
-  
-  if (S.activePopup) S.activePopup.remove();
-  S.activePopup = new maplibregl.Popup({
-    closeButton: true,
-    closeOnClick: true,
-    maxWidth: '460px'          // ← wider than default 240px
-  })
-    .setLngLat(lngLat)
-    .setHTML(buildPopupHTML(props, parcelId))
-    .addTo(S.map);
+
   S.lastPicked = { props, lngLat, parcelId };
-  
-  // Add search functionality to the popup
-  addPopupSearchFunctionality();
-  addPopupEditFunctionality(parcelId);
+
+  if (isInspectPinned()) {
+    showInspect();
+    renderInspectPinnedContent();
+    if (S.activePopup) {
+      suppressPopupCloseClear = true;
+      S.activePopup.remove();
+      suppressPopupCloseClear = false;
+      S.activePopup = null;
+    }
+    return;
+  }
+
+  showPopupForLastPicked();
+  minimizeInspect();
 }
 
 function isTextInputElement(element: Element | null): boolean {
@@ -1678,8 +1804,27 @@ function isTextInputElement(element: Element | null): boolean {
 
 function addPopupSearchFunctionality() {
   setTimeout(() => {
-    const popupElement = S.activePopup?.getElement();
+    const popupElement = isInspectPinned() ? inspectContent : S.activePopup?.getElement();
     if (popupElement) {
+      const pinButton = popupElement.querySelector('.inspect-popup-pin-btn') as HTMLButtonElement | null;
+      if (pinButton && pinButton.dataset.pinHandlerAttached !== 'true') {
+        pinButton.dataset.pinHandlerAttached = 'true';
+        pinButton.addEventListener('click', (event) => {
+          event.preventDefault();
+          showInspect();
+          if (!isInspectPinned()) {
+            btnPinInspect.click();
+          }
+          renderInspectPinnedContent();
+          if (S.activePopup) {
+            suppressPopupCloseClear = true;
+            S.activePopup.remove();
+            suppressPopupCloseClear = false;
+            S.activePopup = null;
+          }
+        });
+      }
+
       const searchInput = popupElement.querySelector('#popupSearch') as HTMLInputElement;
       const tableBody = popupElement.querySelector('#popupFieldsTable') as HTMLTableSectionElement;
       
@@ -1798,7 +1943,7 @@ function formatPopupValue(fieldType: 'numeric' | 'categorical', value: any): str
 
 function addPopupEditFunctionality(parcelId: string) {
   setTimeout(() => {
-    const popupElement = S.activePopup?.getElement();
+    const popupElement = isInspectPinned() ? inspectContent : S.activePopup?.getElement();
     if (!popupElement) return;
     const tableBody = popupElement.querySelector('#popupFieldsTable') as HTMLTableSectionElement | null;
     if (!tableBody || tableBody.dataset.editHandlersAttached === 'true') return;
@@ -2064,10 +2209,14 @@ function buildPopupHTML(props: Record<string, any>, parcelId: string): string {
 
   const errMsg = currentModeErrorMessage(props);
   const errRow = errMsg ? `<div style="margin-top:4px;color:#b00020;">${errMsg}</div>` : '';
+  const showInlinePin = !isInspectPinned();
 
   return `
     <div class="gvw-pop" style="max-width:min(92vw, 460px); font-size:12.5px; line-height:1.35;">
-      ${title ? `<div style="font-weight:600;margin-bottom:4px; overflow-wrap:anywhere;">${title}</div>` : ''}
+      <div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
+        <div style="font-weight:600; overflow-wrap:anywhere; flex:1;">${escapeHtml(String(title || 'Inspect'))}</div>
+        ${showInlinePin ? `<button type="button" class="inspect-popup-pin-btn" title="Pin" style="border:none;background:none;cursor:pointer;padding:2px;width:20px;height:20px;display:flex;align-items:center;justify-content:center;"><img src="${PIN_ICON_TILTED}" alt="Pin menu" style="width:14px;height:14px;display:block;"></button>` : ''}
+      </div>
       ${metricRow}
       ${heightRow}
 	  ${errRow}
@@ -2350,6 +2499,7 @@ btnMinimizeFilters.addEventListener('click', minimizeFilters);
 btnMinimizeLandSchedule.addEventListener('click', minimizeLandSchedule);
 btnMinimizeTimeAdjustment.addEventListener('click', minimizeTimeAdjustment);
 btnMinimizeCompFinder.addEventListener('click', minimizeCompFinder);
+btnMinimizeInspect.addEventListener('click', closeInspectMenu);
 
 landScheduleAddTableButton.addEventListener('click', () => {
   addLandScheduleTable();
@@ -2597,6 +2747,7 @@ makeDraggable(statisticsControlsEl);
 makeDraggable(scatterplotControlsEl);
 makeDraggable(filtersControlsEl);
 makeDraggable(compFinderControlsEl);
+makeDraggable(inspectControlsEl);
 makeDraggable(landScheduleControlsEl);
 makeDraggable(timeAdjustmentControlsEl);
 positionSettingsPanel();

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -1873,10 +1873,10 @@ function addPopupSearchFunctionality() {
         const filterFields = (searchText: string) => {
           const rows = tableBody.querySelectorAll('tr');
           rows.forEach(row => {
-            const fieldNameCell = row.querySelector('td:first-child code');
+            const fieldNameCell = row.querySelector('code');
             if (fieldNameCell) {
               const fieldName = fieldNameCell.textContent || '';
-              const matches = fieldName.toLowerCase().includes(searchText.toLowerCase());
+              const matches = fieldName.toLowerCase().startsWith(searchText.toLowerCase());
               (row as HTMLElement).style.display = matches ? '' : 'none';
             }
           });
@@ -1993,7 +1993,7 @@ function addPopupEditFunctionality(parcelId: string) {
     const updateRowChangedState = (row: HTMLTableRowElement, field: string, fieldType: 'numeric' | 'categorical') => {
       const changed = isFieldChanged(parcelId, field, fieldType);
       row.style.background = changed ? 'rgba(255, 0, 0, 0.08)' : '';
-      const fieldCell = row.querySelector('td:first-child code') as HTMLElement | null;
+      const fieldCell = row.querySelector('code') as HTMLElement | null;
       if (fieldCell) fieldCell.style.fontWeight = changed ? '700' : '';
       const resetButton = row.querySelector('.popup-reset-btn') as HTMLButtonElement | null;
       if (resetButton) resetButton.style.display = changed ? 'inline-flex' : 'none';
@@ -2209,9 +2209,10 @@ function buildPopupHTML(props: Record<string, any>, parcelId: string): string {
   }).join('');
 
   const showInlinePin = !isInspectPinned();
+  const popupMaxWidthStyle = showInlinePin ? 'max-width:min(92vw, 460px);' : 'max-width:none; width:100%;';
 
   return `
-    <div class="gvw-pop" style="max-width:min(92vw, 460px); font-size:12.5px; line-height:1.35;">
+    <div class="gvw-pop" style="${popupMaxWidthStyle} font-size:12.5px; line-height:1.35;">
       ${showInlinePin ? `<div style="display:flex; align-items:center; justify-content:flex-end; gap:6px; margin-bottom:4px;">
         <button type="button" class="inspect-popup-pin-btn" title="Pin" style="border:none;background:none;cursor:pointer;padding:2px;width:20px;height:20px;border-radius:3px;display:flex;align-items:center;justify-content:center;"><img src="${PIN_ICON_TILTED}" alt="Pin menu" style="width:14px;height:14px;display:block;"></button>
         <button type="button" class="inspect-popup-close-btn" title="Close" style="border:none;background:none;cursor:pointer;font-size:14px;color:#666;padding:2px;width:20px;height:20px;border-radius:3px;display:flex;align-items:center;justify-content:center;">❌</button>

--- a/viz/src/rendering.ts
+++ b/viz/src/rendering.ts
@@ -226,6 +226,60 @@ export function addOrUpdateSource(fc: GeoJSON.FeatureCollection) {
 
 let keyHandlersInstalled = false;
 
+
+function polygonCentroid(ring: number[][]): [number, number] | null {
+  if (ring.length < 3) return null;
+  let area2 = 0;
+  let cx = 0;
+  let cy = 0;
+  for (let i = 0; i < ring.length - 1; i += 1) {
+    const [x0, y0] = ring[i];
+    const [x1, y1] = ring[i + 1];
+    const cross = (x0 * y1) - (x1 * y0);
+    area2 += cross;
+    cx += (x0 + x1) * cross;
+    cy += (y0 + y1) * cross;
+  }
+  if (Math.abs(area2) < 1e-12) return null;
+  return [cx / (3 * area2), cy / (3 * area2)];
+}
+
+function getFeatureInspectFocusLngLat(feature: GeoJSON.Feature, fallback: maplibregl.LngLat): maplibregl.LngLatLike {
+  const geom = feature.geometry;
+  if (!geom) return fallback;
+
+  if (geom.type === 'Polygon') {
+    const centroid = polygonCentroid((geom.coordinates?.[0] ?? []) as number[][]);
+    if (centroid) return centroid as [number, number];
+  }
+
+  if (geom.type === 'MultiPolygon') {
+    let best: { area: number; centroid: [number, number] } | null = null;
+    for (const poly of geom.coordinates as number[][][][]) {
+      const ring = poly?.[0] ?? [];
+      const centroid = polygonCentroid(ring as number[][]);
+      if (!centroid) continue;
+      let area = 0;
+      for (let i = 0; i < ring.length - 1; i += 1) {
+        const [x0, y0] = ring[i];
+        const [x1, y1] = ring[i + 1];
+        area += (x0 * y1) - (x1 * y0);
+      }
+      const absArea = Math.abs(area);
+      if (!best || absArea > best.area) {
+        best = { area: absArea, centroid };
+      }
+    }
+    if (best) return best.centroid;
+  }
+
+  const bounds = bbox({ type: 'FeatureCollection', features: [feature] });
+  if (bounds) {
+    return [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2] as [number, number];
+  }
+  return fallback;
+}
+
 export function addExtrusionLayer(layer: LayerState) {
   if (S.map.getLayer(layer.layerId)) return;
   S.map.addLayer({
@@ -251,7 +305,8 @@ export function addExtrusionLayer(layer: LayerState) {
     if (S.isInfoToolActive) {
       const props = (f.properties || {}) as Record<string, any>;
       const parcelId = getParcelId(f);
-      _showPopup(props, e.lngLat, parcelId);
+      const focusLngLat = getFeatureInspectFocusLngLat(f as GeoJSON.Feature, e.lngLat);
+      _showPopup(props, focusLngLat, parcelId);
       return;
     }
 

--- a/viz/src/rendering.ts
+++ b/viz/src/rendering.ts
@@ -94,6 +94,7 @@ let _showPopup: (props: Record<string, any>, lngLat: maplibregl.LngLatLike, parc
 let _buildPopupHTML: (props: Record<string, any>, parcelId: string) => string = () => '';
 let _addPopupSearchFunctionality: () => void = () => {};
 let _addPopupEditFunctionality: (parcelId: string) => void = () => {};
+let _refreshInspectView: () => void = () => {};
 let _updateCursor: () => void = () => {};
 let _isTextInputElement: (el: Element | null) => boolean = () => false;
 let _activateTool: (tool: string) => void = () => {};
@@ -117,6 +118,7 @@ export type RenderingCallbacks = {
   buildPopupHTML: (props: Record<string, any>, parcelId: string) => string;
   addPopupSearchFunctionality: () => void;
   addPopupEditFunctionality: (parcelId: string) => void;
+  refreshInspectView?: () => void;
   updateCursor: () => void;
   isTextInputElement: (el: Element | null) => boolean;
   activateTool: (tool: string) => void;
@@ -136,6 +138,7 @@ export function initRenderingCallbacks(cb: RenderingCallbacks) {
   _buildPopupHTML = cb.buildPopupHTML;
   _addPopupSearchFunctionality = cb.addPopupSearchFunctionality;
   _addPopupEditFunctionality = cb.addPopupEditFunctionality;
+  _refreshInspectView = cb.refreshInspectView ?? (() => {});
   _updateCursor = cb.updateCursor;
   _isTextInputElement = cb.isTextInputElement;
   _activateTool = cb.activateTool;
@@ -661,11 +664,7 @@ export function applyGrayRendering() {
   // refresh which features are flagged as erroneous for current mode
   updateErrorLayer();
 
-  if (S.activePopup && S.lastPicked) {
-    S.activePopup.setHTML(_buildPopupHTML(S.lastPicked.props, S.lastPicked.parcelId)).setLngLat(S.lastPicked.lngLat);
-    _addPopupSearchFunctionality();
-    _addPopupEditFunctionality(S.lastPicked.parcelId);
-  }
+  if (S.lastPicked) _refreshInspectView();
 }
 
 export function applyExtrusion() {
@@ -704,11 +703,7 @@ export function applyExtrusion() {
   // refresh which features are flagged as erroneous for current mode
   updateErrorLayer();
 
-  if (S.activePopup && S.lastPicked) {
-    S.activePopup.setHTML(_buildPopupHTML(S.lastPicked.props, S.lastPicked.parcelId)).setLngLat(S.lastPicked.lngLat);
-    _addPopupSearchFunctionality();
-    _addPopupEditFunctionality(S.lastPicked.parcelId);
-  }
+  if (S.lastPicked) _refreshInspectView();
 }
 
 export function fitToData(fc: GeoJSON.FeatureCollection) {

--- a/viz/src/rendering.ts
+++ b/viz/src/rendering.ts
@@ -139,6 +139,9 @@ export function initRenderingCallbacks(cb: RenderingCallbacks) {
   _addPopupSearchFunctionality = cb.addPopupSearchFunctionality;
   _addPopupEditFunctionality = cb.addPopupEditFunctionality;
   _refreshInspectView = cb.refreshInspectView ?? (() => {});
+  void _buildPopupHTML;
+  void _addPopupSearchFunctionality;
+  void _addPopupEditFunctionality;
   _updateCursor = cb.updateCursor;
   _isTextInputElement = cb.isTextInputElement;
   _activateTool = cb.activateTool;
@@ -280,6 +283,7 @@ export function addExtrusionLayer(layer: LayerState) {
       S.activePopup.remove();
       S.activePopup = null;
       S.lastPicked = null;
+      if (S.inspectFocusMarker) { S.inspectFocusMarker.remove(); S.inspectFocusMarker = null; }
     }
   });
 
@@ -300,6 +304,7 @@ export function addExtrusionLayer(layer: LayerState) {
         S.activePopup.remove();
         S.activePopup = null;
         S.lastPicked = null;
+        if (S.inspectFocusMarker) { S.inspectFocusMarker.remove(); S.inspectFocusMarker = null; }
       }
 
       const activeElement = document.activeElement;

--- a/viz/src/state.ts
+++ b/viz/src/state.ts
@@ -175,7 +175,7 @@ export const S = {
   // --- Selection ---
   selectedLegendItems: new Set<string>(),
   selectedParcels: new Set<string>(),
-  highlightColor: '#FFFF00',
+  highlightColor: '#32CD32',
   selectionControlsPanel: null as HTMLDivElement | null,
 
   // --- Legend sorting ---

--- a/viz/src/state.ts
+++ b/viz/src/state.ts
@@ -110,6 +110,7 @@ export const S = {
   isTimeAdjustmentTrendCollapsed: false,
   isTimeAdjustmentFiltersCollapsed: true,
   isCompFinderMinimized: true,
+  isInspectMinimized: true,
   isCompFinderSubjectCollapsed: false,
   isCompFinderCriteriaCollapsed: false,
   isCompFinderCompsCollapsed: false,

--- a/viz/src/state.ts
+++ b/viz/src/state.ts
@@ -86,6 +86,7 @@ export const S = {
   // --- Popup ---
   activePopup: null as maplibregl.Popup | null,
   lastPicked: null as { props: Record<string, any>; lngLat: maplibregl.LngLatLike; parcelId: string } | null,
+  inspectFocusMarker: null as maplibregl.Marker | null,
 
   // --- Update scheduling ---
   _updTimer: null as number | null,

--- a/viz/src/toolbar.ts
+++ b/viz/src/toolbar.ts
@@ -255,6 +255,7 @@ export function activateTool(tool: 'pan' | 'info' | 'select' | 'comp-finder') {
     S.activePopup.remove();
     S.activePopup = null;
     S.lastPicked = null;
+    if (S.inspectFocusMarker) { S.inspectFocusMarker.remove(); S.inspectFocusMarker = null; }
   }
 }
 

--- a/viz/src/windows.ts
+++ b/viz/src/windows.ts
@@ -762,12 +762,16 @@ function setPinnedCollapsedState(element: HTMLElement, collapsed: boolean) {
       contentEl.dataset.expandedDisplay = contentEl.style.display || 'grid';
       contentEl.style.display = 'none';
     }
-    element.style.height = `${getHeaderHeight(element)}px`;
+    element.dataset.expandedMinHeight = element.style.minHeight || '';
+    const headerHeight = getHeaderHeight(element);
+    element.style.minHeight = `${headerHeight}px`;
+    element.style.height = `${headerHeight}px`;
   } else {
     if (contentEl) {
       const expandedDisplay = contentEl.dataset.expandedDisplay || 'grid';
       contentEl.style.display = expandedDisplay;
     }
+    element.style.minHeight = element.dataset.expandedMinHeight ?? '';
     element.style.height = '';
     ensureWindowMinHeight(element);
   }

--- a/viz/src/windows.ts
+++ b/viz/src/windows.ts
@@ -32,6 +32,7 @@ let _updateLegendPosition: () => void = () => {};
 type DockableWindow = {
   element: HTMLElement;
   pinButton: HTMLButtonElement;
+  collapseButton: HTMLButtonElement | null;
 };
 
 type ResizeMode = 'both' | 'x' | 'y';
@@ -85,16 +86,42 @@ export function initWindowDocking(config: {
 }
 
 export function registerDockableWindow(windowEl: HTMLElement, pinButton: HTMLButtonElement) {
-  dockableWindows.push({ element: windowEl, pinButton });
+  const collapseButton = ensurePinnedCollapseButton(windowEl);
+  dockableWindows.push({ element: windowEl, pinButton, collapseButton });
   pinButton.addEventListener('click', (event) => {
     event.preventDefault();
     event.stopPropagation();
     togglePinnedState(windowEl);
   });
+  collapseButton?.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    togglePinnedCollapsed(windowEl);
+  });
   const minWidth = getWindowRequiredMinWidth(windowEl);
   const storedMin = Number(windowEl.dataset.minWidth ?? MIN_WINDOW_WIDTH);
   windowEl.dataset.minWidth = `${Math.max(storedMin, minWidth)}`;
   updatePinButtonState(windowEl);
+}
+
+function ensurePinnedCollapseButton(windowEl: HTMLElement) {
+  const header = windowEl.querySelector('.window-header') as HTMLElement | null;
+  if (!header) return null;
+  const existing = header.querySelector('.window-pin-collapse') as HTMLButtonElement | null;
+  if (existing) return existing;
+  const button = document.createElement('button');
+  button.className = 'window-pin-collapse';
+  button.type = 'button';
+  button.textContent = '▼';
+  button.title = 'Collapse pinned menu';
+  button.setAttribute('aria-expanded', 'true');
+  const firstChild = header.firstElementChild;
+  if (firstChild) {
+    header.insertBefore(button, firstChild);
+  } else {
+    header.appendChild(button);
+  }
+  return button;
 }
 
 export function enableWindowResizing(windowEl: HTMLElement) {
@@ -615,6 +642,9 @@ export function handleMouseUp() {
 }
 
 function getMinWindowHeight(element: HTMLElement) {
+  if (isPinnedCollapsed(element)) {
+    return getHeaderHeight(element);
+  }
   return Math.max(MIN_WINDOW_HEIGHT, element.scrollHeight);
 }
 
@@ -707,6 +737,48 @@ function updatePinButtonState(element: HTMLElement) {
   img.alt = pinned ? 'Unpin menu' : 'Pin menu';
   entry.pinButton.setAttribute('aria-pressed', String(pinned));
   entry.pinButton.title = pinned ? 'Unpin' : 'Pin';
+  updateCollapseButtonState(element, entry.collapseButton);
+}
+
+function updateCollapseButtonState(element: HTMLElement, collapseButton: HTMLButtonElement | null) {
+  if (!collapseButton) return;
+  const collapsed = isPinnedCollapsed(element);
+  collapseButton.textContent = '▼';
+  collapseButton.title = collapsed ? 'Expand pinned menu' : 'Collapse pinned menu';
+  collapseButton.setAttribute('aria-expanded', String(!collapsed));
+  collapseButton.style.transform = collapsed ? 'rotate(-90deg)' : 'none';
+}
+
+function isPinnedCollapsed(element: HTMLElement) {
+  return element.dataset.pinnedCollapsed === 'true';
+}
+
+function setPinnedCollapsedState(element: HTMLElement, collapsed: boolean) {
+  element.dataset.pinnedCollapsed = collapsed ? 'true' : 'false';
+  element.classList.toggle('is-pinned-collapsed', collapsed);
+  const contentEl = element.querySelector('[data-window-content]') as HTMLElement | null;
+  if (collapsed) {
+    if (contentEl) {
+      contentEl.dataset.expandedDisplay = contentEl.style.display || 'grid';
+      contentEl.style.display = 'none';
+    }
+    element.style.height = `${getHeaderHeight(element)}px`;
+  } else {
+    if (contentEl) {
+      const expandedDisplay = contentEl.dataset.expandedDisplay || 'grid';
+      contentEl.style.display = expandedDisplay;
+    }
+    element.style.height = '';
+    ensureWindowMinHeight(element);
+  }
+  const entry = dockableWindows.find(win => win.element === element);
+  updateCollapseButtonState(element, entry?.collapseButton ?? null);
+}
+
+function togglePinnedCollapsed(element: HTMLElement) {
+  if (!isPinned(element)) return;
+  setPinnedCollapsedState(element, !isPinnedCollapsed(element));
+  updatePinnedLayout();
 }
 
 function pinWindow(element: HTMLElement, column?: HTMLDivElement) {
@@ -768,6 +840,9 @@ function unpinWindow(element: HTMLElement) {
 function setPinnedState(element: HTMLElement, pinned: boolean) {
   element.dataset.pinned = pinned ? 'true' : 'false';
   element.classList.toggle('is-pinned', pinned);
+  if (!pinned) {
+    setPinnedCollapsedState(element, false);
+  }
 }
 
 function updatePinnedLayout() {

--- a/viz/src/windows.ts
+++ b/viz/src/windows.ts
@@ -28,6 +28,7 @@ export type WindowManager = {
 
 let _updateToolbarButtonStates: () => void = () => {};
 let _updateLegendPosition: () => void = () => {};
+let _onPinnedStateChanged: (element: HTMLElement, pinned: boolean) => void = () => {};
 
 type DockableWindow = {
   element: HTMLElement;
@@ -70,9 +71,11 @@ let windowZCounter = WINDOW_STACK_BASE;
 export function initWindowCallbacks(callbacks: {
   updateToolbarButtonStates: () => void;
   updateLegendPosition: () => void;
+  onPinnedStateChanged?: (element: HTMLElement, pinned: boolean) => void;
 }) {
   _updateToolbarButtonStates = callbacks.updateToolbarButtonStates;
   _updateLegendPosition = callbacks.updateLegendPosition;
+  _onPinnedStateChanged = callbacks.onPinnedStateChanged ?? (() => {});
 }
 
 export function initWindowDocking(config: {
@@ -847,6 +850,7 @@ function setPinnedState(element: HTMLElement, pinned: boolean) {
   if (!pinned) {
     setPinnedCollapsedState(element, false);
   }
+  _onPinnedStateChanged(element, pinned);
 }
 
 function updatePinnedLayout() {


### PR DESCRIPTION
## Summary
- replaced the down-chevron close/minimize icon in VIZ floating menu headers with `❌`
- updated all floating menu header close controls in `viz/index.html` (Layers, Settings, Filters, Statistics, Scatterplot, Comp Finder, Adjustment Schedule, Time Adjustment, Legend)
- left collapsible subsection toggles unchanged (still `▼`) as requested

## Validation
- manually inspected `viz/index.html` to confirm only floating menu header minimize buttons were changed
- captured an updated UI screenshot showing the new close icon in menu headers

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698e59f0d4b08326b6f5b49ec5066ab5)