### PR TITLE
Fix VIZ initial fit-to-data, comp finder panel sizing, and default selection color

### DIFF
--- a/viz/src/comp-finder.ts
+++ b/viz/src/comp-finder.ts
@@ -932,7 +932,7 @@ function buildDelta(value: any, subjectValue: any, type: 'numeric' | 'categorica
 
 
 function expandPanelForCompsIfNeeded() {
-  if (!isMenuVisible || comps.length === 0) return;
+  if (!isMenuVisible) return;
   const panel = els.panel;
   const header = panel.querySelector('.window-header') as HTMLElement | null;
   const content = panel.querySelector('[data-window-content]') as HTMLElement | null;
@@ -1247,6 +1247,7 @@ function updateEmptyStateUI() {
   els.criteriaSection.style.display = hasSubject ? 'grid' : 'none';
   updateThresholdUI();
   updateNoCompsIndicator();
+  setTimeout(() => expandPanelForCompsIfNeeded(), 0);
 }
 
 function renderCompsUI() {

--- a/viz/src/layers.ts
+++ b/viz/src/layers.ts
@@ -340,7 +340,7 @@ export function createLayerState(name: string, dataStoreId: string): LayerState 
     hiddenLegendItems: new Set(),
     selectedLegendItems: new Set(),
     selectedParcels: new Set(),
-    highlightColor: '#FFFF00',
+    highlightColor: '#32CD32',
     legendSortField: 'count',
     legendSortDirection: 'desc',
     customColors: new Map(),
@@ -634,7 +634,7 @@ export function removeLayer(layerId: string) {
       S.hiddenLegendItems = new Set();
       S.selectedLegendItems = new Set();
       S.selectedParcels = new Set();
-      S.highlightColor = '#FFFF00';
+      S.highlightColor = '#32CD32';
       S.filters = [];
       S.filterMode = 'none';
       S.filterActionMode = 'none';

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -1572,6 +1572,8 @@ window.addEventListener('data-sources-changed', () => {
 async function loadSelectedColumns() {
   if (!S.lastAsyncBuffer || !S.lastFile) return;
   showLoading('Reading geometry + selected fields…');
+  const hadDataBeforeLoad = Boolean(S.currentGeoJSON?.features?.length);
+  let shouldAutoZoomAfterLoad = false;
 
   try {
     const result: any = await toGeoJson({ file: S.lastAsyncBuffer, compressors });
@@ -1659,13 +1661,16 @@ async function loadSelectedColumns() {
     refreshTimeAdjustmentPanel();
     renderSettingsDataSourcesSection();
 
-    fitToData(S.currentGeoJSON);
+    shouldAutoZoomAfterLoad = !hadDataBeforeLoad && S.currentGeoJSON.features.length > 0;
     persistCurrentLayerState();
   } catch (err: any) {
     console.error('GeoParquet load failed:', err);
     if (!S.cancelRequested) alert(`GeoParquet load failed: ${err?.message ?? err}`);
   } finally {
     hideLoading();
+    if (shouldAutoZoomAfterLoad && S.currentGeoJSON) {
+      requestAnimationFrame(() => fitToData(S.currentGeoJSON!));
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation

- Restore the previous behavior where loading data into an empty VIZ session auto-zooms to the dataset extents. 
- Ensure the Comp Finder menu always expands to fit its rendered content (export buttons included) on first show so controls do not hang off the bottom. 
- Change the default selection highlight color to lime green to match the requested new visual default.

### Description

- Deferred the initial fit-to-data until after the loading overlay is hidden and only trigger it on a no-data → has-data transition by adding `hadDataBeforeLoad`/`shouldAutoZoomAfterLoad` logic and invoking `fitToData` inside a `requestAnimationFrame` in `viz/src/main.ts`.
- Removed the early `comps.length === 0` return in `expandPanelForCompsIfNeeded()` and added a scheduled call to that function from `updateEmptyStateUI()` so the Comp Finder panel will expand to fit its full content on initial render in `viz/src/comp-finder.ts`.
- Updated the default highlight color from yellow (`#FFFF00`) to lime green (`#32CD32`) in the layer defaults and when resetting the current state in `viz/src/layers.ts`.
- Files changed: `viz/src/main.ts`, `viz/src/comp-finder.ts`, `viz/src/layers.ts`.

### Testing

- Attempted a local build with `cd viz && npm run build`, which failed because `vite` is not available in the environment (`vite: not found`).
- Attempted to install dependencies with `cd viz && npm install`, which failed due to a `403 Forbidden` from the npm registry for `geoparquet`, so a full build/test could not be completed.
- Attempted a Playwright-based browser screenshot of `viz/index.html`, but file navigation failed in the test container (`ERR_FILE_NOT_FOUND`).
- All code changes were committed and verified via `git diff` and `git show`; no runtime regressions were observed locally because dependency installation and runtime testing were blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698fe7769e4c8326b804881e376f2a8c)