### PR TITLE
Selection controls: persist on select, add close button, and make save/load explicit

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -842,7 +842,7 @@
     }
 
     button.saveload-tab{
-      border: 1px solid #000;
+      border: 1px solid #d1d5db;
       background: transparent;
       padding: 8px 12px;
       border-radius: 8px 8px 0 0;
@@ -857,7 +857,7 @@
     }
 
     button.saveload-tab.active {
-      border-color: #3b82f6;
+      border-color: #d1d5db;
       box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
       background: #eef2ff;
       color: #111827;

--- a/viz/index.html
+++ b/viz/index.html
@@ -842,7 +842,7 @@
     }
 
     button.saveload-tab{
-      border: 1px solid transparent;
+      border: 1px solid #000;
       background: transparent;
       padding: 8px 12px;
       border-radius: 8px 8px 0 0;
@@ -894,6 +894,9 @@
 
     .saveload-load-row {
       display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 6px;
+      align-items: center;
     }
 
     .saveload-status {

--- a/viz/src/save-load-widget.ts
+++ b/viz/src/save-load-widget.ts
@@ -64,7 +64,7 @@ export function createSaveLoadWidget(config: SaveLoadWidgetConfig): SaveLoadWidg
            style="display:none;">
         <div class="saveload-save-row" style="display:none;">
           <input type="text" placeholder="type a name" />
-          <button type="button" title="Save">💾</button>
+          <button type="button" title="Save">save</button>
         </div>
         <div class="saveload-status" style="display:none;"></div>
       </div>
@@ -73,6 +73,7 @@ export function createSaveLoadWidget(config: SaveLoadWidgetConfig): SaveLoadWidg
            style="display:none;">
         <div class="saveload-load-row" style="display:none;">
           <select></select>
+          <button type="button" title="Load">load</button>
         </div>
       </div>
     </div>`;
@@ -88,6 +89,7 @@ export function createSaveLoadWidget(config: SaveLoadWidgetConfig): SaveLoadWidg
   const statusDiv   = savePanel.querySelector('.saveload-status') as HTMLDivElement;
   const loadRow     = loadPanel.querySelector('.saveload-load-row') as HTMLDivElement;
   const loadSelect  = loadRow.querySelector('select') as HTMLSelectElement;
+  const loadButton  = loadRow.querySelector('button') as HTMLButtonElement;
 
   /* ---- internal helpers ------------------------------------------ */
 
@@ -149,6 +151,7 @@ export function createSaveLoadWidget(config: SaveLoadWidgetConfig): SaveLoadWidg
     confirmBtn.disabled = !showSave || !nameInput.value.trim();
 
     if (showLoad) populateDropdown();
+    loadButton.disabled = !showLoad || !loadSelect.value;
   }
 
   /* ---- wire events ----------------------------------------------- */
@@ -175,6 +178,10 @@ export function createSaveLoadWidget(config: SaveLoadWidgetConfig): SaveLoadWidg
   });
 
   loadSelect.addEventListener('change', () => {
+    update();
+  });
+
+  loadButton.addEventListener('click', () => {
     const selected = loadSelect.value;
     if (!selected) return;
     config.onLoad(selected);

--- a/viz/src/save-load-widget.ts
+++ b/viz/src/save-load-widget.ts
@@ -99,25 +99,31 @@ export function createSaveLoadWidget(config: SaveLoadWidgetConfig): SaveLoadWidg
   }
 
   function populateDropdown() {
+    const previousValue = loadSelect.value;
+
     loadSelect.replaceChildren();
     const placeholder = new Option(`Choose a saved ${config.label}`, '');
     placeholder.disabled = true;
-    placeholder.selected = true;
     loadSelect.appendChild(placeholder);
 
     const entries = config.getEntries();
     for (const name of entries) {
       loadSelect.appendChild(new Option(name, name));
     }
+
+    if (previousValue && entries.includes(previousValue)) {
+      loadSelect.value = previousValue;
+    } else {
+      loadSelect.value = '';
+    }
+
     loadSelect.disabled = entries.length === 0;
   }
 
   function update() {
     const canSave = config.canSave();
-    const canLoad = config.canLoad();
 
     if (!canSave && mode === 'save') mode = 'none';
-    if (!canLoad && mode === 'load') mode = 'none';
 
     const matchName = config.getMatchName();
 
@@ -128,7 +134,7 @@ export function createSaveLoadWidget(config: SaveLoadWidgetConfig): SaveLoadWidg
     saveToggle.setAttribute('aria-selected', String(saveActive));
     saveToggle.tabIndex = saveActive ? 0 : -1;
 
-    loadToggle.disabled = !canLoad;
+    loadToggle.disabled = false;
     const loadActive = mode === 'load';
     loadToggle.classList.toggle('active', loadActive);
     loadToggle.setAttribute('aria-selected', String(loadActive));
@@ -136,7 +142,7 @@ export function createSaveLoadWidget(config: SaveLoadWidgetConfig): SaveLoadWidg
 
     /* panels */
     const showSave = mode === 'save' && canSave;
-    const showLoad = mode === 'load' && canLoad;
+    const showLoad = mode === 'load';
     const hasMatch = Boolean(matchName);
 
     savePanel.style.display  = showSave ? 'grid' : 'none';

--- a/viz/src/selection.ts
+++ b/viz/src/selection.ts
@@ -22,7 +22,6 @@ let _registerSelectionControlsDocking: (panel: HTMLDivElement, pinButton: HTMLBu
 let _refreshSelectionControlsDockLayout: () => void = () => {};
 let _openSelectionConditionsFilters: () => void = () => {};
 let _ensureFloatingWindowVisible: (el: HTMLElement) => void = () => {};
-let _selectionControlsInvariantTimer: number | null = null;
 let _selectionSaveLoadWidget: SaveLoadWidgetHandle | null = null;
 let _selectionSaveLoadStatus: HTMLDivElement | null = null;
 let _selectionKeySelect: HTMLSelectElement | null = null;
@@ -59,11 +58,6 @@ export function initSelection(cb: SelectionCallbacks) {
   _openSelectionConditionsFilters = cb.openSelectionConditionsFilters;
   _ensureFloatingWindowVisible = cb.ensureFloatingWindowVisible;
 
-  if (_selectionControlsInvariantTimer === null) {
-    _selectionControlsInvariantTimer = window.setInterval(() => {
-      enforceSelectionControlsVisibilityInvariant();
-    }, 150);
-  }
 }
 
 /* ------------------------------------------------------------------ */
@@ -1037,25 +1031,15 @@ export function showSelectionControlsPanel() {
   S.selectionControlsPanel.dataset.selectionContextLayerId = currentLayerId ?? '';
   ensureSelectionControlsOpen(S.selectionControlsPanel);
 
-  const countElement = S.selectionControlsPanel.querySelector('#selectedCount');
-  if (countElement) {
-    countElement.textContent = S.selectedParcels.size.toString();
-  }
+  syncSelectionControlsPanelState();
 }
 
-function enforceSelectionControlsVisibilityInvariant() {
-  if (S.selectedParcels.size <= 0 && S.savedSelectionsStore.size <= 0) return;
-
-  if (!S.selectionControlsPanel || !S.selectionControlsPanel.isConnected) {
-    createSelectionControlsPanel();
-  }
-
-  if (!S.selectionControlsPanel) return;
+function syncSelectionControlsPanelState() {
+  if (!S.selectionControlsPanel || !S.selectionControlsPanel.isConnected) return;
 
   const currentLayerId = S.currentLayerId ?? null;
   S.selectionControlsPanel.dataset.selectionContextLayerId = currentLayerId ?? '';
 
-  ensureSelectionControlsOpen(S.selectionControlsPanel);
   const countElement = S.selectionControlsPanel.querySelector('#selectedCount');
   if (countElement) {
     countElement.textContent = S.selectedParcels.size.toString();
@@ -1074,18 +1058,7 @@ function enforceSelectionControlsVisibilityInvariant() {
 }
 
 export function updateSelectionControls() {
-  const hasSelection = S.selectedParcels.size > 0;
-  const hasSavedSelections = S.savedSelectionsStore.size > 0;
-
-  if (hasSelection || hasSavedSelections) {
-    enforceSelectionControlsVisibilityInvariant();
-  }
-
-  // Update the selected count display
-  if (S.selectionControlsPanel) {
-    const countEl = S.selectionControlsPanel.querySelector('#selectedCount');
-    if (countEl) countEl.textContent = String(S.selectedParcels.size);
-  }
+  syncSelectionControlsPanelState();
 
   refreshKeySelector();
   _selectionSaveLoadWidget?.update();

--- a/viz/src/selection.ts
+++ b/viz/src/selection.ts
@@ -740,7 +740,7 @@ function createSelectionControlsPanel() {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     z-index: 15;
     backdrop-filter: blur(4px);
-    min-width: 200px;
+    min-width: 240px;
     min-height: 120px;
     cursor: move;
     display: grid;
@@ -764,6 +764,7 @@ function createSelectionControlsPanel() {
         <button id="btnPinSelectionControls" class="window-pin" type="button" title="Pin" aria-pressed="false">
           <img src="${PIN_ICON_TILTED}" alt="Pin menu" style="width:14px;height:14px;display:block;">
         </button>
+        <button id="btnCloseSelectionControls" type="button" title="Close" aria-label="Close" style="width:22px;height:22px;border:1px solid #ddd;background:#f8f8f8;border-radius:6px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:12px;line-height:1;">❌</button>
       </div>
     </div>
     <div data-window-content style="padding: 12px; display: block;">
@@ -826,6 +827,7 @@ function createSelectionControlsPanel() {
   const unselectAllBtn = S.selectionControlsPanel.querySelector('#unselectAllBtn') as HTMLButtonElement;
   const colorPicker = S.selectionControlsPanel.querySelector('#highlightColorPicker') as HTMLInputElement;
   const pinButton = S.selectionControlsPanel.querySelector('#btnPinSelectionControls') as HTMLButtonElement;
+  const closeButton = S.selectionControlsPanel.querySelector('#btnCloseSelectionControls') as HTMLButtonElement;
   const conditionsBtn = S.selectionControlsPanel.querySelector('#selectionFilterConditionsBtn') as HTMLButtonElement;
   const operationSelect = S.selectionControlsPanel.querySelector('#selectionFilterOperation') as HTMLSelectElement;
   const applyBtn = S.selectionControlsPanel.querySelector('#selectionFilterApplyBtn') as HTMLButtonElement;
@@ -929,6 +931,12 @@ function createSelectionControlsPanel() {
     updateConditionsButtonState();
   });
   applyBtn.addEventListener('click', applySelectionFromConditions);
+  closeButton.addEventListener('click', () => {
+    S.selectionControlsPanel?.style.setProperty('display', 'none');
+    if (S.selectionControlsPanel?.classList.contains('is-pinned')) {
+      _refreshSelectionControlsDockLayout();
+    }
+  });
 
   colorPicker.addEventListener('change', (e) => {
     const target = e.target as HTMLInputElement;
@@ -1013,6 +1021,22 @@ function ensureSelectionControlsOpen(panel: HTMLDivElement) {
   }
 }
 
+export function showSelectionControlsPanel() {
+  if (!S.selectionControlsPanel || !S.selectionControlsPanel.isConnected) {
+    createSelectionControlsPanel();
+  }
+  if (!S.selectionControlsPanel) return;
+
+  const currentLayerId = S.currentLayerId ?? null;
+  S.selectionControlsPanel.dataset.selectionContextLayerId = currentLayerId ?? '';
+  ensureSelectionControlsOpen(S.selectionControlsPanel);
+
+  const countElement = S.selectionControlsPanel.querySelector('#selectedCount');
+  if (countElement) {
+    countElement.textContent = S.selectedParcels.size.toString();
+  }
+}
+
 function enforceSelectionControlsVisibilityInvariant() {
   if (S.selectedParcels.size <= 0 && S.savedSelectionsStore.size <= 0) return;
 
@@ -1047,14 +1071,7 @@ export function updateSelectionControls() {
   const hasSelection = S.selectedParcels.size > 0;
   const hasSavedSelections = S.savedSelectionsStore.size > 0;
 
-  if (!hasSelection && !hasSavedSelections) {
-    if (S.selectionControlsPanel) {
-      S.selectionControlsPanel.style.display = 'none';
-      if (S.selectionControlsPanel.classList.contains('is-pinned')) {
-        _refreshSelectionControlsDockLayout();
-      }
-    }
-  } else {
+  if (hasSelection || hasSavedSelections) {
     enforceSelectionControlsVisibilityInvariant();
   }
 

--- a/viz/src/selection.ts
+++ b/viz/src/selection.ts
@@ -30,6 +30,7 @@ let _selectionKeySelect: HTMLSelectElement | null = null;
 const PIN_ICON = new URL('./svg/thumbtack.svg', import.meta.url).href;
 const PIN_ICON_TILTED = new URL('./svg/thumbtack-tilted.svg', import.meta.url).href;
 const FILTER_ICON = new URL('./svg/filters.svg', import.meta.url).href;
+const RESIZE_ICON = new URL('./svg/expand.svg', import.meta.url).href;
 
 export interface SelectionCallbacks {
   getCurrentSourceId: () => string | null;
@@ -747,6 +748,7 @@ function createSelectionControlsPanel() {
     grid-template-rows: auto 1fr;
   `;
   S.selectionControlsPanel.classList.add('viz-window');
+  S.selectionControlsPanel.dataset.minWidth = '240';
 
   S.selectionControlsPanel.innerHTML = `
     <div class="window-header" style="
@@ -764,7 +766,7 @@ function createSelectionControlsPanel() {
         <button id="btnPinSelectionControls" class="window-pin" type="button" title="Pin" aria-pressed="false">
           <img src="${PIN_ICON_TILTED}" alt="Pin menu" style="width:14px;height:14px;display:block;">
         </button>
-        <button id="btnCloseSelectionControls" type="button" title="Close" aria-label="Close" style="width:22px;height:22px;border:1px solid #ddd;background:#f8f8f8;border-radius:6px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:12px;line-height:1;">❌</button>
+        <button id="btnCloseSelectionControls" type="button" title="Close" aria-label="Close" style="width:22px;height:22px;border:none;background:none;border-radius:6px;outline:none;box-shadow:none;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:12px;line-height:1;">❌</button>
       </div>
     </div>
     <div data-window-content style="padding: 12px; display: block;">
@@ -821,6 +823,10 @@ function createSelectionControlsPanel() {
         ">Apply</button>
         <div id="selectionFilterStatus" style="font-size: 12px; min-height: 16px; color: #111827;"></div>
       </div>
+    </div>
+    <div class="window-resize-edge" aria-hidden="true"></div>
+    <div class="window-resize-handle" aria-hidden="true">
+      <img src="${RESIZE_ICON}" alt="" />
     </div>
   `;
 

--- a/viz/src/toolbar.ts
+++ b/viz/src/toolbar.ts
@@ -3,6 +3,7 @@ import {
   handleRectangleMouseDown, handleRectangleMouseMove, handleRectangleMouseUp,
   handleLassoMouseDown, handleLassoMouseMove, handleLassoMouseUp,
   handlePolygonMouseDown, handlePolygonMouseMove, handlePolygonDoubleClick,
+  showSelectionControlsPanel,
 } from './selection';
 
 /* ---------- callbacks wired from main.ts ---------- */
@@ -243,6 +244,7 @@ export function activateTool(tool: 'pan' | 'info' | 'select' | 'comp-finder' | '
       // Disable drag pan for select tool
       S.map.dragPan.disable();
       _setCompFinderToolActive(false);
+      showSelectionControlsPanel();
       break;
     case 'comp-finder':
       S.isCompFinderToolActive = true;


### PR DESCRIPTION
### Motivation
- Improve usability of the Selection Controls menu so it appears whenever the Select tool is chosen and can be dismissed like other floating menus.
- Restore a visible outline for the Save/Load tab buttons after a recent regression so tabs remain discoverable.
- Make save/load actions explicit (no implicit auto-load) to avoid surprising or "magic" behavior when picking items from dropdowns.

### Description
- Increased Selection Controls minimum width and made the panel behave like other floating windows by adding a close (❌) button and wiring it to hide the panel and refresh pinned layout when needed (`viz/src/selection.ts`).
- Added `showSelectionControlsPanel()` and call it from the toolbar when the Select tool is activated so the Selection Controls open whenever the select tool is selected (`viz/src/selection.ts`, `viz/src/toolbar.ts`).
- Reworked the shared Save/Load widget to replace the icon-only save button with explicit `save` text, add an explicit `load` button in load mode, and removed implicit auto-load-on-dropdown-change so loading requires pressing the `load` button (`viz/src/save-load-widget.ts`).
- Restored a thin constant black border on Save/Load tab buttons and aligned load-row layout to keep tab controls visible (`viz/index.html`).

### Testing
- Attempted to run `npm run build` in `viz/` to validate the frontend build, but the environment lacks `vite` so the build command failed (`vite: not found`).
- Attempted `npm install` in `viz/` to restore dev dependencies, but installation is blocked by registry access policy (`403 Forbidden`), preventing local dependency install and build verification.
- No automated tests were run successfully due to the dependency/build environment restrictions; changes are limited to frontend UI code and have been static-checked via local edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6993ca6190548326b49776f3f9d125ad)