### PR TITLE
Adjust VIZ selection filter control spacing and alignment

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -2279,48 +2279,105 @@
     </div>
     <div id="statisticsContent" data-window-content style="padding: 12px; display: grid; gap: 12px; align-content: start;">
       <div id="statsLayerSection" class="stats-section" style="display: grid; gap: 8px;">
-        <div style="font-weight: 600; font-size: 12px;">Layer:</div>
-        <select id="statsLayerName" class="layer-source-name"></select>
+        <div class="land-schedule-section-header">
+          <button id="statsLayerToggle" class="land-schedule-collapse-toggle" type="button" title="Collapse Layer">▼</button>
+          <div class="land-schedule-subtitle">Layer</div>
+        </div>
+        <div id="statsLayerBody" style="display: grid; gap: 8px;">
+          <select id="statsLayerName" class="layer-source-name"></select>
+          <div id="statsSubjectSection" class="stats-section"></div>
+        </div>
       </div>
-      <div id="statsSubjectSection" class="stats-section"></div>
 
       <div class="divider"></div>
 
-      <div id="statisticsSection" class="stats-section" style="display: none;">
-        <select id="statsField">
-          <option value="" selected disabled>Choose a field</option>
-        </select>
-        <div id="statsDetails" style="display: none; gap: 6px;">
-          <div id="statsNumericBlock" style="display: grid; gap: 6px;">
-            <div id="statsNormalizationControls" style="display: grid; gap: 6px;">
-              <label style="display:flex; gap:8px; align-items:center;">
-                <input type="radio" name="statsNormMode" id="stats-norm-asis" value="asis" checked />
-                <span>as-is</span>
-              </label>
-              <label style="display:flex; gap:8px; align-items:center;">
-                <input type="radio" name="statsNormMode" id="stats-norm-land" value="perLand" disabled />
-                <span>…per land size <em id="statsNormLandUnit">(unit)</em></span>
-              </label>
-              <label style="display:flex; gap:8px; align-items:center;">
-                <input type="radio" name="statsNormMode" id="stats-norm-bldg" value="perBuilding" disabled />
-                <span>…per building size <em id="statsNormBldgUnit">(unit)</em></span>
-              </label>
+      <div id="statsFieldSection" class="stats-section" style="display: grid; gap: 8px;">
+        <div class="land-schedule-section-header">
+          <button id="statsFieldToggle" class="land-schedule-collapse-toggle" type="button" title="Collapse Field">▼</button>
+          <div class="land-schedule-subtitle">Field</div>
+        </div>
+        <div id="statisticsSection" style="display: none; gap: 6px;">
+          <select id="statsField" class="layer-source-name">
+            <option value="" selected disabled>Choose a field</option>
+          </select>
+          <div id="statsDetails" style="display: none; gap: 6px;">
+            <div id="statsNumericBlock" style="display: grid; gap: 6px;">
+              <div id="statsNormalizationControls" style="display: grid; gap: 6px;">
+                <label style="display:flex; gap:8px; align-items:center;">
+                  <input type="radio" name="statsNormMode" id="stats-norm-asis" value="asis" checked />
+                  <span>as-is</span>
+                </label>
+                <label style="display:flex; gap:8px; align-items:center;">
+                  <input type="radio" name="statsNormMode" id="stats-norm-land" value="perLand" disabled />
+                  <span>…per land size <em id="statsNormLandUnit">(unit)</em></span>
+                </label>
+                <label style="display:flex; gap:8px; align-items:center;">
+                  <input type="radio" name="statsNormMode" id="stats-norm-bldg" value="perBuilding" disabled />
+                  <span>…per building size <em id="statsNormBldgUnit">(unit)</em></span>
+                </label>
+              </div>
+              <div class="divider"></div>
+              <div id="statsResults" style="display: grid; gap: 6px;">
+                <div class="stats-section" style="display: grid; gap: 6px;">
+                  <div class="land-schedule-section-header">
+                    <button id="statsSummaryToggle" class="land-schedule-collapse-toggle" type="button" title="Collapse Statistics">▼</button>
+                    <div class="land-schedule-subtitle">Statistics</div>
+                  </div>
+                  <div id="statsSummaryBody">
+                    <table class="stats-table">
+                      <tbody>
+                        <tr><td>Parcel count</td><td><span id="statsParcelCount">—</span></td></tr>
+                        <tr><td>Median</td><td><span id="statsMedian">—</span></td></tr>
+                        <tr><td>Mean</td><td><span id="statsMean">—</span></td></tr>
+                        <tr><td>Standard deviation</td><td><span id="statsStdDev">—</span></td></tr>
+                        <tr><td>Coefficient of dispersion</td><td><span id="statsCod">—</span></td></tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+                <div class="divider"></div>
+                <div class="stats-section" style="display: grid; gap: 6px;">
+                  <div class="land-schedule-section-header">
+                    <button id="statsPercentilesToggle" class="land-schedule-collapse-toggle" type="button" title="Collapse Percentiles">▼</button>
+                    <div class="land-schedule-subtitle">Percentiles</div>
+                  </div>
+                  <div id="statsPercentilesBody" class="stats-table-scroll">
+                    <table class="stats-table">
+                      <thead>
+                        <tr>
+                          <th>Tier</th>
+                          <th>Value</th>
+                          <th>Count</th>
+                        </tr>
+                      </thead>
+                      <tbody id="statsPercentiles"></tbody>
+                    </table>
+                  </div>
+                </div>
+                <div class="divider"></div>
+                <div class="stats-section" style="display: grid; gap: 6px;">
+                  <div class="land-schedule-section-header">
+                    <button id="statsHistogramToggle" class="land-schedule-collapse-toggle" type="button" title="Collapse Histogram">▼</button>
+                    <div class="land-schedule-subtitle">Histogram</div>
+                  </div>
+                  <div id="statsHistogramBody">
+                    <div class="stats-range">
+                      <div class="range-values">
+                        <label>Min: <input id="statsOverflowMinPct" type="text" inputmode="decimal" data-step="0.1" /></label>
+                        <label>Max: <input id="statsOverflowMaxPct" type="text" inputmode="decimal" data-step="0.1" /></label>
+                      </div>
+                    </div>
+                    <div id="statsHistogram" style="display: grid; grid-template-columns: repeat(10, 1fr); gap: 4px; align-items: end; height: 80px; margin-top: 6px;"></div>
+                  </div>
+                </div>
+              </div>
             </div>
-            <div class="divider"></div>
-            <div id="statsResults" style="display: grid; gap: 6px;">
+            <div id="statsCategoricalBlock" style="display: none; gap: 6px;">
               <table class="stats-table">
-                <thead>
-                  <tr>
-                    <th>Statistic</th>
-                    <th>Value</th>
-                  </tr>
-                </thead>
                 <tbody>
-                  <tr><td>Parcel count</td><td><span id="statsParcelCount">—</span></td></tr>
-                  <tr><td>Median</td><td><span id="statsMedian">—</span></td></tr>
-                  <tr><td>Mean</td><td><span id="statsMean">—</span></td></tr>
-                  <tr><td>Standard deviation</td><td><span id="statsStdDev">—</span></td></tr>
-                  <tr><td>Coefficient of dispersion</td><td><span id="statsCod">—</span></td></tr>
+                  <tr><td>Parcel count</td><td><span id="statsCategoricalParcelCount">—</span></td></tr>
+                  <tr><td>Unique category values</td><td><span id="statsCategoricalUniqueCount">—</span></td></tr>
+                  <tr><td>Modal category value</td><td><span id="statsCategoricalModalValue">—</span></td></tr>
                 </tbody>
               </table>
               <div class="divider"></div>
@@ -2328,51 +2385,13 @@
                 <table class="stats-table">
                   <thead>
                     <tr>
-                      <th>Percentile</th>
                       <th>Value</th>
                       <th>Count</th>
                     </tr>
                   </thead>
-                  <tbody id="statsPercentiles"></tbody>
+                  <tbody id="statsCategoricalValues"></tbody>
                 </table>
               </div>
-              <div class="divider"></div>
-              <div>
-                <div class="stats-range">
-                  <div class="range-values">
-                    <label>Min: <input id="statsOverflowMinPct" type="text" inputmode="decimal" data-step="0.1" /></label>
-                    <label>Max: <input id="statsOverflowMaxPct" type="text" inputmode="decimal" data-step="0.1" /></label>
-                  </div>
-                </div>
-                <div id="statsHistogram" style="display: grid; grid-template-columns: repeat(10, 1fr); gap: 4px; align-items: end; height: 80px; margin-top: 6px;"></div>
-              </div>
-            </div>
-          </div>
-          <div id="statsCategoricalBlock" style="display: none; gap: 6px;">
-            <table class="stats-table">
-              <thead>
-                <tr>
-                  <th>Statistic</th>
-                  <th>Value</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr><td>Parcel count</td><td><span id="statsCategoricalParcelCount">—</span></td></tr>
-                <tr><td>Unique category values</td><td><span id="statsCategoricalUniqueCount">—</span></td></tr>
-                <tr><td>Modal category value</td><td><span id="statsCategoricalModalValue">—</span></td></tr>
-              </tbody>
-            </table>
-            <div class="divider"></div>
-            <div class="stats-table-scroll">
-              <table class="stats-table">
-                <thead>
-                  <tr>
-                    <th>Value</th>
-                    <th>Count</th>
-                  </tr>
-                </thead>
-                <tbody id="statsCategoricalValues"></tbody>
-              </table>
             </div>
           </div>
         </div>

--- a/viz/src/layers.ts
+++ b/viz/src/layers.ts
@@ -344,7 +344,7 @@ export function createLayerState(name: string, dataStoreId: string): LayerState 
     hiddenLegendItems: new Set(),
     selectedLegendItems: new Set(),
     selectedParcels: new Set(),
-    highlightColor: '#00FF00',
+    highlightColor: S.highlightColor,
     legendSortField: 'count',
     legendSortDirection: 'desc',
     customColors: new Map(),
@@ -382,7 +382,6 @@ export function persistCurrentLayerState() {
   layer.hiddenLegendItems = S.hiddenLegendItems;
   layer.selectedLegendItems = S.selectedLegendItems;
   layer.selectedParcels = S.selectedParcels;
-  layer.highlightColor = S.highlightColor;
   layer.legendSortField = S.legendSortField;
   layer.legendSortDirection = S.legendSortDirection;
   layer.customColors = S.customColors;
@@ -416,7 +415,6 @@ export function applyLayerState(layer: LayerState) {
   S.hiddenLegendItems = layer.hiddenLegendItems;
   S.selectedLegendItems = layer.selectedLegendItems;
   S.selectedParcels = layer.selectedParcels;
-  S.highlightColor = layer.highlightColor;
   S.legendSortField = layer.legendSortField;
   S.legendSortDirection = layer.legendSortDirection;
   S.customColors = layer.customColors;
@@ -555,11 +553,11 @@ export function applyLayerOrderToMap() {
     const layer = S.layers.get(layerId);
     if (!layer) continue;
     const selectionOverlayLayerId = getSelectionOverlayLayerId(layer.layerId);
-    if (S.map.getLayer(selectionOverlayLayerId)) {
-      S.map.moveLayer(selectionOverlayLayerId);
-    }
     if (S.map.getLayer(layer.layerId)) {
       S.map.moveLayer(layer.layerId);
+    }
+    if (S.map.getLayer(selectionOverlayLayerId)) {
+      S.map.moveLayer(selectionOverlayLayerId);
     }
     if (S.map.getLayer(layer.errorLayerId)) {
       S.map.moveLayer(layer.errorLayerId);

--- a/viz/src/layers.ts
+++ b/viz/src/layers.ts
@@ -308,6 +308,10 @@ export function renderDataStoreList() {
 /*  Layer state management                                            */
 /* ------------------------------------------------------------------ */
 
+function getSelectionOverlayLayerId(layerId: string): string {
+  return `${layerId}-selection-overlay`;
+}
+
 export function createLayerState(name: string, dataStoreId: string): LayerState {
   S.layerCounter += 1;
   const suffix = `layer-${S.layerCounter}`;
@@ -550,6 +554,10 @@ export function applyLayerOrderToMap() {
     const layerId = S.layerOrder[i];
     const layer = S.layers.get(layerId);
     if (!layer) continue;
+    const selectionOverlayLayerId = getSelectionOverlayLayerId(layer.layerId);
+    if (S.map.getLayer(selectionOverlayLayerId)) {
+      S.map.moveLayer(selectionOverlayLayerId);
+    }
     if (S.map.getLayer(layer.layerId)) {
       S.map.moveLayer(layer.layerId);
     }
@@ -604,6 +612,10 @@ export function setLayerVisibility(layer: LayerState, visible: boolean) {
   if (S.map.getLayer(layer.layerId)) {
     S.map.setLayoutProperty(layer.layerId, 'visibility', visibility);
   }
+  const selectionOverlayLayerId = getSelectionOverlayLayerId(layer.layerId);
+  if (S.map.getLayer(selectionOverlayLayerId)) {
+    S.map.setLayoutProperty(selectionOverlayLayerId, 'visibility', visibility);
+  }
   if (S.map.getLayer(layer.errorLayerId)) {
     S.map.setLayoutProperty(layer.errorLayerId, 'visibility', visibility);
   }
@@ -613,6 +625,8 @@ export function removeLayer(layerId: string) {
   const layer = S.layers.get(layerId);
   if (!layer) return;
   if (S.map.getLayer(layer.layerId)) S.map.removeLayer(layer.layerId);
+  const selectionOverlayLayerId = getSelectionOverlayLayerId(layer.layerId);
+  if (S.map.getLayer(selectionOverlayLayerId)) S.map.removeLayer(selectionOverlayLayerId);
   if (S.map.getLayer(layer.errorLayerId)) S.map.removeLayer(layer.errorLayerId);
   if (S.map.getSource(layer.sourceId)) S.map.removeSource(layer.sourceId);
   S.layers.delete(layerId);

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -362,7 +362,7 @@ const btnPinLandSchedule = document.getElementById('btnPinLandSchedule') as HTML
 const btnPinTimeAdjustment = document.getElementById('btnPinTimeAdjustment') as HTMLButtonElement;
 const btnPinLegend = document.getElementById('btnPinLegend') as HTMLButtonElement;
 
-const statsSubjectControls = buildSubjectSelector(statsSubjectSection);
+const statsSubjectControls = buildSubjectSelector(statsSubjectSection, { title: null });
 const scatterSubjectControls = buildSubjectSelector(scatterSubjectSection, { title: null });
 
 const statsSubjectButtons = statsSubjectControls.buttons;
@@ -396,6 +396,15 @@ const statsNormLandUnitEl = document.getElementById('statsNormLandUnit') as HTML
 const statsNormBldgUnitEl = document.getElementById('statsNormBldgUnit') as HTMLElement;
 const statsOverflowMinPct = document.getElementById('statsOverflowMinPct') as HTMLInputElement;
 const statsOverflowMaxPct = document.getElementById('statsOverflowMaxPct') as HTMLInputElement;
+const statsLayerToggle = document.getElementById('statsLayerToggle') as HTMLButtonElement;
+const statsLayerBody = document.getElementById('statsLayerBody') as HTMLDivElement;
+const statsFieldToggle = document.getElementById('statsFieldToggle') as HTMLButtonElement;
+const statsSummaryToggle = document.getElementById('statsSummaryToggle') as HTMLButtonElement;
+const statsSummaryBody = document.getElementById('statsSummaryBody') as HTMLDivElement;
+const statsPercentilesToggle = document.getElementById('statsPercentilesToggle') as HTMLButtonElement;
+const statsPercentilesBody = document.getElementById('statsPercentilesBody') as HTMLDivElement;
+const statsHistogramToggle = document.getElementById('statsHistogramToggle') as HTMLButtonElement;
+const statsHistogramBody = document.getElementById('statsHistogramBody') as HTMLDivElement;
 const landScheduleControlsEl = document.getElementById('landScheduleControls') as HTMLDivElement;
 const timeAdjustmentControlsEl = document.getElementById('timeAdjustmentControls') as HTMLDivElement;
 const timeAdjustmentContent = document.getElementById('timeAdjustmentContent') as HTMLDivElement;
@@ -585,6 +594,72 @@ const setPaintSectionCollapsed = (collapsed: boolean) => {
 setPaintSectionCollapsed(S.isPaintCollapsed);
 paintSectionToggle.addEventListener('click', () => {
   setPaintSectionCollapsed(!S.isPaintCollapsed);
+});
+
+const setStatsLayerCollapsed = (collapsed: boolean) => {
+  S.isStatsLayerCollapsed = collapsed;
+  statsLayerBody.style.display = collapsed ? 'none' : 'grid';
+  statsLayerToggle.classList.toggle('is-collapsed', collapsed);
+  statsLayerToggle.title = collapsed ? 'Expand Layer' : 'Collapse Layer';
+  refreshWindowMinHeight(statisticsControlsEl);
+};
+
+const setStatsFieldCollapsed = (collapsed: boolean) => {
+  S.isStatsFieldCollapsed = collapsed;
+  statisticsSection.style.display = collapsed ? 'none' : 'grid';
+  statsFieldToggle.classList.toggle('is-collapsed', collapsed);
+  statsFieldToggle.title = collapsed ? 'Expand Field' : 'Collapse Field';
+  refreshWindowMinHeight(statisticsControlsEl);
+};
+
+const setStatsSummaryCollapsed = (collapsed: boolean) => {
+  S.isStatsSummaryCollapsed = collapsed;
+  statsSummaryBody.style.display = collapsed ? 'none' : 'block';
+  statsSummaryToggle.classList.toggle('is-collapsed', collapsed);
+  statsSummaryToggle.title = collapsed ? 'Expand Statistics' : 'Collapse Statistics';
+  refreshWindowMinHeight(statisticsControlsEl);
+};
+
+const setStatsPercentilesCollapsed = (collapsed: boolean) => {
+  S.isStatsPercentilesCollapsed = collapsed;
+  statsPercentilesBody.style.display = collapsed ? 'none' : 'block';
+  statsPercentilesToggle.classList.toggle('is-collapsed', collapsed);
+  statsPercentilesToggle.title = collapsed ? 'Expand Percentiles' : 'Collapse Percentiles';
+  refreshWindowMinHeight(statisticsControlsEl);
+};
+
+const setStatsHistogramCollapsed = (collapsed: boolean) => {
+  S.isStatsHistogramCollapsed = collapsed;
+  statsHistogramBody.style.display = collapsed ? 'none' : 'block';
+  statsHistogramToggle.classList.toggle('is-collapsed', collapsed);
+  statsHistogramToggle.title = collapsed ? 'Expand Histogram' : 'Collapse Histogram';
+  refreshWindowMinHeight(statisticsControlsEl);
+};
+
+setStatsLayerCollapsed(S.isStatsLayerCollapsed);
+setStatsFieldCollapsed(S.isStatsFieldCollapsed);
+setStatsSummaryCollapsed(S.isStatsSummaryCollapsed);
+setStatsPercentilesCollapsed(S.isStatsPercentilesCollapsed);
+setStatsHistogramCollapsed(S.isStatsHistogramCollapsed);
+
+statsLayerToggle.addEventListener('click', () => {
+  setStatsLayerCollapsed(!S.isStatsLayerCollapsed);
+});
+
+statsFieldToggle.addEventListener('click', () => {
+  setStatsFieldCollapsed(!S.isStatsFieldCollapsed);
+});
+
+statsSummaryToggle.addEventListener('click', () => {
+  setStatsSummaryCollapsed(!S.isStatsSummaryCollapsed);
+});
+
+statsPercentilesToggle.addEventListener('click', () => {
+  setStatsPercentilesCollapsed(!S.isStatsPercentilesCollapsed);
+});
+
+statsHistogramToggle.addEventListener('click', () => {
+  setStatsHistogramCollapsed(!S.isStatsHistogramCollapsed);
 });
 
 const setLandScheduleTablesCollapsed = (collapsed: boolean) => {

--- a/viz/src/rendering.ts
+++ b/viz/src/rendering.ts
@@ -166,6 +166,23 @@ export function getOpacityValue(): number {
   return parseFloat(_opacityInput.value);
 }
 
+function getSafeOpacityScalar(): number {
+  const value = getOpacityValue();
+  if (!Number.isFinite(value)) {
+    console.warn('[rendering] Invalid opacity value; expected finite number. Falling back to 1.', {
+      raw: _opacityInput?.value,
+      parsed: value
+    });
+    return 1;
+  }
+  if (value < 0 || value > 1) {
+    const clamped = Math.max(0, Math.min(1, value));
+    console.warn('[rendering] Opacity out of range; clamping to [0,1].', { value, clamped });
+    return clamped;
+  }
+  return value;
+}
+
 
 export function getRampName(): string {
   return _rampSelect?.value ?? 'Magma';
@@ -306,12 +323,23 @@ function getFeatureInspectFocusLngLat(feature: GeoJSON.Feature, fallback: maplib
 
 export function addExtrusionLayer(layer: LayerState) {
   if (S.map.getLayer(layer.layerId)) return;
+
+  const baseOpacity = getSafeOpacityScalar();
+  if (!Number.isFinite(baseOpacity)) {
+    console.error('[rendering] Refusing to add extrusion layer with non-finite opacity.', {
+      layerId: layer.layerId,
+      rawOpacityInput: _opacityInput?.value,
+      parsedOpacity: baseOpacity
+    });
+    return;
+  }
+
   S.map.addLayer({
     id: layer.layerId, type: 'fill-extrusion', source: layer.sourceId,
     paint: {
       'fill-extrusion-color': '#888',
       'fill-extrusion-height': 0,
-      'fill-extrusion-opacity': getOpacityValue(),
+      'fill-extrusion-opacity': baseOpacity,
       'fill-extrusion-vertical-gradient': true
     }
   });
@@ -749,7 +777,7 @@ export function applyGrayRendering() {
   ] as any;
   S.map.setPaintProperty(ids.layerId, 'fill-extrusion-color', grayWithSelectionColor);
   S.map.setPaintProperty(ids.layerId, 'fill-extrusion-height', 0);
-  S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', getOpacityValue());
+  S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', getSafeOpacityScalar());
 
   const overlayLayerId = getSelectionOverlayLayerId(ids.layerId);
   if (S.map.getLayer(overlayLayerId)) {
@@ -785,7 +813,7 @@ export function applyExtrusion() {
 
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-color', colorExpr);
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-height', 0);
-    S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', getOpacityValue());
+    S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', getSafeOpacityScalar());
 
     if (S.map.getLayer(overlayLayerId)) {
       S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-color', S.highlightColor);
@@ -804,7 +832,7 @@ export function applyExtrusion() {
 
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-color', colorExpr);
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-height', heightExpr);
-    S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', getOpacityValue());
+    S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', getSafeOpacityScalar());
 
     if (S.map.getLayer(overlayLayerId)) {
       S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-color', S.highlightColor);

--- a/viz/src/rendering.ts
+++ b/viz/src/rendering.ts
@@ -212,7 +212,7 @@ function ensureSelectionOverlayLayer(layer: LayerState) {
       'fill-extrusion-opacity': 1,
       'fill-extrusion-vertical-gradient': true
     }
-  }, layer.layerId);
+  });
 }
 
 /* ================================================================== */

--- a/viz/src/rendering.ts
+++ b/viz/src/rendering.ts
@@ -166,6 +166,13 @@ export function getOpacityValue(): number {
   return parseFloat(_opacityInput.value);
 }
 
+function buildSelectionOpacityExpression(): Expression {
+  return ['case',
+    ['boolean', ['feature-state', 'selected'], false], 1,
+    getOpacityValue()
+  ] as any;
+}
+
 export function getRampName(): string {
   return _rampSelect?.value ?? 'Magma';
 }
@@ -287,7 +294,7 @@ export function addExtrusionLayer(layer: LayerState) {
     paint: {
       'fill-extrusion-color': '#888',
       'fill-extrusion-height': 0,
-      'fill-extrusion-opacity': parseFloat(_opacityInput.value),
+      'fill-extrusion-opacity': buildSelectionOpacityExpression(),
       'fill-extrusion-vertical-gradient': true
     }
   });
@@ -724,7 +731,7 @@ export function applyGrayRendering() {
   ] as any;
   S.map.setPaintProperty(ids.layerId, 'fill-extrusion-color', grayWithSelectionColor);
   S.map.setPaintProperty(ids.layerId, 'fill-extrusion-height', 0);
-  S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', parseFloat(_opacityInput.value));
+  S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', buildSelectionOpacityExpression());
 
   applyMapFilters();
 
@@ -751,7 +758,7 @@ export function applyExtrusion() {
 
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-color', colorExpr);
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-height', 0);
-    S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', parseFloat(_opacityInput.value));
+    S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', buildSelectionOpacityExpression());
   } else {
     // For numeric fields, use the new color expression builder
     const colorExpr = buildNumericColorExpression();
@@ -764,7 +771,7 @@ export function applyExtrusion() {
 
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-color', colorExpr);
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-height', heightExpr);
-    S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', parseFloat(_opacityInput.value));
+    S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', buildSelectionOpacityExpression());
   }
 
   // refresh which features are flagged as erroneous for current mode

--- a/viz/src/rendering.ts
+++ b/viz/src/rendering.ts
@@ -166,15 +166,32 @@ export function getOpacityValue(): number {
   return parseFloat(_opacityInput.value);
 }
 
-function buildSelectionOpacityExpression(): Expression {
-  return ['case',
-    ['boolean', ['feature-state', 'selected'], false], 1,
-    getOpacityValue()
-  ] as any;
-}
 
 export function getRampName(): string {
   return _rampSelect?.value ?? 'Magma';
+}
+
+function getSelectionOverlayLayerId(layerId: string): string {
+  return `${layerId}-selection-overlay`;
+}
+
+function ensureSelectionOverlayLayer(layer: LayerState) {
+  const overlayLayerId = getSelectionOverlayLayerId(layer.layerId);
+  if (S.map.getLayer(overlayLayerId)) return;
+  S.map.addLayer({
+    id: overlayLayerId,
+    type: 'fill-extrusion',
+    source: layer.sourceId,
+    paint: {
+      'fill-extrusion-color': ['case',
+        ['boolean', ['feature-state', 'selected'], false], S.highlightColor,
+        'rgba(0,0,0,0)'
+      ] as any,
+      'fill-extrusion-height': 0,
+      'fill-extrusion-opacity': 1,
+      'fill-extrusion-vertical-gradient': true
+    }
+  }, layer.layerId);
 }
 
 /* ================================================================== */
@@ -294,10 +311,11 @@ export function addExtrusionLayer(layer: LayerState) {
     paint: {
       'fill-extrusion-color': '#888',
       'fill-extrusion-height': 0,
-      'fill-extrusion-opacity': buildSelectionOpacityExpression(),
+      'fill-extrusion-opacity': getOpacityValue(),
       'fill-extrusion-vertical-gradient': true
     }
   });
+  ensureSelectionOverlayLayer(layer);
   _setLayerVisibility(layer, layer.visible);
 
   // NEW: parcel selection and inspection
@@ -731,7 +749,14 @@ export function applyGrayRendering() {
   ] as any;
   S.map.setPaintProperty(ids.layerId, 'fill-extrusion-color', grayWithSelectionColor);
   S.map.setPaintProperty(ids.layerId, 'fill-extrusion-height', 0);
-  S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', buildSelectionOpacityExpression());
+  S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', getOpacityValue());
+
+  const overlayLayerId = getSelectionOverlayLayerId(ids.layerId);
+  if (S.map.getLayer(overlayLayerId)) {
+    S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-color', S.highlightColor);
+    S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-height', 0);
+    S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-opacity', 1);
+  }
 
   applyMapFilters();
 
@@ -752,13 +777,21 @@ export function applyExtrusion() {
     return;
   }
 
+  const overlayLayerId = getSelectionOverlayLayerId(ids.layerId);
+
   if (S.currentFieldType === 'categorical') {
     // For categorical fields, no extrusion - just color
     const colorExpr = buildCategoricalColorExpression();
 
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-color', colorExpr);
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-height', 0);
-    S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', buildSelectionOpacityExpression());
+    S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', getOpacityValue());
+
+    if (S.map.getLayer(overlayLayerId)) {
+      S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-color', S.highlightColor);
+      S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-height', 0);
+      S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-opacity', 1);
+    }
   } else {
     // For numeric fields, use the new color expression builder
     const colorExpr = buildNumericColorExpression();
@@ -771,7 +804,13 @@ export function applyExtrusion() {
 
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-color', colorExpr);
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-height', heightExpr);
-    S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', buildSelectionOpacityExpression());
+    S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', getOpacityValue());
+
+    if (S.map.getLayer(overlayLayerId)) {
+      S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-color', S.highlightColor);
+      S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-height', heightExpr);
+      S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-opacity', 1);
+    }
   }
 
   // refresh which features are flagged as erroneous for current mode

--- a/viz/src/rendering.ts
+++ b/viz/src/rendering.ts
@@ -192,6 +192,13 @@ function getSelectionOverlayLayerId(layerId: string): string {
   return `${layerId}-selection-overlay`;
 }
 
+function getSelectionOverlayColorExpression(): Expression {
+  return ['case',
+    ['boolean', ['feature-state', 'selected'], false], S.highlightColor,
+    'rgba(0,0,0,0)'
+  ] as any;
+}
+
 function ensureSelectionOverlayLayer(layer: LayerState) {
   const overlayLayerId = getSelectionOverlayLayerId(layer.layerId);
   if (S.map.getLayer(overlayLayerId)) return;
@@ -200,10 +207,7 @@ function ensureSelectionOverlayLayer(layer: LayerState) {
     type: 'fill-extrusion',
     source: layer.sourceId,
     paint: {
-      'fill-extrusion-color': ['case',
-        ['boolean', ['feature-state', 'selected'], false], S.highlightColor,
-        'rgba(0,0,0,0)'
-      ] as any,
+      'fill-extrusion-color': getSelectionOverlayColorExpression(),
       'fill-extrusion-height': 0,
       'fill-extrusion-opacity': 1,
       'fill-extrusion-vertical-gradient': true
@@ -781,7 +785,7 @@ export function applyGrayRendering() {
 
   const overlayLayerId = getSelectionOverlayLayerId(ids.layerId);
   if (S.map.getLayer(overlayLayerId)) {
-    S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-color', S.highlightColor);
+    S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-color', getSelectionOverlayColorExpression());
     S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-height', 0);
     S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-opacity', 1);
   }
@@ -816,7 +820,7 @@ export function applyExtrusion() {
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', getSafeOpacityScalar());
 
     if (S.map.getLayer(overlayLayerId)) {
-      S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-color', S.highlightColor);
+      S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-color', getSelectionOverlayColorExpression());
       S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-height', 0);
       S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-opacity', 1);
     }
@@ -835,7 +839,7 @@ export function applyExtrusion() {
     S.map.setPaintProperty(ids.layerId, 'fill-extrusion-opacity', getSafeOpacityScalar());
 
     if (S.map.getLayer(overlayLayerId)) {
-      S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-color', S.highlightColor);
+      S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-color', getSelectionOverlayColorExpression());
       S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-height', heightExpr);
       S.map.setPaintProperty(overlayLayerId, 'fill-extrusion-opacity', 1);
     }

--- a/viz/src/selection.ts
+++ b/viz/src/selection.ts
@@ -764,20 +764,22 @@ function createSelectionControlsPanel() {
       </div>
     </div>
     <div data-window-content style="padding: 12px; display: block;">
-      <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+      <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px; flex-wrap: wrap;">
         <input type="color" id="highlightColorPicker" value="${S.highlightColor}" style="width: 30px; height: 20px; border: 1px solid #ddd; border-radius: 3px; cursor: pointer;">
         <span style="font-size: 12px;">Selected:</span>
         <span id="selectedCount" style="font-weight: 600;">${S.selectedParcels.size}</span>
+        <button id="unselectAllBtn" style="
+          border: 1px solid #ddd;
+          background: #f8f8f8;
+          padding: 4px 8px;
+          border-radius: 6px;
+          cursor: pointer;
+          font-size: 12px;
+          margin-left: auto;
+          width: auto;
+          white-space: nowrap;
+        ">Unselect all</button>
       </div>
-      <button id="unselectAllBtn" style="
-        width: 100%;
-        border: 1px solid #ddd;
-        background: #f8f8f8;
-        padding: 6px 8px;
-        border-radius: 6px;
-        cursor: pointer;
-        font-size: 12px;
-      ">Unselect All</button>
       <div style="margin-top: 10px; border-top: 1px solid #e5e7eb; padding-top: 10px; display: grid; gap: 8px;">
         <div style="font-size: 12px; font-weight: 600;">Select with filter:</div>
         <div style="display: flex; align-items: center; gap: 8px;">

--- a/viz/src/selection.ts
+++ b/viz/src/selection.ts
@@ -780,41 +780,47 @@ function createSelectionControlsPanel() {
       ">Unselect All</button>
       <div style="margin-top: 10px; border-top: 1px solid #e5e7eb; padding-top: 10px; display: grid; gap: 8px;">
         <div style="font-size: 12px; font-weight: 600;">Select with filter:</div>
-        <button id="selectionFilterConditionsBtn" type="button" style="
-          width: 100%;
-          border: 1px solid #ddd;
-          background: #f8f8f8;
-          padding: 6px 8px;
-          border-radius: 6px;
-          cursor: pointer;
-          font-size: 12px;
-          display: flex;
-          align-items: center;
-          gap: 6px;
-          justify-content: center;
-        "><img src="${FILTER_ICON}" alt="Filters" style="width:12px;height:12px;">conditions...</button>
-        <select id="selectionFilterOperation" style="
-          width: 100%;
-          border: 1px solid #ddd;
-          background: #fff;
-          padding: 6px 8px;
-          border-radius: 6px;
-          cursor: pointer;
-          font-size: 12px;
-        ">
-          <option value="add" selected>add to selection</option>
-          <option value="remove">remove from selection</option>
-          <option value="set">set selection to</option>
-        </select>
-        <button id="selectionFilterApplyBtn" style="
-          width: 100%;
-          border: 1px solid #ddd;
-          background: #f8f8f8;
-          padding: 6px 8px;
-          border-radius: 6px;
-          cursor: pointer;
-          font-size: 12px;
-        ">Apply</button>
+        <div style="display: flex; align-items: center; gap: 8px;">
+          <button id="selectionFilterConditionsBtn" type="button" style="
+            flex: 1 1 auto;
+            min-width: 0;
+            border: 1px solid #ddd;
+            background: #f8f8f8;
+            padding: 6px 8px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 12px;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            justify-content: center;
+          "><img src="${FILTER_ICON}" alt="Filters" style="width:12px;height:12px;">conditions...</button>
+          <select id="selectionFilterOperation" style="
+            flex: 0 0 142px;
+            border: 1px solid #ddd;
+            background: #fff;
+            padding: 6px 8px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 12px;
+          ">
+            <option value="add" selected>add to selection</option>
+            <option value="remove">remove from selection</option>
+            <option value="set">set selection to</option>
+          </select>
+        </div>
+        <div style="display: flex; justify-content: flex-end;">
+          <button id="selectionFilterApplyBtn" style="
+            border: 1px solid #ddd;
+            background: #f8f8f8;
+            padding: 6px 18px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 12px;
+            width: auto;
+            text-transform: lowercase;
+          ">apply</button>
+        </div>
         <div id="selectionFilterStatus" style="font-size: 12px; min-height: 16px; color: #111827;"></div>
       </div>
     </div>

--- a/viz/src/state.ts
+++ b/viz/src/state.ts
@@ -130,6 +130,11 @@ export const S = {
   statsOverflowPct: { min: 5, max: 95 },
   statsLayerId: null as string | null,
   statsFilteredName: null as string | null,
+  isStatsLayerCollapsed: false,
+  isStatsFieldCollapsed: false,
+  isStatsSummaryCollapsed: false,
+  isStatsPercentilesCollapsed: false,
+  isStatsHistogramCollapsed: false,
 
   // --- Scatterplot ---
   scatterSubjectMode: 'all' as SubjectMode,

--- a/viz/src/statistics.ts
+++ b/viz/src/statistics.ts
@@ -796,7 +796,6 @@ export function setStatsSubjectMode(mode: SubjectMode) {
 }
 
 export function updateStatisticsSectionVisibility() {
-  statisticsSection.style.display = 'grid';
   populateStatisticsFields();
   const hasField = Boolean(S.statsField);
   statsDetails.style.display = hasField ? 'grid' : 'none';


### PR DESCRIPTION
### Motivation
- Make the Selection Controls "Select with filter" area more compact by placing the `conditions...` button and operation dropdown on a single row and moving the `Apply` control to a short, right-aligned button on the next line.

### Description
- Updated the selection controls markup in `viz/src/selection.ts` to wrap the `conditions...` button and `selectionFilterOperation` dropdown in a flex row and set sensible flex sizing so they share a single line. 
- Replaced the full-width `selectionFilterApplyBtn` with a shorter right-aligned button on the following line while preserving the existing element IDs and behavior. 
- Kept all event hookups and state logic intact; only layout and inline sizing/styles were changed.

### Testing
- Ran `npm run build` in `viz/`, which completed successfully. 
- Launched the dev server with `npm run dev` and captured a browser screenshot via an automated Playwright script to verify the new layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6994877043bc83268c04633bcac20b8d)