### PR TITLE
Refine Layers & Statistics panels: Field-to-visualize section, remove Current layer readout, consolidate Paint controls

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -1043,7 +1043,9 @@
       color: #333;
     }
 
-    .land-schedule-collapse-toggle {
+    .land-schedule-collapse-toggle,
+    #controls .land-schedule-collapse-toggle,
+    #settingsControls .land-schedule-collapse-toggle {
       border: none;
       background: transparent;
       cursor: pointer;
@@ -1053,12 +1055,16 @@
       transition: transform 0.2s ease;
     }
 
-    .land-schedule-collapse-toggle:hover {
+    .land-schedule-collapse-toggle:hover,
+    #controls .land-schedule-collapse-toggle:hover,
+    #settingsControls .land-schedule-collapse-toggle:hover {
       background: #f3f4f6;
       border-radius: 6px;
     }
 
-    .land-schedule-collapse-toggle.is-collapsed {
+    .land-schedule-collapse-toggle.is-collapsed,
+    #controls .land-schedule-collapse-toggle.is-collapsed,
+    #settingsControls .land-schedule-collapse-toggle.is-collapsed {
       transform: rotate(-90deg);
     }
 

--- a/viz/index.html
+++ b/viz/index.html
@@ -2416,7 +2416,7 @@
     </div>
   </div>
 
-  <div id="scatterplotControls" class="viz-window" style="position: absolute; top: 10px; left: 900px; width: min(calc(92vw - 80px), 520px); background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
+  <div id="scatterplotControls" class="viz-window" style="position: absolute; top: 10px; left: 900px; width: min(calc(92vw - 80px), 520px); min-width: 520px; background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
     <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
       <div style="font-weight: 600; font-size: 13px;">Scatterplot</div>
       <div class="window-actions">

--- a/viz/index.html
+++ b/viz/index.html
@@ -2310,26 +2310,26 @@
           <div class="land-schedule-subtitle">Field</div>
         </div>
         <div id="statisticsSection" style="display: none; gap: 6px;">
-          <select id="statsField" class="layer-source-name">
-            <option value="" selected disabled>Choose a field</option>
-          </select>
+          <div class="field-visualize-row">
+            <select id="statsField" class="layer-source-name">
+              <option value="" selected disabled>Choose a field</option>
+            </select>
+            <select id="statsNormModeSelect" class="layer-source-name">
+              <option value="asis">as-is</option>
+              <option value="perLand">…per land size (unit)</option>
+              <option value="perBuilding">…per building size (unit)</option>
+            </select>
+          </div>
+          <div id="statsNormalizationControls" style="display: none;">
+            <input type="radio" name="statsNormMode" id="stats-norm-asis" value="asis" checked />
+            <input type="radio" name="statsNormMode" id="stats-norm-land" value="perLand" disabled />
+            <input type="radio" name="statsNormMode" id="stats-norm-bldg" value="perBuilding" disabled />
+            <em id="statsNormLandUnit">(unit)</em>
+            <em id="statsNormBldgUnit">(unit)</em>
+          </div>
         </div>
         <div id="statsDetails" style="display: none; gap: 6px;">
           <div id="statsNumericBlock" style="display: grid; gap: 6px;">
-              <div id="statsNormalizationControls" style="display: grid; gap: 6px;">
-                <label style="display:flex; gap:8px; align-items:center;">
-                  <input type="radio" name="statsNormMode" id="stats-norm-asis" value="asis" checked />
-                  <span>as-is</span>
-                </label>
-                <label style="display:flex; gap:8px; align-items:center;">
-                  <input type="radio" name="statsNormMode" id="stats-norm-land" value="perLand" disabled />
-                  <span>…per land size <em id="statsNormLandUnit">(unit)</em></span>
-                </label>
-                <label style="display:flex; gap:8px; align-items:center;">
-                  <input type="radio" name="statsNormMode" id="stats-norm-bldg" value="perBuilding" disabled />
-                  <span>…per building size <em id="statsNormBldgUnit">(unit)</em></span>
-                </label>
-              </div>
               <div class="divider"></div>
               <div id="statsResults" style="display: grid; gap: 6px;">
                 <div class="stats-section" style="display: grid; gap: 6px;">

--- a/viz/index.html
+++ b/viz/index.html
@@ -482,10 +482,34 @@
       padding: 6px 8px;
     }
 
-    .current-layer-header {
+    .layer-section-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
       font-size: 12px;
+      font-weight: 600;
       color: #111827;
-      margin-top: 6px;
+    }
+
+    .layer-collapse-toggle {
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      font-size: 14px;
+      color: #4b5563;
+      padding: 2px 4px;
+      transition: transform 0.2s ease;
+    }
+
+    .layer-collapse-toggle.is-collapsed {
+      transform: rotate(-90deg);
+    }
+
+    .field-visualize-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 130px;
+      gap: 8px;
+      align-items: center;
     }
 
     .current-layer-source {
@@ -2031,15 +2055,31 @@
         <div id="layerList" class="layer-list"></div>
       </fieldset>
 
-      <div class="current-layer-header">Current layer</div>
-      <div id="currentLayerSource" class="current-layer-source">source: —</div>
+      <div class="stats-section" style="display: grid; gap: 8px;">
+        <div class="layer-section-header">
+          <button id="fieldVisualizeToggle" class="layer-collapse-toggle" type="button" title="Collapse Field to visualize">▼</button>
+          <span>Field to visualize</span>
+        </div>
+        <div id="fieldVisualizeBody" style="display: grid; gap: 6px;">
+          <div class="field-visualize-row">
+            <select id="field"><option value="" disabled selected>— load a file first —</option></select>
+            <select id="normModeSelect" class="layer-source-name">
+              <option value="asis">as-is</option>
+              <option value="perLand">…per land size (unit)</option>
+              <option value="perBuilding">…per building size (unit)</option>
+            </select>
+          </div>
+          <div id="fieldTypeReadout" class="current-layer-source">Field type: —</div>
+        </div>
+      </div>
 
-      <div class="divider"></div>
-
-      <fieldset>
-        <label for="field">Field to visualize</label>
-        <select id="field"><option value="" disabled selected>— load a file first —</option></select>
-      </fieldset>
+      <div id="normModeLegacyRadios" style="display: none;">
+        <input type="radio" name="normMode" id="norm-asis" value="asis" checked />
+        <input type="radio" name="normMode" id="norm-land" value="perLand" />
+        <input type="radio" name="normMode" id="norm-bldg" value="perBuilding" />
+        <em id="normLandUnit">(unit)</em>
+        <em id="normBldgUnit">(unit)</em>
+      </div>
 
       <fieldset id="legend">      </fieldset>
 
@@ -2053,24 +2093,6 @@
         <div id="paintSectionContent" style="display: grid; gap: 10px;">
           <!-- Numeric field options -->
           <fieldset id="numericOptions">
-            <label>Field type: numeric</label>
-
-            <!-- Normalization choices -->
-            <div id="normGroup" style="display:grid; gap:6px; margin-top:6px;">
-              <label style="display:flex; gap:8px; align-items:center;">
-                <input type="radio" name="normMode" id="norm-asis" value="asis" checked />
-                <span>as-is</span>
-              </label>
-              <label style="display:flex; gap:8px; align-items:center;">
-                <input type="radio" name="normMode" id="norm-land" value="perLand" disabled />
-                <span>…per land size <em id="normLandUnit">(unit)</em></span>
-              </label>
-              <label style="display:flex; gap:8px; align-items:center;">
-                <input type="radio" name="normMode" id="norm-bldg" value="perBuilding" disabled />
-                <span>…per building size <em id="normBldgUnit">(unit)</em></span>
-              </label>
-            </div>
-
             <fieldset class="row">
               <div>
                 <br/>
@@ -2140,29 +2162,27 @@
 
           <!-- Shared visualization options -->
           <fieldset id="colorRampOptions" style="display: none;">
-            <label>Color ramp</label>
-            <div>
-              <select id="ramp"></select>
+            <div class="field-visualize-row" style="gap: 12px;">
+              <div style="display: grid; gap: 4px;">
+                <label for="ramp">Color ramp</label>
+                <select id="ramp"></select>
+              </div>
+              <div style="display: grid; gap: 4px;">
+                <label for="colorModeSelect">Scaling</label>
+                <select id="colorModeSelect" class="layer-source-name">
+                  <option value="continuous">Linear</option>
+                  <option value="quantiles" selected>Quantiles</option>
+                </select>
+              </div>
             </div>
           </fieldset>
+
+          <div id="colorModeLegacyRadios" style="display: none;">
+            <input type="radio" name="colorMode" id="color-cont" value="continuous">
+            <input type="radio" name="colorMode" id="color-quant" value="quantiles" checked>
+          </div>
 
           <div id="paintDividerRamp" class="divider"></div>
-
-          <fieldset id="colorScalingOptions" style="display: none;">
-            <label>Color scaling</label>
-            <div style="display:grid; gap:6px;">
-              <label style="display:flex; gap:8px; align-items:center;">
-                <input type="radio" name="colorMode" id="color-cont" value="continuous">
-                <span>Linear (min→max, clamped p1–p99)</span>
-              </label>
-              <label style="display:flex; gap:8px; align-items:center;">
-                <input type="radio" name="colorMode" id="color-quant" value="quantiles" checked>
-                <span>Quantiles (equal-frequency, p1–p99)</span>
-              </label>
-            </div>
-          </fieldset>
-
-          <div id="paintDividerScaling" class="divider"></div>
 
           <fieldset id="opacityOptions" style="display: none;">
             <label>Opacity</label>
@@ -2265,7 +2285,7 @@
     </div>
   </div>
 
-  <div id="statisticsControls" class="viz-window" style="position: absolute; top: 10px; left: 900px; background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
+  <div id="statisticsControls" class="viz-window" style="position: absolute; top: 10px; left: 900px; min-width: 360px; background: var(--panel); border-radius: 12px; box-shadow: var(--shadow); display: none; gap: var(--gap); z-index: 10; cursor: move;">
     <div class="window-header" style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #eee; background: rgba(248, 248, 248, 0.8); border-radius: 12px 12px 0 0; cursor: move;">
       <div style="font-weight: 600; font-size: 13px;">Statistics</div>
       <div class="window-actions">
@@ -2300,8 +2320,9 @@
           <select id="statsField" class="layer-source-name">
             <option value="" selected disabled>Choose a field</option>
           </select>
-          <div id="statsDetails" style="display: none; gap: 6px;">
-            <div id="statsNumericBlock" style="display: grid; gap: 6px;">
+        </div>
+        <div id="statsDetails" style="display: none; gap: 6px;">
+          <div id="statsNumericBlock" style="display: grid; gap: 6px;">
               <div id="statsNormalizationControls" style="display: grid; gap: 6px;">
                 <label style="display:flex; gap:8px; align-items:center;">
                   <input type="radio" name="statsNormMode" id="stats-norm-asis" value="asis" checked />
@@ -2372,7 +2393,7 @@
                 </div>
               </div>
             </div>
-            <div id="statsCategoricalBlock" style="display: none; gap: 6px;">
+          <div id="statsCategoricalBlock" style="display: none; gap: 6px;">
               <table class="stats-table">
                 <tbody>
                   <tr><td>Parcel count</td><td><span id="statsCategoricalParcelCount">—</span></td></tr>
@@ -2392,7 +2413,6 @@
                   <tbody id="statsCategoricalValues"></tbody>
                 </table>
               </div>
-            </div>
           </div>
         </div>
       </div>

--- a/viz/index.html
+++ b/viz/index.html
@@ -491,20 +491,6 @@
       color: #111827;
     }
 
-    .layer-collapse-toggle {
-      border: none;
-      background: transparent;
-      cursor: pointer;
-      font-size: 14px;
-      color: #4b5563;
-      padding: 2px 4px;
-      transition: transform 0.2s ease;
-    }
-
-    .layer-collapse-toggle.is-collapsed {
-      transform: rotate(-90deg);
-    }
-
     .field-visualize-row {
       display: grid;
       grid-template-columns: minmax(0, 1fr) 130px;
@@ -2055,9 +2041,11 @@
         <div id="layerList" class="layer-list"></div>
       </fieldset>
 
+      <div class="divider"></div>
+
       <div class="stats-section" style="display: grid; gap: 8px;">
         <div class="layer-section-header">
-          <button id="fieldVisualizeToggle" class="layer-collapse-toggle" type="button" title="Collapse Field to visualize">▼</button>
+          <button id="fieldVisualizeToggle" class="land-schedule-collapse-toggle" type="button" title="Collapse Field to visualize">▼</button>
           <span>Field to visualize</span>
         </div>
         <div id="fieldVisualizeBody" style="display: grid; gap: 6px;">
@@ -2095,7 +2083,6 @@
           <fieldset id="numericOptions">
             <fieldset class="row">
               <div>
-                <br/>
                 <label style="display:flex; gap:8px; align-items:center;">
                   <input type="checkbox" id="enable3D" />
                   <span>3D enabled</span>

--- a/viz/src/layers.ts
+++ b/viz/src/layers.ts
@@ -484,6 +484,24 @@ export function applyLayerState(layer: LayerState) {
     _normBldg.checked = S.normalizationMode === 'perBuilding';
   }
   if (_normModeSelect) {
+    console.debug('[NormMode:applyLayerState.beforeOptions]', {
+      layerId: layer.id,
+      layerName: layer.name,
+      layerStoreId: layer.dataStoreId,
+      layerSize: {
+        landSizeField: layer.landSizeField,
+        landSizeUnitLabel: layer.landSizeUnitLabel,
+        bldgSizeField: layer.bldgSizeField,
+        bldgSizeUnitLabel: layer.bldgSizeUnitLabel,
+      },
+      stateSize: {
+        landSizeField: S.landSizeField,
+        landSizeUnitLabel: S.landSizeUnitLabel,
+        bldgSizeField: S.bldgSizeField,
+        bldgSizeUnitLabel: S.bldgSizeUnitLabel,
+      },
+      normModeSelectExists: true,
+    });
     const landUnit = (document.getElementById('normLandUnit')?.textContent || '(unit)').trim();
     const bldgUnit = (document.getElementById('normBldgUnit')?.textContent || '(unit)').trim();
     const perLandOption = _normModeSelect.querySelector('option[value="perLand"]') as HTMLOptionElement | null;
@@ -497,6 +515,19 @@ export function applyLayerState(layer: LayerState) {
       perBuildingOption.textContent = `…per building size ${bldgUnit}`;
     }
     _normModeSelect.value = S.normalizationMode;
+    console.debug('[NormMode:applyLayerState.afterOptions]', {
+      layerId: layer.id,
+      selectedMode: _normModeSelect.value,
+      options: Array.from(_normModeSelect.options).map(option => ({
+        value: option.value,
+        text: option.text,
+        disabled: option.disabled,
+      })),
+      labelSources: {
+        normLandUnitText: document.getElementById('normLandUnit')?.textContent,
+        normBldgUnitText: document.getElementById('normBldgUnit')?.textContent,
+      },
+    });
   }
 
   if (_colorCont && _colorQuant) {
@@ -595,6 +626,17 @@ export function addLayerFromDataStore(storeId: string): boolean {
   layer.landSizeUnitLabel = store.landSizeUnitLabel;
   layer.bldgSizeField = store.bldgSizeField;
   layer.bldgSizeUnitLabel = store.bldgSizeUnitLabel;
+  console.debug('[NormMode:addLayerFromDataStore]', {
+    storeId: store.id,
+    storeName: store.name,
+    storeSize: {
+      landSizeField: store.landSizeField,
+      landSizeUnitLabel: store.landSizeUnitLabel,
+      bldgSizeField: store.bldgSizeField,
+      bldgSizeUnitLabel: store.bldgSizeUnitLabel,
+    },
+    newLayerId: layer.id,
+  });
   registerLayer(layer);
   _addOrUpdateSource(layer.geojson);
   _applyGrayRendering();

--- a/viz/src/layers.ts
+++ b/viz/src/layers.ts
@@ -489,11 +489,11 @@ export function applyLayerState(layer: LayerState) {
     const perLandOption = _normModeSelect.querySelector('option[value="perLand"]') as HTMLOptionElement | null;
     const perBuildingOption = _normModeSelect.querySelector('option[value="perBuilding"]') as HTMLOptionElement | null;
     if (perLandOption) {
-      perLandOption.disabled = _normLand?.disabled ?? false;
+      perLandOption.disabled = !S.landSizeField;
       perLandOption.textContent = `…per land size ${landUnit}`;
     }
     if (perBuildingOption) {
-      perBuildingOption.disabled = _normBldg?.disabled ?? false;
+      perBuildingOption.disabled = !S.bldgSizeField;
       perBuildingOption.textContent = `…per building size ${bldgUnit}`;
     }
     _normModeSelect.value = S.normalizationMode;

--- a/viz/src/layers.ts
+++ b/viz/src/layers.ts
@@ -484,26 +484,8 @@ export function applyLayerState(layer: LayerState) {
     _normBldg.checked = S.normalizationMode === 'perBuilding';
   }
   if (_normModeSelect) {
-    console.debug('[NormMode:applyLayerState.beforeOptions]', {
-      layerId: layer.id,
-      layerName: layer.name,
-      layerStoreId: layer.dataStoreId,
-      layerSize: {
-        landSizeField: layer.landSizeField,
-        landSizeUnitLabel: layer.landSizeUnitLabel,
-        bldgSizeField: layer.bldgSizeField,
-        bldgSizeUnitLabel: layer.bldgSizeUnitLabel,
-      },
-      stateSize: {
-        landSizeField: S.landSizeField,
-        landSizeUnitLabel: S.landSizeUnitLabel,
-        bldgSizeField: S.bldgSizeField,
-        bldgSizeUnitLabel: S.bldgSizeUnitLabel,
-      },
-      normModeSelectExists: true,
-    });
-    const landUnit = (document.getElementById('normLandUnit')?.textContent || '(unit)').trim();
-    const bldgUnit = (document.getElementById('normBldgUnit')?.textContent || '(unit)').trim();
+    const landUnit = S.landSizeField ? (S.landSizeUnitLabel ?? '(unit)') : '(unit)';
+    const bldgUnit = S.bldgSizeField ? (S.bldgSizeUnitLabel ?? '(unit)') : '(unit)';
     const perLandOption = _normModeSelect.querySelector('option[value="perLand"]') as HTMLOptionElement | null;
     const perBuildingOption = _normModeSelect.querySelector('option[value="perBuilding"]') as HTMLOptionElement | null;
     if (perLandOption) {
@@ -515,19 +497,6 @@ export function applyLayerState(layer: LayerState) {
       perBuildingOption.textContent = `…per building size ${bldgUnit}`;
     }
     _normModeSelect.value = S.normalizationMode;
-    console.debug('[NormMode:applyLayerState.afterOptions]', {
-      layerId: layer.id,
-      selectedMode: _normModeSelect.value,
-      options: Array.from(_normModeSelect.options).map(option => ({
-        value: option.value,
-        text: option.text,
-        disabled: option.disabled,
-      })),
-      labelSources: {
-        normLandUnitText: document.getElementById('normLandUnit')?.textContent,
-        normBldgUnitText: document.getElementById('normBldgUnit')?.textContent,
-      },
-    });
   }
 
   if (_colorCont && _colorQuant) {
@@ -626,17 +595,6 @@ export function addLayerFromDataStore(storeId: string): boolean {
   layer.landSizeUnitLabel = store.landSizeUnitLabel;
   layer.bldgSizeField = store.bldgSizeField;
   layer.bldgSizeUnitLabel = store.bldgSizeUnitLabel;
-  console.debug('[NormMode:addLayerFromDataStore]', {
-    storeId: store.id,
-    storeName: store.name,
-    storeSize: {
-      landSizeField: store.landSizeField,
-      landSizeUnitLabel: store.landSizeUnitLabel,
-      bldgSizeField: store.bldgSizeField,
-      bldgSizeUnitLabel: store.bldgSizeUnitLabel,
-    },
-    newLayerId: layer.id,
-  });
   registerLayer(layer);
   _addOrUpdateSource(layer.geojson);
   _applyGrayRendering();

--- a/viz/src/layers.ts
+++ b/viz/src/layers.ts
@@ -25,7 +25,6 @@ const SATELLITE_ICON = new URL('./svg/globe.svg', import.meta.url).href;
 
 let _layerList: HTMLDivElement;
 let _dataStoreList: HTMLDivElement;
-let _currentLayerSource: HTMLDivElement;
 let _fieldSelect: HTMLSelectElement;
 let _rampSelect: HTMLSelectElement;
 let _opacityInput: HTMLInputElement;
@@ -33,8 +32,10 @@ let _opacityOut: HTMLOutputElement;
 let _normAsIs: HTMLInputElement;
 let _normLand: HTMLInputElement;
 let _normBldg: HTMLInputElement;
+let _normModeSelect: HTMLSelectElement | null = null;
 let _colorCont: HTMLInputElement | null;
 let _colorQuant: HTMLInputElement | null;
+let _colorModeSelect: HTMLSelectElement | null = null;
 let _colorPicker: HTMLInputElement;
 let _enable3DCheckbox: HTMLInputElement;
 let _filtersInvertToggle: HTMLInputElement;
@@ -42,7 +43,6 @@ let _filtersInvertToggle: HTMLInputElement;
 export function initLayerElements(els: {
   layerList: HTMLDivElement;
   dataStoreList: HTMLDivElement;
-  currentLayerSource: HTMLDivElement;
   fieldSelect: HTMLSelectElement;
   rampSelect: HTMLSelectElement;
   opacityInput: HTMLInputElement;
@@ -50,15 +50,16 @@ export function initLayerElements(els: {
   normAsIs: HTMLInputElement;
   normLand: HTMLInputElement;
   normBldg: HTMLInputElement;
+  normModeSelect?: HTMLSelectElement | null;
   colorCont: HTMLInputElement | null;
   colorQuant: HTMLInputElement | null;
+  colorModeSelect?: HTMLSelectElement | null;
   colorPicker: HTMLInputElement;
   enable3DCheckbox: HTMLInputElement;
   filtersInvertToggle: HTMLInputElement;
 }) {
   _layerList = els.layerList;
   _dataStoreList = els.dataStoreList;
-  _currentLayerSource = els.currentLayerSource;
   _fieldSelect = els.fieldSelect;
   _rampSelect = els.rampSelect;
   _opacityInput = els.opacityInput;
@@ -66,8 +67,10 @@ export function initLayerElements(els: {
   _normAsIs = els.normAsIs;
   _normLand = els.normLand;
   _normBldg = els.normBldg;
+  _normModeSelect = els.normModeSelect ?? null;
   _colorCont = els.colorCont;
   _colorQuant = els.colorQuant;
+  _colorModeSelect = els.colorModeSelect ?? null;
   _colorPicker = els.colorPicker;
   _enable3DCheckbox = els.enable3DCheckbox;
   _filtersInvertToggle = els.filtersInvertToggle;
@@ -480,11 +483,27 @@ export function applyLayerState(layer: LayerState) {
     _normLand.checked = S.normalizationMode === 'perLand';
     _normBldg.checked = S.normalizationMode === 'perBuilding';
   }
+  if (_normModeSelect) {
+    const landUnit = (document.getElementById('normLandUnit')?.textContent || '(unit)').trim();
+    const bldgUnit = (document.getElementById('normBldgUnit')?.textContent || '(unit)').trim();
+    const perLandOption = _normModeSelect.querySelector('option[value="perLand"]') as HTMLOptionElement | null;
+    const perBuildingOption = _normModeSelect.querySelector('option[value="perBuilding"]') as HTMLOptionElement | null;
+    if (perLandOption) {
+      perLandOption.disabled = _normLand?.disabled ?? false;
+      perLandOption.textContent = `…per land size ${landUnit}`;
+    }
+    if (perBuildingOption) {
+      perBuildingOption.disabled = _normBldg?.disabled ?? false;
+      perBuildingOption.textContent = `…per building size ${bldgUnit}`;
+    }
+    _normModeSelect.value = S.normalizationMode;
+  }
 
   if (_colorCont && _colorQuant) {
     _colorCont.checked = S.colorMode === 'continuous';
     _colorQuant.checked = S.colorMode === 'quantiles';
   }
+  if (_colorModeSelect) _colorModeSelect.value = S.colorMode;
 
   document.querySelectorAll<HTMLInputElement>('input[name="categoricalColorMode"]').forEach(radio => {
     radio.checked = radio.value === S.categoricalColorMode;
@@ -663,19 +682,7 @@ export function removeLayer(layerId: string) {
 /* ------------------------------------------------------------------ */
 
 export function updateCurrentLayerDetails() {
-  if (!_currentLayerSource) return;
-  if (!S.currentLayerId) {
-    _currentLayerSource.textContent = 'source: —';
-    return;
-  }
-  const layer = S.layers.get(S.currentLayerId);
-  if (!layer) {
-    _currentLayerSource.textContent = 'source: —';
-    return;
-  }
-  const store = S.dataStores.get(layer.dataStoreId);
-  const sourceName = store?.file?.name ?? store?.name ?? '—';
-  _currentLayerSource.textContent = `source: ${sourceName}`;
+  // Current layer/source readout removed from UI.
 }
 
 export function renderLayerList() {

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -3015,20 +3015,6 @@ if (normModeSelect) {
       return;
     }
 
-    console.debug('[NormMode:normModeSelect.change]', {
-      requestedMode: next,
-      currentMode: S.normalizationMode,
-      landSizeField: S.landSizeField,
-      landSizeUnitLabel: S.landSizeUnitLabel,
-      bldgSizeField: S.bldgSizeField,
-      bldgSizeUnitLabel: S.bldgSizeUnitLabel,
-      options: Array.from(normModeSelect.options).map(option => ({
-        value: option.value,
-        text: option.text,
-        disabled: option.disabled,
-      })),
-    });
-
     const target = next === 'perLand'
       ? normLand
       : (next === 'perBuilding' ? normBldg : normAsIs);

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -3015,15 +3015,11 @@ if (normModeSelect) {
       return;
     }
 
-    S.normalizationMode = next;
-    normAsIs.checked = next === 'asis';
-    normLand.checked = next === 'perLand';
-    normBldg.checked = next === 'perBuilding';
-
-    S.cachedExtrusionSettings = null;
-    if (!S.currentGeoJSON || !S.currentField) return;
-    scheduleUpdate('recomputeAndAutoScale', /*refreshLegend*/ true);
-    persistCurrentLayerState();
+    const target = next === 'perLand'
+      ? normLand
+      : (next === 'perBuilding' ? normBldg : normAsIs);
+    target.checked = true;
+    target.dispatchEvent(new Event('change', { bubbles: true }));
   });
 }
 

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -295,13 +295,12 @@ const normBldg = document.getElementById('norm-bldg') as HTMLInputElement;
 const normLandUnitEl = document.getElementById('normLandUnit') as HTMLElement;
 const normBldgUnitEl = document.getElementById('normBldgUnit') as HTMLElement;
 const colorRampOptions = document.getElementById('colorRampOptions') as HTMLFieldSetElement;
-const colorScalingOptions = document.getElementById('colorScalingOptions') as HTMLFieldSetElement;
+const colorScalingOptions = document.getElementById('colorScalingOptions') as HTMLFieldSetElement | null;
 const opacityOptions = document.getElementById('opacityOptions') as HTMLFieldSetElement;
 const paintDividerNumeric = document.getElementById('paintDividerNumeric') as HTMLDivElement;
 const paintDividerCategorical = document.getElementById('paintDividerCategorical') as HTMLDivElement;
 const paintDividerRamp = document.getElementById('paintDividerRamp') as HTMLDivElement;
-const paintDividerScaling = document.getElementById('paintDividerScaling') as HTMLDivElement;
-const currentLayerSource = document.getElementById('currentLayerSource') as HTMLDivElement;
+const paintDividerScaling = document.getElementById('paintDividerScaling') as HTMLDivElement | null;
 // Camera view buttons
 const viewButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-view]'));
 (document.getElementById('btn-persp') as HTMLButtonElement)?.addEventListener('click', () => setPerspective());
@@ -576,6 +575,10 @@ const btnConfirmDeleteDataSource = document.getElementById('btnConfirmDeleteData
 // Color scaling radios
 const colorCont = document.getElementById('color-cont') as HTMLInputElement | null;
 const colorQuant = document.getElementById('color-quant') as HTMLInputElement | null;
+const colorModeSelect = document.getElementById('colorModeSelect') as HTMLSelectElement | null;
+const normModeSelect = document.getElementById('normModeSelect') as HTMLSelectElement | null;
+const fieldVisualizeToggle = document.getElementById('fieldVisualizeToggle') as HTMLButtonElement;
+const fieldVisualizeBody = document.getElementById('fieldVisualizeBody') as HTMLDivElement;
 
 // Color picker elements
 const colorOptions = document.getElementById('colorOptions') as HTMLDivElement;
@@ -594,6 +597,18 @@ const setPaintSectionCollapsed = (collapsed: boolean) => {
 setPaintSectionCollapsed(S.isPaintCollapsed);
 paintSectionToggle.addEventListener('click', () => {
   setPaintSectionCollapsed(!S.isPaintCollapsed);
+});
+
+const setFieldVisualizeCollapsed = (collapsed: boolean) => {
+  fieldVisualizeBody.style.display = collapsed ? 'none' : 'grid';
+  fieldVisualizeToggle.classList.toggle('is-collapsed', collapsed);
+  fieldVisualizeToggle.title = collapsed ? 'Expand Field to visualize' : 'Collapse Field to visualize';
+  refreshWindowMinHeight(controlsEl);
+};
+
+setFieldVisualizeCollapsed(false);
+fieldVisualizeToggle.addEventListener('click', () => {
+  setFieldVisualizeCollapsed(fieldVisualizeBody.style.display !== 'none');
 });
 
 const setStatsLayerCollapsed = (collapsed: boolean) => {
@@ -1306,7 +1321,6 @@ setCompFinderMenuVisible(!S.isCompFinderMinimized);
 initLayerElements({
   layerList,
   dataStoreList,
-  currentLayerSource,
   fieldSelect,
   rampSelect,
   opacityInput,
@@ -1314,8 +1328,10 @@ initLayerElements({
   normAsIs,
   normLand,
   normBldg,
+  normModeSelect,
   colorCont,
   colorQuant,
+  colorModeSelect,
   colorPicker,
   enable3DCheckbox: enable3DCheckbox,
   filtersInvertToggle,
@@ -2968,11 +2984,35 @@ fileInput.addEventListener('change', async () => {
     const val = (document.querySelector('input[name="colorMode"]:checked') as HTMLInputElement)?.value;
     if (val === 'continuous' || val === 'quantiles') {
       S.colorMode = val;
+      if (colorModeSelect) colorModeSelect.value = S.colorMode;
       scheduleUpdate('recomputeAndAutoScale', /*refreshLegend*/ true);
       persistCurrentLayerState();
     }
   })
 );
+
+if (colorModeSelect) {
+  colorModeSelect.addEventListener('change', () => {
+    if (!S.currentGeoJSON) return;
+    const next = colorModeSelect.value;
+    const target = next === 'continuous' ? colorCont : colorQuant;
+    if (target) {
+      target.checked = true;
+      target.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  });
+}
+
+if (normModeSelect) {
+  normModeSelect.addEventListener('change', () => {
+    const next = normModeSelect.value;
+    const target = next === 'perLand' ? normLand : (next === 'perBuilding' ? normBldg : normAsIs);
+    if (target) {
+      target.checked = true;
+      target.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  });
+}
 
 // Categorical color mode event listeners
 document.querySelectorAll<HTMLInputElement>('input[name="categoricalColorMode"]').forEach(el =>
@@ -3454,6 +3494,7 @@ fieldSelect.addEventListener('change', () => {
 document.querySelectorAll<HTMLInputElement>('input[name="normMode"]').forEach(r => {
   r.addEventListener('change', () => {
     S.normalizationMode = (document.querySelector('input[name="normMode"]:checked') as HTMLInputElement)?.value as any;
+    if (normModeSelect) normModeSelect.value = S.normalizationMode;
     // Clear cached extrusion settings when normalization mode changes
     S.cachedExtrusionSettings = null;
     if (!S.currentGeoJSON || !S.currentField) return;

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -3015,6 +3015,20 @@ if (normModeSelect) {
       return;
     }
 
+    console.debug('[NormMode:normModeSelect.change]', {
+      requestedMode: next,
+      currentMode: S.normalizationMode,
+      landSizeField: S.landSizeField,
+      landSizeUnitLabel: S.landSizeUnitLabel,
+      bldgSizeField: S.bldgSizeField,
+      bldgSizeUnitLabel: S.bldgSizeUnitLabel,
+      options: Array.from(normModeSelect.options).map(option => ({
+        value: option.value,
+        text: option.text,
+        disabled: option.disabled,
+      })),
+    });
+
     const target = next === 'perLand'
       ? normLand
       : (next === 'perBuilding' ? normBldg : normAsIs);

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -372,6 +372,7 @@ const scatterSubjectButtons = scatterSubjectControls.buttons;
 const scatterCategoryFieldSelect = scatterSubjectControls.categoryFieldSelect;
 const scatterCategoryValueSelect = scatterSubjectControls.categoryValueSelect;
 const statsFieldSelect = document.getElementById('statsField') as HTMLSelectElement;
+const statsNormModeSelect = document.getElementById('statsNormModeSelect') as HTMLSelectElement | null;
 const statsDetails = document.getElementById('statsDetails') as HTMLDivElement;
 const statsNumericBlock = document.getElementById('statsNumericBlock') as HTMLDivElement;
 const statsCategoricalBlock = document.getElementById('statsCategoricalBlock') as HTMLDivElement;
@@ -1168,6 +1169,7 @@ initStatisticsElements({
   statsLayerName,
   statsSubjectControls,
   statsFieldSelect,
+  statsNormModeSelect,
   statsDetails,
   statsNumericBlock,
   statsCategoricalBlock,
@@ -3271,6 +3273,23 @@ statsFieldSelect.addEventListener('change', () => {
   }
 });
 
+if (statsNormModeSelect) {
+  statsNormModeSelect.addEventListener('change', () => {
+    const next = statsNormModeSelect.value as 'asis' | 'perLand' | 'perBuilding';
+    if (next === 'perLand' && statsNormLand.disabled) {
+      statsNormModeSelect.value = S.statsNormalizationMode;
+      return;
+    }
+    if (next === 'perBuilding' && statsNormBldg.disabled) {
+      statsNormModeSelect.value = S.statsNormalizationMode;
+      return;
+    }
+    const target = next === 'perLand' ? statsNormLand : (next === 'perBuilding' ? statsNormBldg : statsNormAsIs);
+    target.checked = true;
+    target.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
 scatterXFieldSelect.addEventListener('change', () => {
   S.scatterXField = scatterXFieldSelect.value || null;
   S.scatterRangeIsCustom = false;
@@ -3311,6 +3330,7 @@ document.querySelectorAll<HTMLInputElement>('input[name="statsNormMode"]').forEa
   radio.addEventListener('change', () => {
     S.statsNormalizationMode = (document.querySelector('input[name="statsNormMode"]:checked') as HTMLInputElement)
       ?.value as 'asis' | 'perLand' | 'perBuilding';
+    if (statsNormModeSelect) statsNormModeSelect.value = S.statsNormalizationMode;
     updateStatisticsResults();
   });
 });

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -3219,15 +3219,18 @@ statsCategoryFieldSelect.addEventListener('change', () => {
   populateStatisticsCategoryValues(S.statsCategoryField);
   updateStatisticsSubjectControls();
   updateStatisticsSectionVisibility();
-  resetStatisticsDisplay();
+  if (S.statsField && (!S.statsCategoryField || S.statsCategoryValueIndices.length > 0)) {
+    updateStatisticsResults();
+  } else {
+    resetStatisticsDisplay();
+  }
 });
 
 statsCategoryValueSelect.addEventListener('change', () => {
-  S.statsCategoryValueIndices = Array.from(statsCategoryValueSelect.selectedOptions)
-    .map(option => option.value)
-    .filter(value => value);
+  const selected = statsCategoryValueSelect.value || '';
+  S.statsCategoryValueIndices = selected ? [selected] : [];
   updateStatisticsSectionVisibility();
-  if (S.statsCategoryValueIndices.length > 0 && S.statsField) {
+  if ((!S.statsCategoryField || S.statsCategoryValueIndices.length > 0) && S.statsField) {
     updateStatisticsResults();
     return;
   }
@@ -3244,9 +3247,8 @@ scatterCategoryFieldSelect.addEventListener('change', () => {
 });
 
 scatterCategoryValueSelect.addEventListener('change', () => {
-  S.scatterCategoryValueIndices = Array.from(scatterCategoryValueSelect.selectedOptions)
-    .map(option => option.value)
-    .filter(value => value);
+  const selected = scatterCategoryValueSelect.value || '';
+  S.scatterCategoryValueIndices = selected ? [selected] : [];
   updateScatterSubjectControls();
   S.scatterRangeIsCustom = false;
   scheduleScatterPlotRefresh();
@@ -3260,10 +3262,8 @@ scatterColorByFieldSelect.addEventListener('change', () => {
 statsFieldSelect.addEventListener('change', () => {
   S.statsField = statsFieldSelect.value || null;
   const layer = getStatsLayer();
-  const dataStore = getLayerDataStore(layer);
-  const useDataSource = S.statsSubjectMode === 'category';
-  const numericFields = useDataSource ? dataStore?.chosenNumericFields ?? [] : layer?.chosenNumericFields ?? [];
-  const categoricalFields = useDataSource ? dataStore?.chosenCategoricalFields ?? [] : layer?.chosenCategoricalFields ?? [];
+  const numericFields = layer?.chosenNumericFields ?? [];
+  const categoricalFields = layer?.chosenCategoricalFields ?? [];
   S.statsFieldType = getStatsFieldType(S.statsField, numericFields, categoricalFields);
   updateStatisticsSectionVisibility();
   if (S.statsField) {

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -3005,12 +3005,25 @@ if (colorModeSelect) {
 
 if (normModeSelect) {
   normModeSelect.addEventListener('change', () => {
-    const next = normModeSelect.value;
-    const target = next === 'perLand' ? normLand : (next === 'perBuilding' ? normBldg : normAsIs);
-    if (target) {
-      target.checked = true;
-      target.dispatchEvent(new Event('change', { bubbles: true }));
+    const next = normModeSelect.value as 'asis' | 'perLand' | 'perBuilding';
+    if (next === 'perLand' && !S.landSizeField) {
+      normModeSelect.value = S.normalizationMode;
+      return;
     }
+    if (next === 'perBuilding' && !S.bldgSizeField) {
+      normModeSelect.value = S.normalizationMode;
+      return;
+    }
+
+    S.normalizationMode = next;
+    normAsIs.checked = next === 'asis';
+    normLand.checked = next === 'perLand';
+    normBldg.checked = next === 'perBuilding';
+
+    S.cachedExtrusionSettings = null;
+    if (!S.currentGeoJSON || !S.currentField) return;
+    scheduleUpdate('recomputeAndAutoScale', /*refreshLegend*/ true);
+    persistCurrentLayerState();
   });
 }
 

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -29,7 +29,7 @@ import {
   updateStatisticsSectionVisibility,
   updateStatisticsResults, refreshStatisticsPanel,
   updateStatisticsSubjectControls, setStatsSubjectMode,
-  renderStatsLayerOptions,
+  renderStatsLayerOptions, getCurrentStatsSubjectSelection,
 } from './statistics';
 import {
   initScatterplotElements, initScatterplotCallbacks,
@@ -39,7 +39,7 @@ import {
   scheduleScatterPlotRefresh,
   refreshScatterPanel, renderScatterLayerOptions,
   clearScatterSelection, clearScatterHover, zoomToScatterSelection,
-  initScatterplotMapLayers,
+  initScatterplotMapLayers, getCurrentScatterSubjectSelection,
 } from './scatterplot';
 
 
@@ -367,10 +367,12 @@ const scatterSubjectControls = buildSubjectSelector(scatterSubjectSection, { tit
 const statsSubjectButtons = statsSubjectControls.buttons;
 const statsCategoryFieldSelect = statsSubjectControls.categoryFieldSelect;
 const statsCategoryValueSelect = statsSubjectControls.categoryValueSelect;
+const statsSelectOnMapButton = statsSubjectControls.selectOnMapButton;
 
 const scatterSubjectButtons = scatterSubjectControls.buttons;
 const scatterCategoryFieldSelect = scatterSubjectControls.categoryFieldSelect;
 const scatterCategoryValueSelect = scatterSubjectControls.categoryValueSelect;
+const scatterSelectOnMapButton = scatterSubjectControls.selectOnMapButton;
 const statsFieldSelect = document.getElementById('statsField') as HTMLSelectElement;
 const statsNormModeSelect = document.getElementById('statsNormModeSelect') as HTMLSelectElement | null;
 const statsDetails = document.getElementById('statsDetails') as HTMLDivElement;
@@ -3180,6 +3182,16 @@ filtersInvertToggle.addEventListener('change', () => {
   persistFiltersContext();
 });
 
+
+function replaceMapSelectionFromFeatures(features: GeoJSON.Feature[], contextLabel: string) {
+  if (features.length === 0) {
+    alert(`No parcels are currently resolved for ${contextLabel}.`);
+    return;
+  }
+  clearAllSelections();
+  features.forEach(feature => addParcelToSelection(feature));
+}
+
 statsSubjectButtons.forEach(button => {
   button.addEventListener('click', () => {
     const mode = button.dataset.subjectMode as SubjectMode | undefined;
@@ -3252,6 +3264,14 @@ scatterCategoryValueSelect.addEventListener('change', () => {
   updateScatterSubjectControls();
   S.scatterRangeIsCustom = false;
   scheduleScatterPlotRefresh();
+});
+
+statsSelectOnMapButton.addEventListener('click', () => {
+  replaceMapSelectionFromFeatures(getCurrentStatsSubjectSelection(), 'the Statistics Group selection');
+});
+
+scatterSelectOnMapButton.addEventListener('click', () => {
+  replaceMapSelectionFromFeatures(getCurrentScatterSubjectSelection(), 'the Scatterplot Group selection');
 });
 
 scatterColorByFieldSelect.addEventListener('change', () => {

--- a/viz/src/modals.ts
+++ b/viz/src/modals.ts
@@ -806,6 +806,39 @@ export function setSizeState(
     S.statsNormalizationMode = 'asis';
     statsNormAsIs.checked = true;
   }
+
+  console.debug('[NormMode:setSizeState]', {
+    currentLayerId: S.currentLayerId,
+    currentDataStoreId: S.currentDataStoreId,
+    incoming: {
+      bField,
+      bUnit,
+      lField,
+      lUnit,
+    },
+    resolvedState: {
+      landSizeField: S.landSizeField,
+      landSizeUnitLabel: S.landSizeUnitLabel,
+      bldgSizeField: S.bldgSizeField,
+      bldgSizeUnitLabel: S.bldgSizeUnitLabel,
+    },
+    activeStore: activeStore
+      ? {
+          id: activeStore.id,
+          name: activeStore.name,
+          landSizeField: activeStore.landSizeField,
+          landSizeUnitLabel: activeStore.landSizeUnitLabel,
+          bldgSizeField: activeStore.bldgSizeField,
+          bldgSizeUnitLabel: activeStore.bldgSizeUnitLabel,
+        }
+      : null,
+    ui: {
+      normLandDisabled: normLand.disabled,
+      normBldgDisabled: normBldg.disabled,
+      normLandUnitText: normLandUnitEl.textContent,
+      normBldgUnitText: normBldgUnitEl.textContent,
+    },
+  });
 }
 
 /* ------------------------------------------------------------------ */

--- a/viz/src/modals.ts
+++ b/viz/src/modals.ts
@@ -798,6 +798,20 @@ export function setSizeState(
   statsNormLandUnitEl.textContent = S.landSizeField ? (S.landSizeUnitLabel ?? '(unit)') : '(unit)';
   statsNormBldgUnitEl.textContent = S.bldgSizeField ? (S.bldgSizeUnitLabel ?? '(unit)') : '(unit)';
 
+  const normModeSelect = document.getElementById('normModeSelect') as HTMLSelectElement | null;
+  if (normModeSelect) {
+    const perLandOption = normModeSelect.querySelector('option[value="perLand"]') as HTMLOptionElement | null;
+    const perBuildingOption = normModeSelect.querySelector('option[value="perBuilding"]') as HTMLOptionElement | null;
+    if (perLandOption) {
+      perLandOption.disabled = !S.landSizeField;
+      perLandOption.textContent = `…per land size ${S.landSizeField ? (S.landSizeUnitLabel ?? '(unit)') : '(unit)'}`;
+    }
+    if (perBuildingOption) {
+      perBuildingOption.disabled = !S.bldgSizeField;
+      perBuildingOption.textContent = `…per building size ${S.bldgSizeField ? (S.bldgSizeUnitLabel ?? '(unit)') : '(unit)'}`;
+    }
+  }
+
   if (S.statsNormalizationMode === 'perLand' && !S.landSizeField) {
     S.statsNormalizationMode = 'asis';
     statsNormAsIs.checked = true;
@@ -807,38 +821,7 @@ export function setSizeState(
     statsNormAsIs.checked = true;
   }
 
-  console.debug('[NormMode:setSizeState]', {
-    currentLayerId: S.currentLayerId,
-    currentDataStoreId: S.currentDataStoreId,
-    incoming: {
-      bField,
-      bUnit,
-      lField,
-      lUnit,
-    },
-    resolvedState: {
-      landSizeField: S.landSizeField,
-      landSizeUnitLabel: S.landSizeUnitLabel,
-      bldgSizeField: S.bldgSizeField,
-      bldgSizeUnitLabel: S.bldgSizeUnitLabel,
-    },
-    activeStore: activeStore
-      ? {
-          id: activeStore.id,
-          name: activeStore.name,
-          landSizeField: activeStore.landSizeField,
-          landSizeUnitLabel: activeStore.landSizeUnitLabel,
-          bldgSizeField: activeStore.bldgSizeField,
-          bldgSizeUnitLabel: activeStore.bldgSizeUnitLabel,
-        }
-      : null,
-    ui: {
-      normLandDisabled: normLand.disabled,
-      normBldgDisabled: normBldg.disabled,
-      normLandUnitText: normLandUnitEl.textContent,
-      normBldgUnitText: normBldgUnitEl.textContent,
-    },
-  });
+
 }
 
 /* ------------------------------------------------------------------ */

--- a/viz/src/rendering.ts
+++ b/viz/src/rendering.ts
@@ -1040,6 +1040,7 @@ export function update3DUI() {
 export function updateFieldTypeUI() {
   const numericOptions = document.getElementById('numericOptions');
   const categoricalOptions = document.getElementById('categoricalOptions');
+  const fieldTypeReadout = document.getElementById('fieldTypeReadout');
 
   if (!S.currentField) {
     // Hide all options when no field is selected
@@ -1054,16 +1055,19 @@ export function updateFieldTypeUI() {
     if (_paintDividerRamp) _paintDividerRamp.style.display = 'none';
     if (_paintDividerScaling) _paintDividerScaling.style.display = 'none';
     _extrusionOptions.style.display = 'none';
+    if (fieldTypeReadout) fieldTypeReadout.textContent = 'Field type: —';
   } else {
     const showNumericOptions = S.currentFieldType === 'numeric';
     const showCategoricalOptions = S.currentFieldType === 'categorical';
     const showColorRampOptions = showNumericOptions || (showCategoricalOptions && S.categoricalColorMode === 'colorRamp');
-    const showColorScalingOptions = showNumericOptions;
+    const showColorScalingOptions = !!_colorScalingOptions && showNumericOptions;
     const showOpacityOptions = true;
 
     if (_colorRampOptions) _colorRampOptions.style.display = showColorRampOptions ? 'grid' : 'none';
     if (_colorScalingOptions) _colorScalingOptions.style.display = showColorScalingOptions ? 'grid' : 'none';
     if (_opacityOptions) _opacityOptions.style.display = showOpacityOptions ? 'grid' : 'none';
+
+    if (fieldTypeReadout) fieldTypeReadout.textContent = `Field type: ${S.currentFieldType ?? '—'}`;
 
     if (showNumericOptions) {
       if (numericOptions) numericOptions.style.display = 'grid';

--- a/viz/src/scatterplot.ts
+++ b/viz/src/scatterplot.ts
@@ -240,7 +240,7 @@ export function updateScatterSubjectControls() {
     scatterSubjectControls,
     S.scatterSubjectMode,
     true,
-    !S.scatterCategoryField || Boolean(S.scatterCategoryValueIndices[0])
+    !S.scatterCategoryField || scatterCategoryValueSelect.options.length > 1
   );
 }
 

--- a/viz/src/scatterplot.ts
+++ b/viz/src/scatterplot.ts
@@ -124,9 +124,9 @@ let scatterPlotPointsByParcelId = new Map<string, ScatterPoint>();
 let scatterPlotEventsBound = false;
 
 export function populateScatterCategoryFields() {
-  const scatterStore = _getScatterDataStore();
-  const geoJSON = scatterStore?.geojson ?? null;
-  const categoricalFields = scatterStore?.chosenCategoricalFields ?? [];
+  const layer = _getScatterLayer();
+  const geoJSON = layer?.geojson ?? null;
+  const categoricalFields = layer?.chosenCategoricalFields ?? [];
   const available = populateCategoryFields(geoJSON, categoricalFields, scatterCategoryFieldSelect);
 
   if (S.scatterCategoryField && available.includes(S.scatterCategoryField)) {
@@ -137,8 +137,8 @@ export function populateScatterCategoryFields() {
 }
 
 export function populateScatterCategoryValues(field: string | null) {
-  const scatterStore = _getScatterDataStore();
-  const geoJSON = scatterStore?.geojson ?? null;
+  const layer = _getScatterLayer();
+  const geoJSON = layer?.geojson ?? null;
   const result = populateCategoryValues(
     geoJSON,
     field,
@@ -227,9 +227,8 @@ export function populateScatterColorByFields() {
 
 export function updateScatterSubjectControls() {
   const layer = _getScatterLayer();
-  const scatterStore = _getScatterDataStore();
-  const scatterGeoJSON = scatterStore?.geojson ?? null;
-  if (!layer || !scatterGeoJSON) {
+  const hasLayerData = Boolean(layer?.geojson);
+  if (!hasLayerData) {
     scatterSubjectControls.buttons.forEach(button => { button.disabled = true; });
     scatterSubjectControls.categoryControls.style.display = 'none';
     scatterCategoryFieldSelect.disabled = true;
@@ -240,8 +239,8 @@ export function updateScatterSubjectControls() {
   updateSubjectControls(
     scatterSubjectControls,
     S.scatterSubjectMode,
-    scatterCategoryFieldSelect.options.length > 1,
-    Boolean(S.scatterCategoryField)
+    true,
+    !S.scatterCategoryField || Boolean(S.scatterCategoryValueIndices[0])
   );
 }
 
@@ -250,7 +249,7 @@ function updateScatterSubjectButtons() {
 }
 
 export function setScatterSubjectMode(mode: SubjectMode) {
-  const allowedModes: SubjectMode[] = ['all', 'visible', 'selected'];
+  const allowedModes: SubjectMode[] = ['all', 'visible', 'selected', 'group'];
   S.scatterSubjectMode = allowedModes.includes(mode) ? mode : 'all';
   updateScatterSubjectButtons();
   updateScatterSubjectControls();
@@ -558,17 +557,15 @@ function getScatterSubjectSelection(
     if (!layerGeoJSON) return [];
     return layerGeoJSON.features.filter(feature => layer.selectedParcels.has(_getParcelId(feature)));
   }
-  if (mode === 'category') {
-    if (!dataGeoJSON || !categoryField || categoryValueIndices.length === 0) return [];
-    const selectedValues = new Set(
-      categoryValueIndices
-        .map(index => categoryValueMap[Number(index)])
-        .filter((entry): entry is { label: string; value: unknown } => Boolean(entry))
-        .map(entry => entry.value)
-    );
-    return dataGeoJSON.features.filter(feature => {
+  if (mode === 'group') {
+    if (!layerGeoJSON) return [];
+    if (!categoryField) return layerGeoJSON.features;
+    if (categoryValueIndices.length === 0) return [];
+    const selected = categoryValueMap[Number(categoryValueIndices[0])];
+    if (!selected) return [];
+    return layerGeoJSON.features.filter(feature => {
       const value = (feature.properties as Record<string, unknown> | undefined)?.[categoryField];
-      return selectedValues.has(value);
+      return value === selected.value;
     });
   }
   return layerGeoJSON?.features ?? [];
@@ -591,8 +588,8 @@ export function updateScatterPlot() {
     resetScatterPlot('Load data to render the scatterplot.');
     return;
   }
-  if (S.scatterSubjectMode === 'category' && (!S.scatterCategoryField || S.scatterCategoryValueIndices.length === 0)) {
-    resetScatterPlot('Choose category values to render the scatterplot.');
+  if (S.scatterSubjectMode === 'group' && S.scatterCategoryField && S.scatterCategoryValueIndices.length === 0) {
+    resetScatterPlot('Choose value to render the scatterplot.');
     return;
   }
   if (!S.scatterXField || !S.scatterYField) {
@@ -730,7 +727,7 @@ export function refreshScatterPanel() {
   populateScatterCategoryValues(S.scatterCategoryField);
   populateScatterFields();
   populateScatterColorByFields();
-  const allowedModes: SubjectMode[] = ['all', 'visible', 'selected'];
+  const allowedModes: SubjectMode[] = ['all', 'visible', 'selected', 'group'];
   if (!allowedModes.includes(S.scatterSubjectMode)) {
     S.scatterSubjectMode = 'all';
   }

--- a/viz/src/scatterplot.ts
+++ b/viz/src/scatterplot.ts
@@ -571,6 +571,22 @@ function getScatterSubjectSelection(
   return layerGeoJSON?.features ?? [];
 }
 
+
+export function getCurrentScatterSubjectSelection(): GeoJSON.Feature[] {
+  const layer = _getScatterLayer();
+  const scatterStore = _getScatterDataStore();
+  if (!layer || !layer.geojson || !scatterStore?.geojson) return [];
+  return getScatterSubjectSelection(
+    layer,
+    layer.geojson,
+    scatterStore.geojson,
+    S.scatterSubjectMode,
+    S.scatterCategoryField,
+    S.scatterCategoryValueIndices,
+    S.scatterCategoryValueMap
+  );
+}
+
 export function updateScatterPlot() {
   const plotly = getPlotly();
   if (!plotly) {

--- a/viz/src/statistics.ts
+++ b/viz/src/statistics.ts
@@ -89,10 +89,16 @@ export function buildSubjectSelector(
   valuePlaceholder.selected = true;
   categoryValueSelect.appendChild(valuePlaceholder);
 
-  categoryControls.append(categoryFieldSelect, categoryValueSelect);
+  const selectOnMapButton = document.createElement('button');
+  selectOnMapButton.type = 'button';
+  selectOnMapButton.textContent = 'Select on map';
+  selectOnMapButton.style.gridColumn = '2';
+  selectOnMapButton.style.justifySelf = 'stretch';
+
+  categoryControls.append(categoryFieldSelect, categoryValueSelect, selectOnMapButton);
   container.append(subjectBlock, categoryControls);
 
-  return { buttons, categoryControls, categoryFieldSelect, categoryValueSelect };
+  return { buttons, categoryControls, categoryFieldSelect, categoryValueSelect, selectOnMapButton };
 }
 
 export function updateSubjectButtons(controls: SubjectSelectorControls, mode: SubjectMode) {
@@ -111,6 +117,7 @@ export function updateSubjectControls(
   controls.categoryControls.style.display = isGroup ? 'grid' : 'none';
   controls.categoryFieldSelect.disabled = !isGroup || !hasFieldOptions;
   controls.categoryValueSelect.disabled = !isGroup || !hasFieldChosen;
+  controls.selectOnMapButton.disabled = !isGroup;
 }
 
 /**
@@ -656,6 +663,16 @@ export function getStatsSubjectSelection(
     });
   }
   return layerGeoJSON?.features ?? [];
+}
+
+
+export function getCurrentStatsSubjectSelection(): GeoJSON.Feature[] {
+  return getStatsSubjectSelection(
+    S.statsSubjectMode,
+    S.statsCategoryField,
+    S.statsCategoryValueIndices,
+    S.statsCategoryValueMap
+  );
 }
 
 export function updateStatisticsResults() {

--- a/viz/src/statistics.ts
+++ b/viz/src/statistics.ts
@@ -52,7 +52,8 @@ export function buildSubjectSelector(
   const modes: Array<{ mode: SubjectMode; label: string }> = [
     { mode: 'all', label: 'All' },
     { mode: 'visible', label: 'Visible' },
-    { mode: 'selected', label: 'Selected' }
+    { mode: 'selected', label: 'Selected' },
+    { mode: 'group', label: 'Group...' }
   ];
   modes.forEach(({ mode, label }) => {
     const button = document.createElement('button');
@@ -70,20 +71,18 @@ export function buildSubjectSelector(
 
   const categoryControls = document.createElement('div');
   categoryControls.style.display = 'none';
-  categoryControls.style.gap = '6px';
+  categoryControls.style.gap = '8px';
   categoryControls.style.marginTop = '8px';
+  categoryControls.style.gridTemplateColumns = 'minmax(0, 1fr) minmax(0, 1fr)';
 
   const categoryFieldSelect = document.createElement('select');
-  const fieldPlaceholder = new Option('Choose a field', '');
-  fieldPlaceholder.disabled = true;
+  const fieldPlaceholder = new Option('Everything', '');
   fieldPlaceholder.selected = true;
   categoryFieldSelect.appendChild(fieldPlaceholder);
 
   const categoryValueSelect = document.createElement('select');
-  categoryValueSelect.multiple = true;
-  categoryValueSelect.size = 4;
   categoryValueSelect.disabled = true;
-  const valuePlaceholder = new Option('Choose value(s)', '');
+  const valuePlaceholder = new Option('Choose value', '');
   valuePlaceholder.disabled = true;
   valuePlaceholder.selected = true;
   categoryValueSelect.appendChild(valuePlaceholder);
@@ -106,10 +105,10 @@ export function updateSubjectControls(
   hasFieldOptions: boolean,
   hasFieldSelected: boolean
 ) {
-  const isCategory = mode === 'category';
-  controls.categoryControls.style.display = isCategory ? 'grid' : 'none';
-  controls.categoryFieldSelect.disabled = !isCategory || !hasFieldOptions;
-  controls.categoryValueSelect.disabled = !isCategory || !hasFieldSelected;
+  const isGroup = mode === 'group';
+  controls.categoryControls.style.display = isGroup ? 'grid' : 'none';
+  controls.categoryFieldSelect.disabled = !isGroup || !hasFieldOptions;
+  controls.categoryValueSelect.disabled = !isGroup || !hasFieldSelected;
 }
 
 /**
@@ -122,8 +121,7 @@ export function populateCategoryFields(
   select: HTMLSelectElement
 ): string[] {
   select.replaceChildren();
-  const placeholder = new Option('Choose a field', '');
-  placeholder.disabled = true;
+  const placeholder = new Option('Everything', '');
   placeholder.selected = true;
   select.appendChild(placeholder);
 
@@ -140,7 +138,7 @@ export function populateCategoryFields(
     select.appendChild(new Option(field, field));
   });
 
-  select.disabled = available.length === 0;
+  select.disabled = false;
   return available;
 }
 
@@ -155,9 +153,9 @@ export function populateCategoryValues(
   currentIndices: string[]
 ): { valueMap: Array<{ label: string; value: unknown }>; indices: string[] } {
   select.replaceChildren();
-  const placeholder = new Option('Choose value(s)', '');
+  const placeholder = new Option('Choose value', '');
   placeholder.disabled = true;
-  placeholder.selected = currentIndices.length === 0;
+  placeholder.selected = true;
   select.appendChild(placeholder);
 
   if (!geoJSON || !field) {
@@ -165,35 +163,61 @@ export function populateCategoryValues(
     return { valueMap: [], indices: [] };
   }
 
-  const rawMap = new Map<string, { label: string; value: unknown }>();
+  const formatCount = (count: number) => {
+    if (count >= 1_000_000_000) return `${(count / 1_000_000_000).toFixed(count >= 10_000_000_000 ? 0 : 1).replace(/\.0$/, '')}B`;
+    if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(count >= 10_000_000 ? 0 : 1).replace(/\.0$/, '')}M`;
+    if (count >= 1_000) return `${(count / 1_000).toFixed(count >= 10_000 ? 0 : 1).replace(/\.0$/, '')}K`;
+    return String(count);
+  };
+
+  const buckets = new Map<string, { label: string; value: unknown; count: number }>();
   geoJSON.features.forEach(feature => {
     const raw = (feature.properties as Record<string, unknown> | undefined)?.[field];
-    if (raw === null || raw === undefined) return;
-    const key = `${typeof raw}:${String(raw)}`;
-    if (!rawMap.has(key)) {
-      rawMap.set(key, { label: String(raw), value: raw });
+    let key: string;
+    let label: string;
+    if (raw === undefined) {
+      key = 'undefined';
+      label = '(undefined)';
+    } else if (raw === null) {
+      key = 'null';
+      label = '(null)';
+    } else if (typeof raw === 'string' && raw.length === 0) {
+      key = 'string:';
+      label = '(empty)';
+    } else {
+      key = `${typeof raw}:${String(raw)}`;
+      label = String(raw);
+    }
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      buckets.set(key, { label, value: raw, count: 1 });
     }
   });
 
-  const valueMap = Array.from(rawMap.values()).sort((a, b) => a.label.localeCompare(b.label));
+  const sortedEntries = Array.from(buckets.values())
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
 
-  valueMap.forEach((entry, index) => {
-    select.appendChild(new Option(entry.label, String(index)));
+  sortedEntries.forEach((entry, index) => {
+    select.appendChild(new Option(`(${formatCount(entry.count)}) ${entry.label}`, String(index)));
   });
 
-  select.disabled = false;
-  const validSelections = new Set(
-    currentIndices.filter(index => valueMap[Number(index)])
-  );
-  const indices = Array.from(validSelections);
-  Array.from(select.options).forEach(option => {
-    option.selected = validSelections.has(option.value);
-  });
-  if (indices.length === 0) {
-    placeholder.selected = true;
+  select.disabled = sortedEntries.length === 0;
+
+  const valueMap = sortedEntries.map(({ label, value }) => ({ label, value }));
+  const selectedIndex = currentIndices.length ? currentIndices[0] : '';
+  const hasSelected = selectedIndex !== '' && valueMap[Number(selectedIndex)];
+  if (hasSelected) {
+    select.value = selectedIndex;
+    placeholder.selected = false;
+    return { valueMap, indices: [selectedIndex] };
   }
-  return { valueMap, indices };
+
+  placeholder.selected = true;
+  return { valueMap, indices: [] };
 }
+
 
 /* ------------------------------------------------------------------ */
 /*  DOM element references (set once via initStatisticsElements)       */
@@ -332,9 +356,8 @@ export function resetStatisticsDisplay() {
 
 export function populateStatisticsCategoryFields() {
   const layer = _getStatsLayer();
-  const dataStore = _getLayerDataStore(layer);
-  const geoJSON = dataStore?.geojson ?? null;
-  const categoricalFields = dataStore?.chosenCategoricalFields ?? [];
+  const geoJSON = _getLayerGeoJSON(layer);
+  const categoricalFields = layer?.chosenCategoricalFields ?? [];
   const available = populateCategoryFields(geoJSON, categoricalFields, statsCategoryFieldSelect);
 
   if (S.statsCategoryField && available.includes(S.statsCategoryField)) {
@@ -346,8 +369,7 @@ export function populateStatisticsCategoryFields() {
 
 export function populateStatisticsCategoryValues(field: string | null) {
   const layer = _getStatsLayer();
-  const dataStore = _getLayerDataStore(layer);
-  const geoJSON = dataStore?.geojson ?? null;
+  const geoJSON = _getLayerGeoJSON(layer);
   const result = populateCategoryValues(
     geoJSON,
     field,
@@ -367,11 +389,9 @@ export function getStatsFieldType(field: string | null, numericFields: string[],
 
 export function populateStatisticsFields() {
   const layer = _getStatsLayer();
-  const dataStore = _getLayerDataStore(layer);
-  const useDataSource = S.statsSubjectMode === 'category';
-  const sourceGeoJSON = useDataSource ? dataStore?.geojson ?? null : _getLayerGeoJSON(layer);
-  const numericFields = useDataSource ? dataStore?.chosenNumericFields ?? [] : layer?.chosenNumericFields ?? [];
-  const categoricalFields = useDataSource ? dataStore?.chosenCategoricalFields ?? [] : layer?.chosenCategoricalFields ?? [];
+  const sourceGeoJSON = _getLayerGeoJSON(layer);
+  const numericFields = layer?.chosenNumericFields ?? [];
+  const categoricalFields = layer?.chosenCategoricalFields ?? [];
 
   statsFieldSelect.replaceChildren();
   const placeholder = new Option('Choose a field', '');
@@ -559,13 +579,12 @@ export function getStatsSourceContext() {
 }
 
 export function getStatsNormalizationContext() {
-  const { layer, dataStore } = getStatsSourceContext();
-  const useDataSource = S.statsSubjectMode === 'category';
+  const { layer } = getStatsSourceContext();
   return {
-    landField: useDataSource ? dataStore?.landSizeField ?? null : layer?.landSizeField ?? null,
-    landUnit: useDataSource ? dataStore?.landSizeUnitLabel ?? null : layer?.landSizeUnitLabel ?? null,
-    bldgField: useDataSource ? dataStore?.bldgSizeField ?? null : layer?.bldgSizeField ?? null,
-    bldgUnit: useDataSource ? dataStore?.bldgSizeUnitLabel ?? null : layer?.bldgSizeUnitLabel ?? null
+    landField: layer?.landSizeField ?? null,
+    landUnit: layer?.landSizeUnitLabel ?? null,
+    bldgField: layer?.bldgSizeField ?? null,
+    bldgUnit: layer?.bldgSizeUnitLabel ?? null
   };
 }
 
@@ -623,28 +642,25 @@ export function getStatsSubjectSelection(
     if (!layerGeoJSON) return [];
     return layerGeoJSON.features.filter(feature => layer.selectedParcels.has(_getParcelId(feature)));
   }
-  if (mode === 'category') {
-    if (!dataGeoJSON || !categoryField || categoryValueIndices.length === 0) return [];
-    const selectedValues = new Set(
-      categoryValueIndices
-        .map(index => categoryValueMap[Number(index)])
-        .filter((entry): entry is { label: string; value: unknown } => Boolean(entry))
-        .map(entry => entry.value)
-    );
-    return dataGeoJSON.features.filter(feature => {
+  if (mode === 'group') {
+    if (!layerGeoJSON) return [];
+    if (!categoryField) return layerGeoJSON.features;
+    if (categoryValueIndices.length === 0) return [];
+    const selected = categoryValueMap[Number(categoryValueIndices[0])];
+    if (!selected) return [];
+    return layerGeoJSON.features.filter(feature => {
       const value = (feature.properties as Record<string, unknown> | undefined)?.[categoryField];
-      return selectedValues.has(value);
+      return value === selected.value;
     });
   }
   return layerGeoJSON?.features ?? [];
 }
 
 export function updateStatisticsResults() {
-  const { layer, layerGeoJSON, dataGeoJSON, dataStore } = getStatsSourceContext();
-  const useDataSource = S.statsSubjectMode === 'category';
-  const sourceGeoJSON = useDataSource ? dataGeoJSON : layerGeoJSON;
-  const numericFields = useDataSource ? dataStore?.chosenNumericFields ?? [] : layer?.chosenNumericFields ?? [];
-  const categoricalFields = useDataSource ? dataStore?.chosenCategoricalFields ?? [] : layer?.chosenCategoricalFields ?? [];
+  const { layer, layerGeoJSON } = getStatsSourceContext();
+  const sourceGeoJSON = layerGeoJSON;
+  const numericFields = layer?.chosenNumericFields ?? [];
+  const categoricalFields = layer?.chosenCategoricalFields ?? [];
 
   updateStatisticsNormalizationControls();
 
@@ -653,7 +669,7 @@ export function updateStatisticsResults() {
     resetStatisticsDisplay();
     return;
   }
-  if (S.statsSubjectMode === 'category' && (!S.statsCategoryField || S.statsCategoryValueIndices.length === 0)) {
+  if (S.statsSubjectMode === 'group' && S.statsCategoryField && S.statsCategoryValueIndices.length === 0) {
     S.statsValuesCache = [];
     resetStatisticsDisplay();
     return;
@@ -794,8 +810,8 @@ export function updateStatisticsSubjectControls() {
   updateSubjectControls(
     statsSubjectControls,
     S.statsSubjectMode,
-    statsCategoryFieldSelect.options.length > 1,
-    Boolean(S.statsCategoryField)
+    true,
+    !S.statsCategoryField || Boolean(S.statsCategoryValueIndices[0])
   );
 }
 
@@ -804,7 +820,7 @@ function updateStatisticsSubjectButtons() {
 }
 
 export function setStatsSubjectMode(mode: SubjectMode) {
-  const allowedModes: SubjectMode[] = ['all', 'visible', 'selected'];
+  const allowedModes: SubjectMode[] = ['all', 'visible', 'selected', 'group'];
   S.statsSubjectMode = allowedModes.includes(mode) ? mode : 'all';
   updateStatisticsSubjectButtons();
   updateStatisticsSubjectControls();
@@ -843,7 +859,7 @@ export function refreshStatisticsPanel() {
   populateStatisticsCategoryFields();
   populateStatisticsCategoryValues(S.statsCategoryField);
 
-  const allowedModes: SubjectMode[] = ['all', 'visible', 'selected'];
+  const allowedModes: SubjectMode[] = ['all', 'visible', 'selected', 'group'];
   if (!allowedModes.includes(S.statsSubjectMode)) {
     S.statsSubjectMode = 'all';
   }

--- a/viz/src/statistics.ts
+++ b/viz/src/statistics.ts
@@ -36,7 +36,7 @@ export function buildSubjectSelector(
   subjectBlock.style.display = 'grid';
   subjectBlock.style.gap = '6px';
 
-  const titleText = options.title ?? 'Subject:';
+  const titleText = options.title !== undefined ? options.title : 'Subject:';
   let title: HTMLDivElement | null = null;
   if (titleText) {
     title = document.createElement('div');

--- a/viz/src/statistics.ts
+++ b/viz/src/statistics.ts
@@ -76,11 +76,13 @@ export function buildSubjectSelector(
   categoryControls.style.gridTemplateColumns = 'minmax(0, 1fr) minmax(0, 1fr)';
 
   const categoryFieldSelect = document.createElement('select');
+  categoryFieldSelect.className = 'layer-source-name';
   const fieldPlaceholder = new Option('Everything', '');
   fieldPlaceholder.selected = true;
   categoryFieldSelect.appendChild(fieldPlaceholder);
 
   const categoryValueSelect = document.createElement('select');
+  categoryValueSelect.className = 'layer-source-name';
   categoryValueSelect.disabled = true;
   const valuePlaceholder = new Option('Choose value', '');
   valuePlaceholder.disabled = true;
@@ -103,12 +105,12 @@ export function updateSubjectControls(
   controls: SubjectSelectorControls,
   mode: SubjectMode,
   hasFieldOptions: boolean,
-  hasFieldSelected: boolean
+  hasFieldChosen: boolean
 ) {
   const isGroup = mode === 'group';
   controls.categoryControls.style.display = isGroup ? 'grid' : 'none';
   controls.categoryFieldSelect.disabled = !isGroup || !hasFieldOptions;
-  controls.categoryValueSelect.disabled = !isGroup || !hasFieldSelected;
+  controls.categoryValueSelect.disabled = !isGroup || !hasFieldChosen;
 }
 
 /**
@@ -811,7 +813,7 @@ export function updateStatisticsSubjectControls() {
     statsSubjectControls,
     S.statsSubjectMode,
     true,
-    !S.statsCategoryField || Boolean(S.statsCategoryValueIndices[0])
+    !S.statsCategoryField || statsCategoryValueSelect.options.length > 1
   );
 }
 

--- a/viz/src/statistics.ts
+++ b/viz/src/statistics.ts
@@ -204,6 +204,7 @@ let statsSubjectControls: SubjectSelectorControls;
 let statsCategoryFieldSelect: HTMLSelectElement;
 let statsCategoryValueSelect: HTMLSelectElement;
 let statsFieldSelect: HTMLSelectElement;
+let statsNormModeSelect: HTMLSelectElement | null = null;
 let statsDetails: HTMLDivElement;
 let statsNumericBlock: HTMLDivElement;
 let statsCategoricalBlock: HTMLDivElement;
@@ -232,6 +233,7 @@ export function initStatisticsElements(els: {
   statsLayerName: HTMLSelectElement;
   statsSubjectControls: SubjectSelectorControls;
   statsFieldSelect: HTMLSelectElement;
+  statsNormModeSelect?: HTMLSelectElement | null;
   statsDetails: HTMLDivElement;
   statsNumericBlock: HTMLDivElement;
   statsCategoricalBlock: HTMLDivElement;
@@ -261,6 +263,7 @@ export function initStatisticsElements(els: {
   statsCategoryFieldSelect = els.statsSubjectControls.categoryFieldSelect;
   statsCategoryValueSelect = els.statsSubjectControls.categoryValueSelect;
   statsFieldSelect = els.statsFieldSelect;
+  statsNormModeSelect = els.statsNormModeSelect ?? null;
   statsDetails = els.statsDetails;
   statsNumericBlock = els.statsNumericBlock;
   statsCategoricalBlock = els.statsCategoricalBlock;
@@ -581,6 +584,20 @@ export function updateStatisticsNormalizationControls() {
     S.statsNormalizationMode = 'asis';
     statsNormAsIs.checked = true;
   }
+
+  if (statsNormModeSelect) {
+    const perLandOption = statsNormModeSelect.querySelector('option[value="perLand"]') as HTMLOptionElement | null;
+    const perBuildingOption = statsNormModeSelect.querySelector('option[value="perBuilding"]') as HTMLOptionElement | null;
+    if (perLandOption) {
+      perLandOption.disabled = !context.landField;
+      perLandOption.textContent = `…per land size ${context.landField ? (context.landUnit ?? '(unit)') : '(unit)'}`;
+    }
+    if (perBuildingOption) {
+      perBuildingOption.disabled = !context.bldgField;
+      perBuildingOption.textContent = `…per building size ${context.bldgField ? (context.bldgUnit ?? '(unit)') : '(unit)'}`;
+    }
+    statsNormModeSelect.value = S.statsNormalizationMode;
+  }
 }
 
 export function getStatsSubjectSelection(
@@ -818,7 +835,7 @@ export function updateStatisticsSectionVisibility() {
   const isNumeric = S.statsFieldType === 'numeric';
   statsNumericBlock.style.display = isNumeric ? 'grid' : 'none';
   statsCategoricalBlock.style.display = isNumeric ? 'none' : 'grid';
-  statsNormalizationControls.style.display = isNumeric ? 'grid' : 'none';
+  statsNormalizationControls.style.display = 'none';
   updateStatisticsNormalizationControls();
 }
 

--- a/viz/src/types.ts
+++ b/viz/src/types.ts
@@ -224,6 +224,7 @@ export type SubjectSelectorControls = {
   categoryControls: HTMLDivElement;
   categoryFieldSelect: HTMLSelectElement;
   categoryValueSelect: HTMLSelectElement;
+  selectOnMapButton: HTMLButtonElement;
 };
 
 export type SubjectSelectorOptions = {

--- a/viz/src/types.ts
+++ b/viz/src/types.ts
@@ -47,7 +47,7 @@ export type CategoricalColorMode = 'random' | 'single' | 'colorRamp';
 export type QualityMode = 'fast' | 'high';
 export type UpdateMode = 'applyOnly' | 'recomputeAndAutoScale';
 export type MetricUnitKey = 'centimeters' | 'meters' | 'kilometers';
-export type SubjectMode = 'all' | 'visible' | 'selected' | 'category';
+export type SubjectMode = 'all' | 'visible' | 'selected' | 'group';
 export type LandSchedulePerUnit = 'lot' | 'area' | 'frontage';
 
 export type LandScheduleBaseLot = {


### PR DESCRIPTION
### Motivation
- Prevent panel chrome from collapsing behind controls and improve clarity in the Layers and Statistics panels by enforcing sensible minimum sizing and separating concerns.
- Make the “Field to visualize” controls their own collapsible section and avoid collapsing downstream content when toggled.
- Remove the redundant "Current layer / Source" header and its readout to simplify the Layers panel UI.
- Consolidate paint-related controls (color ramp + scaling) into a compact single-line layout that pairs the ramp and scaling choices.

### Description
- Added a dedicated collapsible "Field to visualize" section in `viz/index.html` that places the field selector and normalization selector on one row with a small field-type readout underneath, and hid legacy radio controls for compatibility (`viz/index.html`).
- Removed the visible "Current layer / source" readout and removed the code that populated it from the UI (`viz/src/layers.ts`) and replaced the update function with a no-op comment.
- Wired new dropdown controls and the field collapse toggle in `viz/src/main.ts`, added sync listeners so the new `normModeSelect` and `colorModeSelect` control existing radio-based logic, and added a handler so collapsing the field section only affects that section.
- Updated rendering logic in `viz/src/rendering.ts` to drive the new "Field type: …" readout and to tolerate optional/missing color-scaling elements safely.
- Fixed subject selector title handling so passing `{ title: null }` truly suppresses the "Subject:" label and set a minimum width on the Statistics window to prevent extreme horizontal shrinkage (`viz/src/statistics.ts`, `viz/index.html`).

### Testing
- Ran `git diff --check` to verify whitespace / patch issues and it produced no errors.
- Ran `npm run build` in the `viz` workspace which failed due to missing local toolchain/dependencies (`vite` not installed and npm registry access restricted), so a production build could not be validated here.
- Ran `npx tsc --noEmit` which failed in this environment because dependent packages and type declarations could not be fetched, so type-checking could not be fully validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6994998473ec8326be369bbfd2da4e8e)