### PR TITLE
Fix VIZ create-field write propagation and add datasource-field update event

### DIFF
--- a/viz/src/layers.ts
+++ b/viz/src/layers.ts
@@ -40,6 +40,13 @@ let _colorPicker: HTMLInputElement;
 let _enable3DCheckbox: HTMLInputElement;
 let _filtersInvertToggle: HTMLInputElement;
 
+const LAYERS_FIELD_DEBUG = true;
+function layersFieldDebug(message: string, payload?: Record<string, unknown>) {
+  if (!LAYERS_FIELD_DEBUG) return;
+  if (payload) console.debug(`[layers-fields] ${message}`, payload);
+  else console.debug(`[layers-fields] ${message}`);
+}
+
 export function initLayerElements(els: {
   layerList: HTMLDivElement;
   dataStoreList: HTMLDivElement;
@@ -473,6 +480,14 @@ export function applyLayerState(layer: LayerState) {
         ...S.chosenNumericFields.filter(k => S.currentGeoJSON?.features?.some(f => f?.properties?.hasOwnProperty(k))),
         ...S.chosenCategoricalFields.filter(k => S.currentGeoJSON?.features?.some(f => f?.properties?.hasOwnProperty(k)))
       ];
+      layersFieldDebug('populating active-layer field dropdown', {
+        currentLayerId: S.currentLayerId,
+        currentDataStoreId: S.currentDataStoreId,
+        numericFieldCount: S.chosenNumericFields.length,
+        categoricalFieldCount: S.chosenCategoricalFields.length,
+        availableFieldCount: allAvailableFields.length,
+        sampleAvailableFields: allAvailableFields.slice(0, 10),
+      });
       _populateFieldDropdownFromList(allAvailableFields);
       _fieldSelect.value = S.currentField ?? '';
     }

--- a/viz/src/layers.ts
+++ b/viz/src/layers.ts
@@ -40,13 +40,6 @@ let _colorPicker: HTMLInputElement;
 let _enable3DCheckbox: HTMLInputElement;
 let _filtersInvertToggle: HTMLInputElement;
 
-const LAYERS_FIELD_DEBUG = true;
-function layersFieldDebug(message: string, payload?: Record<string, unknown>) {
-  if (!LAYERS_FIELD_DEBUG) return;
-  if (payload) console.debug(`[layers-fields] ${message}`, payload);
-  else console.debug(`[layers-fields] ${message}`);
-}
-
 export function initLayerElements(els: {
   layerList: HTMLDivElement;
   dataStoreList: HTMLDivElement;
@@ -480,14 +473,6 @@ export function applyLayerState(layer: LayerState) {
         ...S.chosenNumericFields.filter(k => S.currentGeoJSON?.features?.some(f => f?.properties?.hasOwnProperty(k))),
         ...S.chosenCategoricalFields.filter(k => S.currentGeoJSON?.features?.some(f => f?.properties?.hasOwnProperty(k)))
       ];
-      layersFieldDebug('populating active-layer field dropdown', {
-        currentLayerId: S.currentLayerId,
-        currentDataStoreId: S.currentDataStoreId,
-        numericFieldCount: S.chosenNumericFields.length,
-        categoricalFieldCount: S.chosenCategoricalFields.length,
-        availableFieldCount: allAvailableFields.length,
-        sampleAvailableFields: allAvailableFields.slice(0, 10),
-      });
       _populateFieldDropdownFromList(allAvailableFields);
       _fieldSelect.value = S.currentField ?? '';
     }

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -2080,6 +2080,13 @@ let writeCancelRequested = false;
 let writeSafetyTimer: number | null = null;
 
 const DATA_SOURCE_FIELDS_UPDATED_EVENT = 'data-source-fields-updated';
+const WRITE_FIELD_DEBUG = true;
+
+function writeFieldDebug(message: string, payload?: Record<string, unknown>) {
+  if (!WRITE_FIELD_DEBUG) return;
+  if (payload) console.debug(`[write-fields] ${message}`, payload);
+  else console.debug(`[write-fields] ${message}`);
+}
 
 function getWriteDataStore() {
   const id = writeDataSource.value;
@@ -2337,21 +2344,36 @@ function updateMapSourceDataForLayer(layerId: string) {
 }
 
 function dispatchDataSourceFieldsUpdated(dataStoreId: string, field: string, fieldType: 'numeric' | 'categorical') {
+  writeFieldDebug('dispatching datasource field update event', { dataStoreId, field, fieldType });
   window.dispatchEvent(new CustomEvent(DATA_SOURCE_FIELDS_UPDATED_EVENT, {
     detail: { dataStoreId, field, fieldType },
   }));
 }
 
 function refreshMenusBoundToDataSource(dataStoreId: string) {
-  const hasAffectedLayer = S.layerOrder.some((layerId) => S.layers.get(layerId)?.dataStoreId === dataStoreId);
-  if (!hasAffectedLayer) return;
+  const affectedLayers = S.layerOrder.filter((layerId) => S.layers.get(layerId)?.dataStoreId === dataStoreId);
+  writeFieldDebug('refreshMenusBoundToDataSource invoked', {
+    dataStoreId,
+    affectedLayerCount: affectedLayers.length,
+    affectedLayers,
+    currentLayerId: S.currentLayerId,
+  });
+  if (affectedLayers.length === 0) return;
 
   // Always refresh the Layers panel itself so all datasource-bound layers expose new fields immediately.
   renderLayerList();
 
   const currentLayer = getCurrentLayer();
-  if (!currentLayer || currentLayer.dataStoreId !== dataStoreId) return;
+  if (!currentLayer || currentLayer.dataStoreId !== dataStoreId) {
+    writeFieldDebug('skipping current-layer panel refresh; current layer not bound to datasource', {
+      currentLayerId: currentLayer?.id ?? null,
+      currentLayerDataStoreId: currentLayer?.dataStoreId ?? null,
+      dataStoreId,
+    });
+    return;
+  }
 
+  writeFieldDebug('refreshing panels for current layer bound to updated datasource', { currentLayerId: currentLayer.id, dataStoreId });
   renderDataStoreList();
   refreshFiltersUI();
   refreshStatisticsPanel();
@@ -2521,6 +2543,14 @@ async function runWriteOperation() {
   }
 
   if (isCreateField) {
+    writeFieldDebug('create-field operation completed staging; syncing schema lists', {
+      dataStoreId: store.id,
+      targetField,
+      targetFieldType,
+      changedCount: stagedChanges.length,
+      selectedMode: writeApplyTo.value,
+      selectedParcelCount: selectedIds.size,
+    });
     if (targetFieldType === 'numeric') {
       if (!store.chosenNumericFields.includes(targetField)) store.chosenNumericFields.push(targetField);
     } else if (!store.chosenCategoricalFields.includes(targetField)) {
@@ -2529,6 +2559,22 @@ async function runWriteOperation() {
     getLayersForDataSource(store.id).forEach(layer => {
       if (targetFieldType === 'numeric' && !layer.chosenNumericFields.includes(targetField)) layer.chosenNumericFields.push(targetField);
       if (targetFieldType === 'categorical' && !layer.chosenCategoricalFields.includes(targetField)) layer.chosenCategoricalFields.push(targetField);
+      writeFieldDebug('updated layer schema arrays from create-field', {
+        layerId: layer.id,
+        dataStoreId: layer.dataStoreId,
+        numericFieldCount: layer.chosenNumericFields.length,
+        categoricalFieldCount: layer.chosenCategoricalFields.length,
+      });
+    });
+
+    const activeLayer = getCurrentLayer();
+    writeFieldDebug('post-sync active field lists snapshot', {
+      activeLayerId: activeLayer?.id ?? null,
+      activeLayerDataStoreId: activeLayer?.dataStoreId ?? null,
+      stateNumericContainsField: S.chosenNumericFields.includes(targetField),
+      stateCategoricalContainsField: S.chosenCategoricalFields.includes(targetField),
+      storeNumericContainsField: store.chosenNumericFields.includes(targetField),
+      storeCategoricalContainsField: store.chosenCategoricalFields.includes(targetField),
     });
   }
 
@@ -3187,10 +3233,17 @@ window.addEventListener('data-sources-changed', () => {
 });
 
 window.addEventListener(DATA_SOURCE_FIELDS_UPDATED_EVENT, (event) => {
-  const detail = (event as CustomEvent<{ dataStoreId?: string }>).detail;
+  const detail = (event as CustomEvent<{ dataStoreId?: string; field?: string; fieldType?: 'numeric' | 'categorical' }>).detail;
   const dataStoreId = detail?.dataStoreId;
+  writeFieldDebug('received datasource field update event', {
+    dataStoreId: dataStoreId ?? null,
+    field: detail?.field ?? null,
+    fieldType: detail?.fieldType ?? null,
+    writeDataSourceValue: writeDataSource.value || null,
+  });
   if (!dataStoreId) return;
   if (writeDataSource.value === dataStoreId) {
+    writeFieldDebug('refreshing write UI for matching datasource', { dataStoreId });
     refreshWriteUI();
   }
   refreshMenusBoundToDataSource(dataStoreId);

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -2080,13 +2080,6 @@ let writeCancelRequested = false;
 let writeSafetyTimer: number | null = null;
 
 const DATA_SOURCE_FIELDS_UPDATED_EVENT = 'data-source-fields-updated';
-const WRITE_FIELD_DEBUG = true;
-
-function writeFieldDebug(message: string, payload?: Record<string, unknown>) {
-  if (!WRITE_FIELD_DEBUG) return;
-  if (payload) console.debug(`[write-fields] ${message}`, payload);
-  else console.debug(`[write-fields] ${message}`);
-}
 
 function getWriteDataStore() {
   const id = writeDataSource.value;
@@ -2344,36 +2337,30 @@ function updateMapSourceDataForLayer(layerId: string) {
 }
 
 function dispatchDataSourceFieldsUpdated(dataStoreId: string, field: string, fieldType: 'numeric' | 'categorical') {
-  writeFieldDebug('dispatching datasource field update event', { dataStoreId, field, fieldType });
   window.dispatchEvent(new CustomEvent(DATA_SOURCE_FIELDS_UPDATED_EVENT, {
     detail: { dataStoreId, field, fieldType },
   }));
 }
 
 function refreshMenusBoundToDataSource(dataStoreId: string) {
-  const affectedLayers = S.layerOrder.filter((layerId) => S.layers.get(layerId)?.dataStoreId === dataStoreId);
-  writeFieldDebug('refreshMenusBoundToDataSource invoked', {
-    dataStoreId,
-    affectedLayerCount: affectedLayers.length,
-    affectedLayers,
-    currentLayerId: S.currentLayerId,
-  });
-  if (affectedLayers.length === 0) return;
+  const hasAffectedLayer = S.layerOrder.some((layerId) => S.layers.get(layerId)?.dataStoreId === dataStoreId);
+  if (!hasAffectedLayer) return;
 
   // Always refresh the Layers panel itself so all datasource-bound layers expose new fields immediately.
   renderLayerList();
 
   const currentLayer = getCurrentLayer();
-  if (!currentLayer || currentLayer.dataStoreId !== dataStoreId) {
-    writeFieldDebug('skipping current-layer panel refresh; current layer not bound to datasource', {
-      currentLayerId: currentLayer?.id ?? null,
-      currentLayerDataStoreId: currentLayer?.dataStoreId ?? null,
-      dataStoreId,
-    });
-    return;
+  if (!currentLayer || currentLayer.dataStoreId !== dataStoreId) return;
+
+  if (S.currentGeoJSON) {
+    const allAvailableFields = [
+      ...S.chosenNumericFields.filter((k) => S.currentGeoJSON?.features?.some((f) => f?.properties?.hasOwnProperty(k))),
+      ...S.chosenCategoricalFields.filter((k) => S.currentGeoJSON?.features?.some((f) => f?.properties?.hasOwnProperty(k))),
+    ];
+    populateFieldDropdownFromList(allAvailableFields);
+    fieldSelect.value = S.currentField ?? '';
   }
 
-  writeFieldDebug('refreshing panels for current layer bound to updated datasource', { currentLayerId: currentLayer.id, dataStoreId });
   renderDataStoreList();
   refreshFiltersUI();
   refreshStatisticsPanel();
@@ -2543,14 +2530,6 @@ async function runWriteOperation() {
   }
 
   if (isCreateField) {
-    writeFieldDebug('create-field operation completed staging; syncing schema lists', {
-      dataStoreId: store.id,
-      targetField,
-      targetFieldType,
-      changedCount: stagedChanges.length,
-      selectedMode: writeApplyTo.value,
-      selectedParcelCount: selectedIds.size,
-    });
     if (targetFieldType === 'numeric') {
       if (!store.chosenNumericFields.includes(targetField)) store.chosenNumericFields.push(targetField);
     } else if (!store.chosenCategoricalFields.includes(targetField)) {
@@ -2559,23 +2538,14 @@ async function runWriteOperation() {
     getLayersForDataSource(store.id).forEach(layer => {
       if (targetFieldType === 'numeric' && !layer.chosenNumericFields.includes(targetField)) layer.chosenNumericFields.push(targetField);
       if (targetFieldType === 'categorical' && !layer.chosenCategoricalFields.includes(targetField)) layer.chosenCategoricalFields.push(targetField);
-      writeFieldDebug('updated layer schema arrays from create-field', {
-        layerId: layer.id,
-        dataStoreId: layer.dataStoreId,
-        numericFieldCount: layer.chosenNumericFields.length,
-        categoricalFieldCount: layer.chosenCategoricalFields.length,
-      });
     });
 
     const activeLayer = getCurrentLayer();
-    writeFieldDebug('post-sync active field lists snapshot', {
-      activeLayerId: activeLayer?.id ?? null,
-      activeLayerDataStoreId: activeLayer?.dataStoreId ?? null,
-      stateNumericContainsField: S.chosenNumericFields.includes(targetField),
-      stateCategoricalContainsField: S.chosenCategoricalFields.includes(targetField),
-      storeNumericContainsField: store.chosenNumericFields.includes(targetField),
-      storeCategoricalContainsField: store.chosenCategoricalFields.includes(targetField),
-    });
+    const activeStateBoundToStore = S.currentDataStoreId === store.id || activeLayer?.dataStoreId === store.id;
+    if (activeStateBoundToStore) {
+      if (targetFieldType === 'numeric' && !S.chosenNumericFields.includes(targetField)) S.chosenNumericFields.push(targetField);
+      if (targetFieldType === 'categorical' && !S.chosenCategoricalFields.includes(targetField)) S.chosenCategoricalFields.push(targetField);
+    }
   }
 
   stagedChanges.forEach(({ feature, parcelId, previous, next }) => {
@@ -3233,17 +3203,10 @@ window.addEventListener('data-sources-changed', () => {
 });
 
 window.addEventListener(DATA_SOURCE_FIELDS_UPDATED_EVENT, (event) => {
-  const detail = (event as CustomEvent<{ dataStoreId?: string; field?: string; fieldType?: 'numeric' | 'categorical' }>).detail;
+  const detail = (event as CustomEvent<{ dataStoreId?: string }>).detail;
   const dataStoreId = detail?.dataStoreId;
-  writeFieldDebug('received datasource field update event', {
-    dataStoreId: dataStoreId ?? null,
-    field: detail?.field ?? null,
-    fieldType: detail?.fieldType ?? null,
-    writeDataSourceValue: writeDataSource.value || null,
-  });
   if (!dataStoreId) return;
   if (writeDataSource.value === dataStoreId) {
-    writeFieldDebug('refreshing write UI for matching datasource', { dataStoreId });
     refreshWriteUI();
   }
   refreshMenusBoundToDataSource(dataStoreId);

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -2343,8 +2343,15 @@ function dispatchDataSourceFieldsUpdated(dataStoreId: string, field: string, fie
 }
 
 function refreshMenusBoundToDataSource(dataStoreId: string) {
+  const hasAffectedLayer = S.layerOrder.some((layerId) => S.layers.get(layerId)?.dataStoreId === dataStoreId);
+  if (!hasAffectedLayer) return;
+
+  // Always refresh the Layers panel itself so all datasource-bound layers expose new fields immediately.
+  renderLayerList();
+
   const currentLayer = getCurrentLayer();
   if (!currentLayer || currentLayer.dataStoreId !== dataStoreId) return;
+
   renderDataStoreList();
   refreshFiltersUI();
   refreshStatisticsPanel();

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -2079,6 +2079,8 @@ let writeBusy = false;
 let writeCancelRequested = false;
 let writeSafetyTimer: number | null = null;
 
+const DATA_SOURCE_FIELDS_UPDATED_EVENT = 'data-source-fields-updated';
+
 function getWriteDataStore() {
   const id = writeDataSource.value;
   return id ? (S.dataStores.get(id) ?? null) : null;
@@ -2334,6 +2336,31 @@ function updateMapSourceDataForLayer(layerId: string) {
   if (source) source.setData(layer.geojson);
 }
 
+function dispatchDataSourceFieldsUpdated(dataStoreId: string, field: string, fieldType: 'numeric' | 'categorical') {
+  window.dispatchEvent(new CustomEvent(DATA_SOURCE_FIELDS_UPDATED_EVENT, {
+    detail: { dataStoreId, field, fieldType },
+  }));
+}
+
+function refreshMenusBoundToDataSource(dataStoreId: string) {
+  const currentLayer = getCurrentLayer();
+  if (!currentLayer || currentLayer.dataStoreId !== dataStoreId) return;
+  renderDataStoreList();
+  refreshFiltersUI();
+  refreshStatisticsPanel();
+  refreshScatterPanel();
+  refreshLandSchedulePanel();
+  refreshTimeAdjustmentPanel();
+  renderStatsLayerOptions();
+  renderScatterLayerOptions();
+  if (S.isInspectMinimized || !S.lastPicked) return;
+  if (isInspectPinned()) {
+    renderInspectPinnedContent();
+    return;
+  }
+  showPopupForLastPicked();
+}
+
 function setParcelPatchForLayer(layerId: string, parcelId: string, field: string, original: any, current: any, fieldType: 'numeric' | 'categorical') {
   const layer = S.layers.get(layerId);
   if (!layer) return;
@@ -2431,6 +2458,7 @@ async function runWriteOperation() {
     const parcelId = getParcelId(feature as any);
     if (targetParcelSet && !targetParcelSet.has(parcelId)) continue;
 
+    const hadTargetField = Object.prototype.hasOwnProperty.call(props, targetField);
     const previous = normalizeFieldValue(targetFieldType, props[targetField]);
     let next = previous;
 
@@ -2473,7 +2501,8 @@ async function runWriteOperation() {
       if (writeCancelRequested) break;
     }
 
-    if (valuesEqualForField(targetFieldType, previous, next)) continue;
+    const unchangedValue = valuesEqualForField(targetFieldType, previous, next);
+    if (unchangedValue && (!isCreateField || hadTargetField)) continue;
     stagedChanges.push({ feature, parcelId, previous, next });
   }
 
@@ -2513,10 +2542,16 @@ async function runWriteOperation() {
   layerIds.forEach(updateMapSourceDataForLayer);
   if (S.currentLayerId && layerIds.includes(S.currentLayerId)) {
     S.parcelPatchMap = S.layers.get(S.currentLayerId)?.parcelPatchMap ?? new Map();
+    if (S.lastPicked) {
+      const picked = findFeatureByParcelId(S.lastPicked.parcelId);
+      if (picked?.properties) {
+        S.lastPicked.props = { ...picked.properties };
+      }
+    }
   }
-  if (S.lastPicked && targetField in (S.lastPicked.props ?? {})) {
-    const picked = findFeatureByParcelId(S.lastPicked.parcelId);
-    if (picked?.properties) S.lastPicked.props[targetField] = picked.properties[targetField];
+
+  if (isCreateField) {
+    dispatchDataSourceFieldsUpdated(store.id, targetField, targetFieldType);
   }
 
   if (changed === 0) {
@@ -3142,6 +3177,16 @@ writeCancel.addEventListener('click', () => {
 
 window.addEventListener('data-sources-changed', () => {
   resetWriteMenu();
+});
+
+window.addEventListener(DATA_SOURCE_FIELDS_UPDATED_EVENT, (event) => {
+  const detail = (event as CustomEvent<{ dataStoreId?: string }>).detail;
+  const dataStoreId = detail?.dataStoreId;
+  if (!dataStoreId) return;
+  if (writeDataSource.value === dataStoreId) {
+    refreshWriteUI();
+  }
+  refreshMenusBoundToDataSource(dataStoreId);
 });
 
 if (writeSelectionCountTimer) {


### PR DESCRIPTION
### Motivation

- Create-new-field operations could be skipped when both the previous and next normalized values were `null`, so newly created fields were not materialized on features or exposed to UI selectors.
- After creating fields the UI did not always refresh menus/panels bound to that datasource, causing selectors and the inspect/pinned inspect view to miss the new field until a manual refresh.

### Description

- Adjusted the write/create-field flow in `viz/src/main.ts` to detect whether a field previously existed (`hadTargetField`) and only skip staging when appropriate, ensuring create-field writes always materialize target properties on features. (`runWriteOperation` logic)
- Added a new event constant `DATA_SOURCE_FIELDS_UPDATED_EVENT` and a helper `dispatchDataSourceFieldsUpdated` to emit a `CustomEvent` after successful create-field operations. (new event dispatch)
- Implemented `refreshMenusBoundToDataSource` to selectively refresh datasource-bound menus/panels (write, filters, statistics, scatter, land schedule, time adjustment, layer selectors) and to refresh the inspect popup/pinned inspect content when the active datasource is affected. (event-driven UI refresh)
- Ensured `S.lastPicked.props` is kept in sync after writes so the inspect popup/pinned inspect immediately shows newly created fields. (inspect cache sync)
- All changes are contained in `viz/src/main.ts` (updates include new helper functions, event listener registration, and small behavioral changes in the write pipeline).

### Testing

- Attempted to run a local build with `npm --prefix viz run build`, but the environment lacked the local `vite` binary and the command failed with `vite: not found` (automated build attempt failed).
- Attempted to install dependencies with `npm --prefix viz install`, but the session could not access the npm registry (`403 Forbidden`), so dependency installation and a full build/test run were not possible in this environment (automated install attempt blocked).
- No unit tests were present/executed as part of this change in the current environment; code-level verification was performed via static inspection and targeted runs of repository commands (`git` operations and quick greps) to verify the patch and commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6994d31eeb54832695c3fda26ac80ebb)