### PR TITLE
Add VIZ local mode testing docs and deploy-local mode switch

### DIFF
--- a/deploy-local.js
+++ b/deploy-local.js
@@ -20,6 +20,20 @@ const utilOut = path.join(siteOut, "util");
 
 const PORT = 3000;
 
+
+function parseVizMode(argv) {
+  const prefix = "--viz-mode=";
+  const modeArg = argv.find(arg => arg.startsWith(prefix));
+  const mode = modeArg ? modeArg.slice(prefix.length).trim().toLowerCase() : "browser";
+  const allowed = new Set(["browser", "desktop", "hosted"]);
+  if (!allowed.has(mode)) {
+    console.error(`Invalid --viz-mode value "${mode}". Use one of: browser, desktop, hosted.`);
+    process.exit(1);
+  }
+  return mode;
+}
+
+
 async function rmrf(p) {
   await fs.rm(p, { recursive: true, force: true });
 }
@@ -110,9 +124,11 @@ function startServer(rootDir) {
 
   // Build viz into local-deploy/site/viz
   // Ensure viz deps are installed once: cd viz && npm install
-  console.log("Building viz into:", vizOut);
-  run(npmCmd, ["run", "build", "--", "--outDir", vizOut, "--emptyOutDir"], vizSrc);
-  console.log("Viz build complete");
+  const vizMode = parseVizMode(process.argv.slice(2));
+  const vizBuildScript = `build:${vizMode}`;
+  console.log(`Building viz (${vizMode}) into:`, vizOut);
+  run(npmCmd, ["run", vizBuildScript, "--", "--outDir", vizOut, "--emptyOutDir"], vizSrc);
+  console.log(`Viz build complete (${vizMode})`);
 
   // Serve local-deploy/site
   console.log("Starting local server...");

--- a/viz/.env.browser
+++ b/viz/.env.browser
@@ -1,0 +1,1 @@
+VITE_VIZ_BUILD_MODE=browser

--- a/viz/.env.desktop
+++ b/viz/.env.desktop
@@ -1,0 +1,1 @@
+VITE_VIZ_BUILD_MODE=desktop

--- a/viz/.env.hosted
+++ b/viz/.env.hosted
@@ -1,0 +1,1 @@
+VITE_VIZ_BUILD_MODE=hosted

--- a/viz/AGENTS.md
+++ b/viz/AGENTS.md
@@ -1041,3 +1041,225 @@ The data they export looks like this:
 ## New Menus
 
 ### Data 
+
+---
+
+## VIZ Build Modes Architecture Decisions (2026-02)
+
+This section captures the current decisions for the three-tier VIZ architecture and replaces the accidental lowercase `viz/agents.md` draft.
+
+### Finalized decisions so far
+
+1. **Single repo/branch** for Browser, Desktop, and Hosted/Cloud.
+2. **Build mode checks** are the primary differentiation mechanism (`browser`, `desktop`, `hosted`).
+3. **Graceful degradation** is required: unsupported features are hidden/disabled by mode and never break flows.
+4. **Desktop + Hosted DB technology target: PostgreSQL + PostGIS** (shared technology strategy across upper tiers).
+5. **Project format**: folder-based project with:
+   - one project metadata file (`viz-project.json`),
+   - supporting dependent files in the same folder,
+   - separate data directories: `/data/raw` and `/data/derived`.
+6. **Distribution model** (no license gating):
+   - Browser = no-install lightweight/demo access,
+   - Desktop = single-user power workflow,
+   - Hosted/Cloud = office/team workflow.
+
+### Recommended hosted tenancy model (decision guidance)
+
+For municipal assessor office usage, start with a **single-tenant-per-office deployment** model (one org per deployment/database) and design internals to be **tenant-aware later**.
+
+Why this is the best starting point:
+- Simpler security and compliance review for government IT teams.
+- Easier permission modeling and incident boundaries.
+- Lower operational complexity for the first production rollout.
+- Still compatible with future multi-tenant refactor if needed.
+
+### Authentication/authorization clarification
+
+"Auth provider direction" means who verifies user identity and how roles/permissions are enforced.
+
+Recommended staged approach:
+- **Desktop:** no RBAC requirement (single-user local workflow).
+- **Hosted Phase 1 (later):** app-managed local accounts + role-based access control (RBAC).
+- **Hosted Phase 2:** enterprise identity integration (OIDC/SAML) for SSO with municipal IT.
+
+Role baseline to define early:
+- Viewer (read-only)
+- Editor (create/edit workspace changes)
+- Reviewer/Approver (can reconcile/commit to upstream)
+- Admin (user/role/system management)
+
+### Collaboration model clarification (non-Figma realtime)
+
+Adopt a **workspace + commit + reconcile** model:
+- Users pull from upstream into isolated workspaces.
+- Users make local edits in workspace branches/snapshots.
+- Users commit changes back to upstream via reconcile workflow.
+- Conflicts are resolved explicitly at commit/reconcile time.
+- Every commit/write is audited (who, when, what changed).
+
+Initial conflict policy:
+- `last-write-wins` may be allowed in low-risk fields,
+- but all overwrite events must be captured in audit history and reversible where possible.
+
+
+### Delivery priority (near-term)
+
+- **Now:** implement Browser + Desktop architecture and Desktop runtime enablement (Desktop first).
+- **Not now:** no Hosted runtime implementation yet.
+- **Still required now:** define Hosted-facing interfaces/contracts so Desktop choices do not block future Hosted rollout.
+
+### Browser persistence options (clarification)
+
+Two practical options:
+1. **Ephemeral browser mode**
+   - Data lives in memory while tab is open.
+   - User persists via manual import/export/download.
+   - Pros: simple, predictable privacy posture.
+   - Cons: less convenient, slower repeated workflows.
+2. **IndexedDB-assisted browser mode (optional cache)**
+   - Local cached state/assets between sessions.
+   - Pros: faster reopen/resume, better UX for large projects.
+   - Cons: cache management/versioning complexity.
+
+Recommended default now: **ephemeral-first**, with optional IndexedDB cache as a future opt-in once invalidation/versioning policy is defined.
+
+### Hosted offline clarification
+
+"Hosted offline" means whether hosted users can continue editing when disconnected from the server (for example, laptop on field network outage), then sync/reconcile later.
+
+This is independent from where hosted runs (intranet, datacenter, cloud VM, local server).
+
+Recommendation:
+- Hosted MVP: **online-required** for commits and collaborative state.
+- Later phase: optional offline workspace queue/sync if field operations require it.
+
+### Security posture clarification
+
+"Encryption at rest" means stored data is encrypted on disk (database/files).
+"Customer-managed keys (CMK)" means the customer controls encryption keys instead of provider-managed defaults.
+
+Practical default posture:
+- Desktop: OS-level disk encryption support + optional app-level encrypted local secrets.
+- Hosted: enable encryption at rest for DB/storage by default; TLS in transit always.
+- CMK: treat as a future enterprise requirement unless municipal procurement mandates it immediately.
+
+### Desktop data and storage model (confirmed)
+
+- Desktop uses **one Postgres/PostGIS database per project**.
+- Importing a data source creates **one physical table per imported data source**, using a sanitized source-name-derived table name.
+- Multiple in-app layers that reference the same data source must share that single table (no duplicate table copies).
+- Geometry is stored in standard PostGIS geometry columns with SRID/CRS preserved where available.
+- Import pipeline eagerly creates indexes for query performance on large datasets: geometry index (where geometry exists) and PK index (where a primary key exists); no broad auto-indexing on other fields by default.
+- By default, imported source files are retained under `/data/raw`.
+- Derived outputs/caches/materializations are stored under `/data/derived`.
+- Desktop should allow immediate use of imported data without requiring a tile-bake step.
+
+### Desktop map access path (phase plan)
+
+- **Phase 1 desktop behavior:** direct DB-backed query windows + server-side pagination/chunking.
+- **Later desktop enhancement:** optional vector tile server/materialization for faster large-scale map rendering.
+- Users are not forced to pre-bake vector tiles before they can work with newly imported data.
+
+### Project lifecycle semantics (clarified)
+
+- **Delete project behavior:** deleting a project folder should also remove its bound project database to prevent orphaned local DBs and storage bloat (with soft confirmation only).
+- **Migration behavior:** when opening a project, the app compares the `viz-project.json` schema/app version to current version and runs lightweight **forward-only** migrations automatically (with backup-safe migration steps). If migration cannot complete safely, opening is blocked with a clear error.
+- **Backups:** manual export only in initial desktop milestone.
+
+### Desktop configuration and secrets posture (recommended default)
+
+For Desktop v1, prefer:
+- OS-native app config directory for non-secret config,
+- OS credential/key store for secrets (DB password, service tokens),
+- env-var overrides for development/ops only.
+
+Rationale: this is more secure than plaintext `.env` files while still preserving controlled override paths for troubleshooting and CI packaging.
+
+### Implementation guardrails
+
+- Prefer explicit **mode checks** (`mode === 'browser' | 'desktop' | 'hosted'`) over fine-grained capability flags to keep behavior easy to reason about.
+- UI should only render tools/actions that are available in current mode.
+- Data formats should preserve unknown/high-tier metadata whenever feasible to maximize cross-tier compatibility.
+- Audit logging is a first-class requirement for Hosted/Cloud write operations.
+
+
+
+### Desktop implementation plan (minimal, unambiguous)
+
+#### Milestone 0 — Mode/build scaffolding (no behavior change in browser)
+1. Add a single runtime mode constant with allowed values: `browser | desktop | hosted`.
+2. Keep browser as default mode.
+3. Add explicit mode-based build scripts:
+   - `build:browser`
+   - `build:desktop`
+   - `build:hosted` (placeholder for packaging parity; no hosted runtime work yet)
+4. Ensure all new gating uses explicit mode checks only.
+
+#### Milestone 1 — Electron desktop shell foundation (Windows first)
+1. Add desktop app shell with secure defaults:
+   - `contextIsolation: true`
+   - `nodeIntegration: false`
+   - strict IPC allowlist
+   - navigation/window-open restrictions
+2. Implement preload bridge with minimal APIs:
+   - project folder selection/creation
+   - safe read/write within project root
+   - app config read access (non-secret)
+3. Keep renderer logic shared with browser code path wherever possible.
+
+#### Milestone 2 — Project structure contract + lifecycle
+1. Standardize project folder structure:
+   - `/viz-project.json`
+   - `/data/raw`
+   - `/data/derived`
+   - `/assets`
+   - `/logs`
+2. `viz-project.json` must include:
+   - `projectId`, `name`, `createdAt`, `updatedAt`
+   - `schemaVersion`
+   - `dbBinding` (project DB identifier, no secrets)
+   - `sources[]` with logical source metadata
+3. On delete project:
+   - show soft confirmation
+   - delete project folder
+   - drop bound project DB
+4. On open project:
+   - run forward-only schema migrations by version
+   - block open with explicit error if migration fails safely
+
+#### Milestone 3 — Bundled Postgres/PostGIS (one DB per project)
+1. Windows installer provisions app-specific Postgres + PostGIS runtime.
+2. App creates one DB per project using naming pattern `viz_<projectId>`.
+3. Store secrets in OS credential store; non-secret config in OS app config dir.
+4. Support env overrides for dev/ops only.
+
+#### Milestone 4 — Import pipeline v1 (large-data ready baseline)
+1. On import, copy original input into `/data/raw` by default.
+2. Create one physical table per imported data source.
+3. Table names use sanitized source-name-derived identifiers.
+4. If multiple in-app layers reference same data source, they point to same table.
+5. Preserve geometry with SRID/CRS where available.
+6. Build indexes automatically:
+   - geometry index (if geometry exists)
+   - PK index (if PK exists)
+   - no auto-indexes on non-key attributes by default
+
+#### Milestone 5 — Data access path v1
+1. Desktop map/data reads use DB-backed query windows + server-side pagination/chunking.
+2. Imported data is usable immediately without vector tile bake.
+3. Add performance telemetry/logging around query latency and pagination behavior.
+
+#### Milestone 6 — Deferred (explicitly not in initial implementation)
+1. Hosted runtime implementation.
+2. RBAC implementation (hosted only).
+3. Vector tile server/materialization pipeline.
+4. Automatic backup rotation (manual export only in v1).
+5. macOS/Linux installer and packaging (after Windows stabilization).
+
+#### Exit criteria for initial Desktop launch track
+- Browser build behavior unchanged.
+- Desktop build launches and can create/open/delete projects.
+- Each project gets its own Postgres/PostGIS DB.
+- Imports populate DB tables (one per source) and retain raw source files.
+- Large datasets can be browsed via paginated DB reads without requiring tile bake.
+- Core security posture is in place (secure Electron + OS secret storage).

--- a/viz/README.md
+++ b/viz/README.md
@@ -1,0 +1,70 @@
+# VIZ local testing (build modes)
+
+VIZ supports three build/runtime modes:
+
+- `browser`
+- `desktop`
+- `hosted`
+
+Mode is selected via `VITE_VIZ_BUILD_MODE` through Vite mode env files:
+
+- `.env.browser`
+- `.env.desktop`
+- `.env.hosted`
+
+## Prerequisite
+
+Install VIZ dependencies once:
+
+```bash
+cd viz
+npm install
+```
+
+## Fast local app testing (VIZ only)
+
+From `viz/`:
+
+```bash
+# Browser mode (default behavior)
+npm run dev -- --mode browser
+
+# Desktop mode
+npm run dev -- --mode desktop
+
+# Hosted mode scaffold
+npm run dev -- --mode hosted
+```
+
+## Build outputs by mode (VIZ only)
+
+From `viz/`:
+
+```bash
+npm run build:browser
+npm run build:desktop
+npm run build:hosted
+```
+
+## Full-site local deploy testing (equivalent to current deploy-local flow)
+
+From repository root, use the deploy script with mode flag:
+
+```bash
+# Browser mode site deploy
+node deploy-local.js --viz-mode=browser
+
+# Desktop mode site deploy
+node deploy-local.js --viz-mode=desktop
+
+# Hosted mode site deploy (scaffold only for now)
+node deploy-local.js --viz-mode=hosted
+```
+
+This keeps the same simple deploy-local flow while allowing mode-specific VIZ builds.
+The local server starts at `http://localhost:3000`.
+
+## Notes
+
+- `desktop` and `hosted` are currently scaffolding at the VIZ build/runtime-mode layer.
+- Browser behavior remains the baseline.

--- a/viz/README.md
+++ b/viz/README.md
@@ -18,7 +18,7 @@ Install VIZ dependencies once:
 
 ```bash
 cd viz
-npm install
+npm install --include=dev
 ```
 
 ## Fast local app testing (VIZ only)
@@ -83,3 +83,28 @@ The local server starts at `http://localhost:3000`.
 
 - `desktop` includes an initial Electron shell run target (`npm run run:desktop`) for Milestone 1 testing; installer packaging is not included yet.
 - Browser behavior remains the baseline.
+
+
+### Troubleshooting (Windows)
+
+If you see:
+
+```
+'electron' is not recognized as an internal or external command
+```
+
+then local dev dependencies were not installed. Re-run:
+
+```bash
+cd viz
+npm install --include=dev
+```
+
+Then run again:
+
+```bash
+npm run run:desktop
+```
+
+`run:desktop` uses `npm exec electron ...` so it resolves the local Electron binary from `node_modules`.
+

--- a/viz/README.md
+++ b/viz/README.md
@@ -108,3 +108,21 @@ npm run run:desktop
 
 `run:desktop` uses `npm exec electron ...` so it resolves the local Electron binary from `node_modules`.
 
+
+If you see these errors in Electron:
+
+```
+index-*.css Failed to load resource: net::ERR_FILE_NOT_FOUND
+index-*.js Failed to load resource: net::ERR_FILE_NOT_FOUND
+```
+
+that usually means desktop assets were built with the wrong base path. Rebuild in desktop mode:
+
+```bash
+cd viz
+npm run build:desktop
+npm run run:desktop
+```
+
+Desktop mode now builds with relative asset URLs so `file://` loading works.
+

--- a/viz/README.md
+++ b/viz/README.md
@@ -46,6 +46,21 @@ npm run build:desktop
 npm run build:hosted
 ```
 
+## Run Desktop shell locally (Electron Milestone 1)
+
+From `viz/`:
+
+```bash
+npm run run:desktop
+```
+
+What this does:
+- builds VIZ in `desktop` mode
+- launches Electron with secure defaults (`contextIsolation`, `nodeIntegration=false`, sandboxed renderer)
+- exposes a minimal preload bridge as `window.vizDesktop` for project-folder/file operations
+
+This is a **run target** for local desktop testing (not installer packaging yet).
+
 ## Full-site local deploy testing (equivalent to current deploy-local flow)
 
 From repository root, use the deploy script with mode flag:
@@ -66,5 +81,5 @@ The local server starts at `http://localhost:3000`.
 
 ## Notes
 
-- `desktop` and `hosted` are currently scaffolding at the VIZ build/runtime-mode layer.
+- `desktop` includes an initial Electron shell run target (`npm run run:desktop`) for Milestone 1 testing; installer packaging is not included yet.
 - Browser behavior remains the baseline.

--- a/viz/electron/main.cjs
+++ b/viz/electron/main.cjs
@@ -1,0 +1,135 @@
+const path = require('path');
+const fs = require('fs/promises');
+const { app, BrowserWindow, ipcMain, dialog, shell } = require('electron');
+
+const isMac = process.platform === 'darwin';
+let mainWindow = null;
+let currentProjectRoot = null;
+
+function resolveRendererEntry() {
+  return path.join(__dirname, '..', 'dist', 'index.html');
+}
+
+function isPathInsideProjectRoot(candidatePath) {
+  if (!currentProjectRoot) return false;
+  const root = path.resolve(currentProjectRoot);
+  const candidate = path.resolve(candidatePath);
+  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+function assertProjectBoundPath(candidatePath) {
+  if (!currentProjectRoot) {
+    throw new Error('No active project root selected.');
+  }
+  if (!isPathInsideProjectRoot(candidatePath)) {
+    throw new Error('Path is outside active project root.');
+  }
+}
+
+async function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1500,
+    height: 900,
+    minWidth: 1100,
+    minHeight: 700,
+    show: false,
+    autoHideMenuBar: true,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      preload: path.join(__dirname, 'preload.cjs')
+    }
+  });
+
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('https://') || url.startsWith('http://')) {
+      void shell.openExternal(url);
+    }
+    return { action: 'deny' };
+  });
+
+  mainWindow.webContents.on('will-navigate', (event, navigationUrl) => {
+    const allowedPrefix = 'file://';
+    if (!navigationUrl.startsWith(allowedPrefix)) {
+      event.preventDefault();
+    }
+  });
+
+  mainWindow.once('ready-to-show', () => {
+    mainWindow?.show();
+  });
+
+  await mainWindow.loadFile(resolveRendererEntry());
+}
+
+ipcMain.handle('desktop:selectProjectFolder', async () => {
+  if (!mainWindow) throw new Error('Main window unavailable.');
+  const result = await dialog.showOpenDialog(mainWindow, {
+    title: 'Select VIZ Project Folder',
+    properties: ['openDirectory', 'createDirectory']
+  });
+
+  if (result.canceled || !result.filePaths[0]) {
+    return { canceled: true };
+  }
+
+  currentProjectRoot = path.resolve(result.filePaths[0]);
+  return { canceled: false, projectRoot: currentProjectRoot };
+});
+
+ipcMain.handle('desktop:createProjectFolder', async (_evt, parentDir, projectFolderName) => {
+  if (!parentDir || !projectFolderName) {
+    throw new Error('parentDir and projectFolderName are required.');
+  }
+
+  const folderName = String(projectFolderName).trim();
+  if (!folderName) {
+    throw new Error('projectFolderName cannot be empty.');
+  }
+
+  const target = path.resolve(parentDir, folderName);
+  await fs.mkdir(target, { recursive: true });
+  currentProjectRoot = target;
+  return { projectRoot: currentProjectRoot };
+});
+
+ipcMain.handle('desktop:readTextFile', async (_evt, relativePath) => {
+  if (!relativePath) throw new Error('relativePath is required.');
+  const target = path.resolve(currentProjectRoot ?? '', String(relativePath));
+  assertProjectBoundPath(target);
+  const content = await fs.readFile(target, 'utf-8');
+  return { content };
+});
+
+ipcMain.handle('desktop:writeTextFile', async (_evt, relativePath, content) => {
+  if (!relativePath) throw new Error('relativePath is required.');
+  const target = path.resolve(currentProjectRoot ?? '', String(relativePath));
+  assertProjectBoundPath(target);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.writeFile(target, String(content ?? ''), 'utf-8');
+  return { ok: true };
+});
+
+ipcMain.handle('desktop:getAppConfig', async () => {
+  return {
+    mode: 'desktop',
+    platform: process.platform,
+    userDataDir: app.getPath('userData'),
+    projectRoot: currentProjectRoot
+  };
+});
+
+app.whenReady().then(async () => {
+  await createWindow();
+
+  app.on('activate', async () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      await createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (!isMac) app.quit();
+});

--- a/viz/electron/preload.cjs
+++ b/viz/electron/preload.cjs
@@ -1,0 +1,11 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+const desktopApi = {
+  selectProjectFolder: () => ipcRenderer.invoke('desktop:selectProjectFolder'),
+  createProjectFolder: (parentDir, projectFolderName) => ipcRenderer.invoke('desktop:createProjectFolder', parentDir, projectFolderName),
+  readTextFile: (relativePath) => ipcRenderer.invoke('desktop:readTextFile', relativePath),
+  writeTextFile: (relativePath, content) => ipcRenderer.invoke('desktop:writeTextFile', relativePath, content),
+  getAppConfig: () => ipcRenderer.invoke('desktop:getAppConfig')
+};
+
+contextBridge.exposeInMainWorld('vizDesktop', desktopApi);

--- a/viz/package.json
+++ b/viz/package.json
@@ -18,6 +18,6 @@
     "build:browser": "vite build --mode browser",
     "build:desktop": "vite build --mode desktop",
     "build:hosted": "vite build --mode hosted",
-    "run:desktop": "npm run build:desktop && electron ./electron/main.cjs"
+    "run:desktop": "npm run build:desktop && npm exec electron ./electron/main.cjs"
   }
 }

--- a/viz/package.json
+++ b/viz/package.json
@@ -8,7 +8,8 @@
   },
   "devDependencies": {
     "typescript": "^5.9.2",
-    "vite": "^7.1.3"
+    "vite": "^7.1.3",
+    "electron": "^33.2.1"
   },
   "scripts": {
     "dev": "vite",
@@ -16,6 +17,7 @@
     "preview": "vite preview --host --port 4173",
     "build:browser": "vite build --mode browser",
     "build:desktop": "vite build --mode desktop",
-    "build:hosted": "vite build --mode hosted"
+    "build:hosted": "vite build --mode hosted",
+    "run:desktop": "npm run build:desktop && electron ./electron/main.cjs"
   }
 }

--- a/viz/package.json
+++ b/viz/package.json
@@ -13,6 +13,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --host --port 4173"
+    "preview": "vite preview --host --port 4173",
+    "build:browser": "vite build --mode browser",
+    "build:desktop": "vite build --mode desktop",
+    "build:hosted": "vite build --mode hosted"
   }
 }

--- a/viz/src/desktop-api.d.ts
+++ b/viz/src/desktop-api.d.ts
@@ -1,0 +1,18 @@
+export {};
+
+declare global {
+  interface Window {
+    vizDesktop?: {
+      selectProjectFolder: () => Promise<{ canceled: boolean; projectRoot?: string }>;
+      createProjectFolder: (parentDir: string, projectFolderName: string) => Promise<{ projectRoot: string }>;
+      readTextFile: (relativePath: string) => Promise<{ content: string }>;
+      writeTextFile: (relativePath: string, content: string) => Promise<{ ok: boolean }>;
+      getAppConfig: () => Promise<{
+        mode: 'desktop';
+        platform: string;
+        userDataDir: string;
+        projectRoot: string | null;
+      }>;
+    };
+  }
+}

--- a/viz/src/main.ts
+++ b/viz/src/main.ts
@@ -142,7 +142,23 @@ import {
   createDataStore, renderDataStoreList,
 } from './layers';
 import { initMetadataModule } from './metadata.js';
+import { getRuntimeMode, isBrowserMode, isDesktopMode, isHostedMode } from './runtime-mode';
 (window as any).savedFiltersStore = S.savedFiltersStore;
+
+/* ---------------- Runtime Mode ----------------- */
+
+const runtimeMode = getRuntimeMode();
+console.info(`[viz] runtime mode: ${runtimeMode}`);
+if (isBrowserMode()) {
+  console.info('[viz] browser mode features enabled');
+} else if (isDesktopMode()) {
+  console.info('[viz] desktop mode features enabled');
+} else if (isHostedMode()) {
+  console.info('[viz] hosted mode features enabled');
+}
+if (typeof document !== 'undefined') {
+  document.documentElement.setAttribute('data-viz-runtime-mode', runtimeMode);
+}
 
 /* ---------------- Map Bootstrap ----------------- */
 

--- a/viz/src/runtime-mode.ts
+++ b/viz/src/runtime-mode.ts
@@ -1,0 +1,28 @@
+export type RuntimeMode = 'browser' | 'desktop' | 'hosted';
+
+const FALLBACK_MODE: RuntimeMode = 'browser';
+const ALLOWED_MODES = new Set<RuntimeMode>(['browser', 'desktop', 'hosted']);
+
+function readBuildMode(): string | undefined {
+  return (import.meta.env.VITE_VIZ_BUILD_MODE as string | undefined)?.trim().toLowerCase();
+}
+
+export function getRuntimeMode(): RuntimeMode {
+  const mode = readBuildMode();
+  if (!mode) return FALLBACK_MODE;
+  if (ALLOWED_MODES.has(mode as RuntimeMode)) return mode as RuntimeMode;
+  console.warn(`[runtime-mode] Invalid VITE_VIZ_BUILD_MODE="${mode}". Falling back to "${FALLBACK_MODE}".`);
+  return FALLBACK_MODE;
+}
+
+export function isBrowserMode(): boolean {
+  return getRuntimeMode() === 'browser';
+}
+
+export function isDesktopMode(): boolean {
+  return getRuntimeMode() === 'desktop';
+}
+
+export function isHostedMode(): boolean {
+  return getRuntimeMode() === 'hosted';
+}

--- a/viz/src/vite-env.d.ts
+++ b/viz/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_VIZ_BUILD_MODE?: 'browser' | 'desktop' | 'hosted';
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/viz/vite.config.ts
+++ b/viz/vite.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig } from 'vite';
 
-export default defineConfig({
-	base: '/viz/'
+export default defineConfig(({ mode }) => {
+	const isDesktopMode = mode === 'desktop';
+	return {
+		// Browser/hosted deploys are served under /viz/ on GitHub Pages.
+		// Desktop Electron file:// loads must use relative asset URLs.
+		base: isDesktopMode ? './' : '/viz/'
+	};
 });


### PR DESCRIPTION
### Motivation

- Provide an easy, deploy-local-friendly way to test the VIZ app in the three runtime/build modes (`browser`, `desktop`, `hosted`) and keep the workflow as simple as the current `deploy-local` flow. 
- Make mode-specific VIZ builds deterministic and explicit while preserving existing default behavior.

### Description

- Added `viz/README.md` with concise instructions for `dev` and `build` commands per-mode and examples for full-site local testing using the deploy script. 
- Updated `deploy-local.js` to accept `--viz-mode=<browser|desktop|hosted>`, default to `browser` when omitted, and invoke the matching npm build script (`build:browser`, `build:desktop`, `build:hosted`).
- Added input validation to `deploy-local.js` that errors and exits for invalid `--viz-mode` values so local testing fails fast and predictably.
- Kept existing behavior unchanged when no mode flag is provided to maintain backward compatibility.

### Testing

- Performed a syntax/load check with `node -c deploy-local.js`, which succeeded. 
- Verified invalid-mode validation by running `node deploy-local.js --viz-mode=invalid` and observing a non-zero exit and the expected error message. 
- Confirmed the files were staged and committed successfully (local commit recorded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999331a526c832699a9dad002136596)