### PR TITLE
Add Construct inspect logging and prevent large-profile stack overflow

### DIFF
--- a/util/src/apps/constructApp.js
+++ b/util/src/apps/constructApp.js
@@ -62,6 +62,7 @@ export default function startConstructApp() {
   const cancelLoad = (side) => {
     const active = state.loading[side];
     if (active?.worker) {
+      if (active.progressTicker) clearInterval(active.progressTicker);
       active.worker.terminate();
       state.loading[side] = null;
       byId(`${side}Status`).textContent = 'Load canceled.';
@@ -79,9 +80,33 @@ export default function startConstructApp() {
     const worker = new Worker(new URL('./constructWorker.js', import.meta.url));
     state.loading[side] = { worker };
     const csvOptions = side === 'left' ? state.leftCsvOptions : state.rightCsvOptions;
+    const clearProgressTicker = () => {
+      const active = state.loading[side];
+      if (active?.progressTicker) {
+        clearInterval(active.progressTicker);
+        active.progressTicker = null;
+      }
+    };
+
+    const startProgressTicker = (phase, detail = '') => {
+      clearProgressTicker();
+      if (phase !== 'gdal-convert') return;
+      const active = state.loading[side];
+      if (!active || active.worker !== worker) return;
+      const baseDetail = detail.replace(/\s*\(\d+s\)\s*$/, '').trim() || 'Converting to GeoJSON';
+      const startedAt = Date.now();
+      active.progressTicker = setInterval(() => {
+        if (state.loading[side]?.worker !== worker) return;
+        const secs = Math.max(0, Math.floor((Date.now() - startedAt) / 1000));
+        const current = statusEl.innerHTML;
+        statusEl.innerHTML = current.replace(/\s*\(\d+s\)(?=<)/, ` (${secs}s)`).replace(/Converting to GeoJSON(?:\s*\(\d+s\))?/, `${baseDetail} (${secs}s)`);
+      }, 1000);
+    };
+
     const setLoadProgress = (payload = {}) => {
       const percent = Number.isFinite(payload.percent) ? Math.max(0, Math.min(100, Math.round(payload.percent))) : null;
       const detail = payload.detail ? ` ${payload.detail}` : '';
+      startProgressTicker(payload.phase, payload.detail || '');
       if (percent === null) {
         statusEl.innerHTML = `<span class="spinner">⟳</span> Loading...${detail}`;
         return;
@@ -101,12 +126,14 @@ export default function startConstructApp() {
         if (state.loading[side]?.worker !== worker) return;
         worker.terminate();
         state.loading[side] = null;
+        clearProgressTicker();
         cancelBtn.classList.add('hidden');
         statusEl.textContent = p.message;
       }
       if (type === 'success') {
         if (state.loading[side]?.worker !== worker) return;
         worker.terminate();
+        clearProgressTicker();
         state.loading[side] = null;
         cancelBtn.classList.add('hidden');
         const info = p;
@@ -122,6 +149,7 @@ export default function startConstructApp() {
     worker.onerror = (e) => {
       if (state.loading[side]?.worker !== worker) return;
       worker.terminate();
+      clearProgressTicker();
       state.loading[side] = null;
       cancelBtn.classList.add('hidden');
       statusEl.textContent = e.message || 'Worker failure';

--- a/util/src/apps/constructApp.js
+++ b/util/src/apps/constructApp.js
@@ -79,9 +79,24 @@ export default function startConstructApp() {
     const worker = new Worker(new URL('./constructWorker.js', import.meta.url));
     state.loading[side] = { worker };
     const csvOptions = side === 'left' ? state.leftCsvOptions : state.rightCsvOptions;
+    const setLoadProgress = (payload = {}) => {
+      const percent = Number.isFinite(payload.percent) ? Math.max(0, Math.min(100, Math.round(payload.percent))) : null;
+      const detail = payload.detail ? ` ${payload.detail}` : '';
+      if (percent === null) {
+        statusEl.innerHTML = `<span class="spinner">⟳</span> Loading...${detail}`;
+        return;
+      }
+      statusEl.innerHTML = `<span class="spinner">⟳</span> Loading ${percent}%${detail}<div style="margin-top:.35rem;width:220px;max-width:100%;height:6px;background:#e5e9f2;border-radius:999px;overflow:hidden"><div style="height:100%;width:${percent}%;background:var(--accent)"></div></div>`;
+    };
+
     worker.onmessage = (e) => {
       const { type, payload:p } = e.data || {};
       if (type === 'log') log(p.message);
+      if (type === 'progress') {
+        if (state.loading[side]?.worker !== worker) return;
+        if (p.side && p.side !== side) return;
+        setLoadProgress(p);
+      }
       if (type === 'error') {
         if (state.loading[side]?.worker !== worker) return;
         worker.terminate();

--- a/util/src/apps/constructWorker.js
+++ b/util/src/apps/constructWorker.js
@@ -6,7 +6,7 @@ const gdalPromise = self.initGdalJs({ path: GDAL_BASE, useWorker: false });
 const textDecoder = new TextDecoder('utf-8');
 const send = (type, payload) => self.postMessage({ type, payload });
 const debug = (message) => send('log', { message: `[Construct inspect] ${message}` });
-const clampPercent = (value) => Math.max(0, Math.min(100, Math.round(value)));
+const clampPercent = (value) => Math.max(0, Math.min(99, Math.round(value)));
 const sendProgress = (side, phase, percent, detail = '') => send('progress', { side, phase, percent: clampPercent(percent), detail });
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const withProgressPulse = async ({ side, phase, startPercent, endPercent, detail, estimatedMs = 30000, tickMs = 700 }, work) => {
@@ -29,7 +29,7 @@ const withProgressPulse = async ({ side, phase, startPercent, endPercent, detail
     const result = await work();
     finished = true;
     await ticker;
-    sendProgress(side, phase, endPercent, `${detail} complete`);
+    sendProgress(side, phase, Math.min(endPercent, 99), `${detail} complete`);
     return result;
   } catch (err) {
     finished = true;
@@ -349,7 +349,7 @@ const loadAsFeatures = async (file, side, csvOptions = {}) => {
     debug(`CSV parsed for ${side}: rows=${records.length}, fields=${fields.length}, delimiter=${csv.delimiter}`);
     sendProgress(side, 'csv-profile', 70, 'Profiling columns');
     const info = { label:'CSV (.csv)', hasGeometry:false, rowCount:records.length, fields, records, csv, columnProfiles: buildColumnProfilesSafe(records, fields, `${side}/csv`) };
-    sendProgress(side, 'done', 100, 'Load complete');
+    sendProgress(side, 'done', 99, 'Load complete');
     return info;
   }
   sendProgress(side, 'read-buffer', 10, 'Reading file bytes');
@@ -363,7 +363,7 @@ const loadAsFeatures = async (file, side, csvOptions = {}) => {
     sendProgress(side, 'profile', 92, 'Finalizing GeoParquet profile');
     debug(`GeoParquet load summary for ${side}: rows=${info.rowCount}, fields=${info.fields.length}, geomTypes=${(info.geometryTypes || []).join(', ') || 'none'}`);
     enforceSideGeometryRules(side, info);
-    sendProgress(side, 'done', 100, 'Load complete');
+    sendProgress(side, 'done', 99, 'Load complete');
     return info;
   }
   let geojson;
@@ -403,7 +403,7 @@ const loadAsFeatures = async (file, side, csvOptions = {}) => {
   sendProgress(side, 'profile', 82, 'Profiling columns');
   const info = { label:isZip?'ESRI Shapefile (.shp.zip)':isGeoJson?'GeoJSON (.geojson)':isGpkg?'GeoPackage (.gpkg)':'Dataset', hasGeometry:features.some((f)=>Boolean(f.geometry)), rowCount:records.length, fields, records, geometryTypes:Array.from(new Set(features.map((f)=>f.geometry?.type).filter(Boolean))), columnProfiles: buildColumnProfilesSafe(records, fields, `${side}/${isGpkg ? 'gpkg' : isZip ? 'shpzip' : isGeoJson ? 'geojson' : 'dataset'}`) };
   enforceSideGeometryRules(side, info);
-  sendProgress(side, 'done', 100, 'Load complete');
+  sendProgress(side, 'done', 99, 'Load complete');
   return info;
 };
 

--- a/util/src/apps/constructWorker.js
+++ b/util/src/apps/constructWorker.js
@@ -6,6 +6,8 @@ const gdalPromise = self.initGdalJs({ path: GDAL_BASE, useWorker: false });
 const textDecoder = new TextDecoder('utf-8');
 const send = (type, payload) => self.postMessage({ type, payload });
 const debug = (message) => send('log', { message: `[Construct inspect] ${message}` });
+const clampPercent = (value) => Math.max(0, Math.min(100, Math.round(value)));
+const sendProgress = (side, phase, percent, detail = '') => send('progress', { side, phase, percent: clampPercent(percent), detail });
 const slugify = (value) => String(value).normalize('NFKD').replace(/[^\w\s-]/g, '').trim().replace(/[\s_-]+/g, '-').replace(/^-+|-+$/g, '').toLowerCase();
 let parquetModulePromise = null;
 let parquetInitialized = false;
@@ -186,13 +188,15 @@ const decodeWkbGeometry = (wkb) => {
   return parseWkbGeometry(view, 0).geometry;
 };
 
-const loadGeoParquetRows = async (buffer, file) => {
+const loadGeoParquetRows = async (buffer, file, side) => {
   debug(`GeoParquet: initializing parser for ${file.name || 'unknown'}`);
+  sendProgress(side, 'parquet-init', 20, 'Initializing GeoParquet parser');
   const parquetModule = await ensureParquetModule();
   const Arrow = self.Arrow;
   if (!Arrow) throw new Error('Arrow library failed to load.');
 
   const parquetFile = await parquetModule.ParquetFile.fromFile(file);
+  sendProgress(side, 'parquet-metadata', 30, 'Reading GeoParquet metadata');
   const metadata = parquetFile.metadata();
   const fileMetadata = metadata.fileMetadata();
   const geoMetadata = parseGeoMetadata(fileMetadata.keyValueMetadata());
@@ -207,6 +211,7 @@ const loadGeoParquetRows = async (buffer, file) => {
   const wasmTable = parquetModule.readParquet(new Uint8Array(buffer));
   const ipc = wasmTable.intoIPCStream();
   const table = Arrow.tableFromIPC(ipc);
+  sendProgress(side, 'parquet-table', 45, 'Reading table rows');
   const geometryVector = table.getChild(geometryColumn);
   if (!geometryVector) throw new Error(`GeoParquet geometry column "${geometryColumn}" was not found.`);
 
@@ -215,6 +220,7 @@ const loadGeoParquetRows = async (buffer, file) => {
   debug(`GeoParquet table ready: rows=${table.numRows}, nonGeometryFields=${fields.length}`);
   const records = [];
   const geometryTypes = new Set();
+  const progressEvery = Math.max(1, Math.floor(table.numRows / 40));
 
   for (let i = 0; i < table.numRows; i += 1) {
     const geometry = decodeWkbGeometry(geometryVector.get(i));
@@ -225,6 +231,10 @@ const loadGeoParquetRows = async (buffer, file) => {
       row[name] = vector ? vector.get(i) : null;
     });
     records.push(row);
+    if ((i + 1) % progressEvery === 0 || i + 1 === table.numRows) {
+      const pct = 45 + (((i + 1) / Math.max(table.numRows, 1)) * 45);
+      sendProgress(side, 'parquet-rows', pct, `Decoded ${(i + 1).toLocaleString()} / ${table.numRows.toLocaleString()} rows`);
+    }
   }
   debug(`GeoParquet row extraction complete: rows=${records.length}, geometryTypes=${Array.from(geometryTypes).join(', ') || 'none'}`);
 
@@ -301,35 +311,51 @@ const buildColumnProfilesSafe = (rows, fields, label) => {
 const loadAsFeatures = async (file, side, csvOptions = {}) => {
   const name = file.name?.toLowerCase() || '';
   debug(`loadAsFeatures(side=${side}) file=${file.name || 'unknown'} sizeBytes=${file.size || 0}`);
+  sendProgress(side, 'start', 2, 'Preparing file');
   if (name.endsWith('.csv')) {
+    sendProgress(side, 'csv-read', 20, 'Reading CSV text');
     const csv = parseCsvContent(await file.text(), csvOptions);
     const records = csv.rows;
     const fields = csv.header;
     debug(`CSV parsed for ${side}: rows=${records.length}, fields=${fields.length}, delimiter=${csv.delimiter}`);
-    return { label:'CSV (.csv)', hasGeometry:false, rowCount:records.length, fields, records, csv, columnProfiles: buildColumnProfilesSafe(records, fields, `${side}/csv`) };
+    sendProgress(side, 'csv-profile', 70, 'Profiling columns');
+    const info = { label:'CSV (.csv)', hasGeometry:false, rowCount:records.length, fields, records, csv, columnProfiles: buildColumnProfilesSafe(records, fields, `${side}/csv`) };
+    sendProgress(side, 'done', 100, 'Load complete');
+    return info;
   }
+  sendProgress(side, 'read-buffer', 10, 'Reading file bytes');
   const buffer = await file.arrayBuffer();
   debug(`Loaded ArrayBuffer for ${side}: bytes=${buffer.byteLength}`);
   const isZip = name.endsWith('.zip'); const isGeoJson = name.endsWith('.geojson') || name.endsWith('.json') || name.endsWith('.geo.json'); const isGpkg = name.endsWith('.gpkg'); const isParquet = name.endsWith('.parquet') || name.endsWith('.geoparquet');
   if (isParquet) {
     debug(`Detected GeoParquet extension for ${side}.`);
-    const info = await loadGeoParquetRows(buffer, file);
+    sendProgress(side, 'parquet', 15, 'Detected GeoParquet');
+    const info = await loadGeoParquetRows(buffer, file, side);
+    sendProgress(side, 'profile', 92, 'Finalizing GeoParquet profile');
     debug(`GeoParquet load summary for ${side}: rows=${info.rowCount}, fields=${info.fields.length}, geomTypes=${(info.geometryTypes || []).join(', ') || 'none'}`);
     enforceSideGeometryRules(side, info);
+    sendProgress(side, 'done', 100, 'Load complete');
     return info;
   }
   let geojson;
-  if (isGeoJson) geojson = JSON.parse(textDecoder.decode(new Uint8Array(buffer))); else {
+  if (isGeoJson) {
+    sendProgress(side, 'geojson-parse', 45, 'Parsing GeoJSON');
+    geojson = JSON.parse(textDecoder.decode(new Uint8Array(buffer)));
+  } else {
+    sendProgress(side, 'gdal-open', 35, 'Opening dataset');
     const gdal = await gdalPromise; let input = file;
     if (isZip) { const entries = readZipEntries(buffer); if (!entries) throw new Error('Not a supported format. This zip archive could not be read as a shapefile bundle.'); ensureShapefileParts(entries); input = toFilesFromZipEntries(entries); }
+    sendProgress(side, 'gdal-convert', 55, 'Converting to GeoJSON');
     const { datasets, errors } = await gdal.open(input); if (!datasets?.length) throw new Error(errors?.[0] || 'Unable to open dataset'); const out = await gdal.ogr2ogr(datasets[0], ['-f','GeoJSON']); geojson = JSON.parse(textDecoder.decode(await gdal.getFileBytes(out)));
   }
   const features = geojson.features || [];
   const records = features.map((f,i)=>({ ...f.properties, __row:i, __geometry:f.geometry || null }));
   const fields = Array.from(new Set(records.flatMap((r)=>Object.keys(r).filter((k)=>!k.startsWith('__')))));
   debug(`Vector load summary for ${side}: features=${features.length}, records=${records.length}, fields=${fields.length}`);
+  sendProgress(side, 'profile', 75, 'Profiling columns');
   const info = { label:isZip?'ESRI Shapefile (.shp.zip)':isGeoJson?'GeoJSON (.geojson)':isGpkg?'GeoPackage (.gpkg)':'Dataset', hasGeometry:features.some((f)=>Boolean(f.geometry)), rowCount:records.length, fields, records, geometryTypes:Array.from(new Set(features.map((f)=>f.geometry?.type).filter(Boolean))), columnProfiles: buildColumnProfilesSafe(records, fields, `${side}/${isGpkg ? 'gpkg' : isZip ? 'shpzip' : isGeoJson ? 'geojson' : 'dataset'}`) };
   enforceSideGeometryRules(side, info);
+  sendProgress(side, 'done', 100, 'Load complete');
   return info;
 };
 

--- a/util/src/apps/constructWorker.js
+++ b/util/src/apps/constructWorker.js
@@ -5,6 +5,7 @@ const GDAL_BASE = new URL('../../vendor/gdal/', self.location).toString();
 const gdalPromise = self.initGdalJs({ path: GDAL_BASE, useWorker: false });
 const textDecoder = new TextDecoder('utf-8');
 const send = (type, payload) => self.postMessage({ type, payload });
+const debug = (message) => send('log', { message: `[Construct inspect] ${message}` });
 const slugify = (value) => String(value).normalize('NFKD').replace(/[^\w\s-]/g, '').trim().replace(/[\s_-]+/g, '-').replace(/^-+|-+$/g, '').toLowerCase();
 let parquetModulePromise = null;
 let parquetInitialized = false;
@@ -186,6 +187,7 @@ const decodeWkbGeometry = (wkb) => {
 };
 
 const loadGeoParquetRows = async (buffer, file) => {
+  debug(`GeoParquet: initializing parser for ${file.name || 'unknown'}`);
   const parquetModule = await ensureParquetModule();
   const Arrow = self.Arrow;
   if (!Arrow) throw new Error('Arrow library failed to load.');
@@ -197,6 +199,7 @@ const loadGeoParquetRows = async (buffer, file) => {
   if (!geoMetadata) throw new Error('This parquet file does not include GeoParquet metadata.');
   const geometryColumn = geoMetadata?.primary_column || 'geometry';
   const geometryEncoding = geoMetadata?.columns?.[geometryColumn]?.encoding;
+  debug(`GeoParquet metadata: primaryGeometry=${geometryColumn}, encoding=${geometryEncoding || 'unknown'}`);
   if (typeof geometryEncoding === 'string' && geometryEncoding.toUpperCase() !== 'WKB') {
     throw new Error(`GeoParquet geometry encoding "${geometryEncoding}" is not supported.`);
   }
@@ -209,6 +212,7 @@ const loadGeoParquetRows = async (buffer, file) => {
 
   const fields = table.schema.fields.map((field) => field.name).filter((name) => name !== geometryColumn);
   const fieldVectors = fields.map((name) => table.getChild(name));
+  debug(`GeoParquet table ready: rows=${table.numRows}, nonGeometryFields=${fields.length}`);
   const records = [];
   const geometryTypes = new Set();
 
@@ -222,6 +226,7 @@ const loadGeoParquetRows = async (buffer, file) => {
     });
     records.push(row);
   }
+  debug(`GeoParquet row extraction complete: rows=${records.length}, geometryTypes=${Array.from(geometryTypes).join(', ') || 'none'}`);
 
   return {
     label: 'GeoParquet (.parquet/.geoparquet)',
@@ -230,7 +235,7 @@ const loadGeoParquetRows = async (buffer, file) => {
     fields,
     records,
     geometryTypes: Array.from(geometryTypes),
-    columnProfiles: buildColumnProfiles(records, fields)
+    columnProfiles: buildColumnProfilesSafe(records, fields, 'geoparquet')
   };
 };
 
@@ -262,25 +267,54 @@ const buildColumnProfiles = (rows, fields) => fields.map((name) => {
   const inferredType = types.size === 0 ? 'string' : (types.has('string') ? 'string' : (types.has('datetime') ? 'datetime' : (types.has('date') ? 'date' : (types.has('float') ? 'float' : (types.has('integer') ? 'integer' : 'boolean')))));
   let min = null; let max = null;
   if (['integer','float','date','datetime'].includes(inferredType) && vals.length) {
-    const mapped = vals.map((v)=> inferredType === 'integer' || inferredType === 'float' ? Number(v) : Date.parse(v)).filter((v)=>Number.isFinite(v));
-    if (mapped.length) { min = Math.min(...mapped); max = Math.max(...mapped); }
+    let foundFinite = false;
+    for (let i = 0; i < vals.length; i += 1) {
+      const mapped = inferredType === 'integer' || inferredType === 'float' ? Number(vals[i]) : Date.parse(vals[i]);
+      if (!Number.isFinite(mapped)) continue;
+      if (!foundFinite) {
+        min = mapped;
+        max = mapped;
+        foundFinite = true;
+      } else {
+        if (mapped < min) min = mapped;
+        if (mapped > max) max = mapped;
+      }
+    }
   }
   const uniqueCount = new Set(vals.map((v)=>String(v))).size;
   return { name, inferredType, mixed, nonNullCount, totalCount, uniqueCount, min, max, sampleValues: vals.slice(0,5) };
 });
 
+const buildColumnProfilesSafe = (rows, fields, label) => {
+  const startedAt = Date.now();
+  debug(`Building column profiles for ${label}: rows=${rows.length}, fields=${fields.length}`);
+  try {
+    const profiles = buildColumnProfiles(rows, fields);
+    debug(`Finished column profiles for ${label} in ${Date.now() - startedAt}ms`);
+    return profiles;
+  } catch (err) {
+    debug(`Column profile failure for ${label}: ${err?.message || String(err)}`);
+    throw err;
+  }
+};
+
 const loadAsFeatures = async (file, side, csvOptions = {}) => {
   const name = file.name?.toLowerCase() || '';
+  debug(`loadAsFeatures(side=${side}) file=${file.name || 'unknown'} sizeBytes=${file.size || 0}`);
   if (name.endsWith('.csv')) {
     const csv = parseCsvContent(await file.text(), csvOptions);
     const records = csv.rows;
     const fields = csv.header;
-    return { label:'CSV (.csv)', hasGeometry:false, rowCount:records.length, fields, records, csv, columnProfiles: buildColumnProfiles(records, fields) };
+    debug(`CSV parsed for ${side}: rows=${records.length}, fields=${fields.length}, delimiter=${csv.delimiter}`);
+    return { label:'CSV (.csv)', hasGeometry:false, rowCount:records.length, fields, records, csv, columnProfiles: buildColumnProfilesSafe(records, fields, `${side}/csv`) };
   }
   const buffer = await file.arrayBuffer();
+  debug(`Loaded ArrayBuffer for ${side}: bytes=${buffer.byteLength}`);
   const isZip = name.endsWith('.zip'); const isGeoJson = name.endsWith('.geojson') || name.endsWith('.json') || name.endsWith('.geo.json'); const isGpkg = name.endsWith('.gpkg'); const isParquet = name.endsWith('.parquet') || name.endsWith('.geoparquet');
   if (isParquet) {
+    debug(`Detected GeoParquet extension for ${side}.`);
     const info = await loadGeoParquetRows(buffer, file);
+    debug(`GeoParquet load summary for ${side}: rows=${info.rowCount}, fields=${info.fields.length}, geomTypes=${(info.geometryTypes || []).join(', ') || 'none'}`);
     enforceSideGeometryRules(side, info);
     return info;
   }
@@ -293,7 +327,8 @@ const loadAsFeatures = async (file, side, csvOptions = {}) => {
   const features = geojson.features || [];
   const records = features.map((f,i)=>({ ...f.properties, __row:i, __geometry:f.geometry || null }));
   const fields = Array.from(new Set(records.flatMap((r)=>Object.keys(r).filter((k)=>!k.startsWith('__')))));
-  const info = { label:isZip?'ESRI Shapefile (.shp.zip)':isGeoJson?'GeoJSON (.geojson)':isGpkg?'GeoPackage (.gpkg)':'Dataset', hasGeometry:features.some((f)=>Boolean(f.geometry)), rowCount:records.length, fields, records, geometryTypes:Array.from(new Set(features.map((f)=>f.geometry?.type).filter(Boolean))), columnProfiles: buildColumnProfiles(records, fields) };
+  debug(`Vector load summary for ${side}: features=${features.length}, records=${records.length}, fields=${fields.length}`);
+  const info = { label:isZip?'ESRI Shapefile (.shp.zip)':isGeoJson?'GeoJSON (.geojson)':isGpkg?'GeoPackage (.gpkg)':'Dataset', hasGeometry:features.some((f)=>Boolean(f.geometry)), rowCount:records.length, fields, records, geometryTypes:Array.from(new Set(features.map((f)=>f.geometry?.type).filter(Boolean))), columnProfiles: buildColumnProfilesSafe(records, fields, `${side}/${isGpkg ? 'gpkg' : isZip ? 'shpzip' : isGeoJson ? 'geojson' : 'dataset'}`) };
   enforceSideGeometryRules(side, info);
   return info;
 };

--- a/util/src/apps/constructWorker.js
+++ b/util/src/apps/constructWorker.js
@@ -218,6 +218,7 @@ const decodeWkbGeometry = (wkb) => {
 };
 
 const loadGeoParquetRows = async (buffer, file, side) => {
+  const keepGeometry = side === 'left';
   debug(`GeoParquet: initializing parser for ${file.name || 'unknown'}`);
   sendProgress(side, 'parquet-init', 20, 'Initializing GeoParquet parser');
   const parquetModule = await ensureParquetModule();
@@ -232,6 +233,7 @@ const loadGeoParquetRows = async (buffer, file, side) => {
   if (!geoMetadata) throw new Error('This parquet file does not include GeoParquet metadata.');
   const geometryColumn = geoMetadata?.primary_column || 'geometry';
   const geometryEncoding = geoMetadata?.columns?.[geometryColumn]?.encoding;
+  const metadataGeometryTypes = geoMetadata?.columns?.[geometryColumn]?.geometry_types;
   debug(`GeoParquet metadata: primaryGeometry=${geometryColumn}, encoding=${geometryEncoding || 'unknown'}`);
   if (typeof geometryEncoding === 'string' && geometryEncoding.toUpperCase() !== 'WKB') {
     throw new Error(`GeoParquet geometry encoding "${geometryEncoding}" is not supported.`);
@@ -248,13 +250,17 @@ const loadGeoParquetRows = async (buffer, file, side) => {
   const fieldVectors = fields.map((name) => table.getChild(name));
   debug(`GeoParquet table ready: rows=${table.numRows}, nonGeometryFields=${fields.length}`);
   const records = [];
-  const geometryTypes = new Set();
+  const geometryTypes = new Set(Array.isArray(metadataGeometryTypes) ? metadataGeometryTypes : []);
   const progressEvery = Math.max(1, Math.floor(table.numRows / 40));
+  const rowExtractionStart = Date.now();
 
   for (let i = 0; i < table.numRows; i += 1) {
-    const geometry = decodeWkbGeometry(geometryVector.get(i));
-    if (geometry?.type) geometryTypes.add(geometry.type);
-    const row = { __row: i, __geometry: geometry || null };
+    let geometry = null;
+    if (keepGeometry) {
+      geometry = decodeWkbGeometry(geometryVector.get(i));
+      if (geometry?.type) geometryTypes.add(geometry.type);
+    }
+    const row = { __row: i, __geometry: keepGeometry ? (geometry || null) : null };
     fields.forEach((name, idx) => {
       const vector = fieldVectors[idx];
       row[name] = vector ? vector.get(i) : null;
@@ -265,11 +271,12 @@ const loadGeoParquetRows = async (buffer, file, side) => {
       sendProgress(side, 'parquet-rows', pct, `Decoded ${(i + 1).toLocaleString()} / ${table.numRows.toLocaleString()} rows`);
     }
   }
-  debug(`GeoParquet row extraction complete: rows=${records.length}, geometryTypes=${Array.from(geometryTypes).join(', ') || 'none'}`);
+  debug(`GeoParquet row extraction complete: rows=${records.length}, keptGeometry=${keepGeometry}, ms=${Date.now() - rowExtractionStart}, geometryTypes=${Array.from(geometryTypes).join(', ') || 'none'}`);
+  if (!keepGeometry) debug('RIGHT-side GeoParquet geometry decode skipped to reduce load time/memory; RIGHT join uses attributes only.');
 
   return {
     label: 'GeoParquet (.parquet/.geoparquet)',
-    hasGeometry: records.some((r) => Boolean(r.__geometry)),
+    hasGeometry: Boolean(geometryVector) && table.numRows > 0,
     rowCount: records.length,
     fields,
     records,
@@ -369,12 +376,16 @@ const loadAsFeatures = async (file, side, csvOptions = {}) => {
   let geojson;
   if (isGeoJson) {
     sendProgress(side, 'geojson-parse', 45, 'Parsing GeoJSON');
+    const parseStart = Date.now();
     geojson = JSON.parse(textDecoder.decode(new Uint8Array(buffer)));
+    debug(`GeoJSON parse timing (${side}): ms=${Date.now() - parseStart}`);
   } else {
     sendProgress(side, 'gdal-open', 15, 'Opening dataset');
     const gdal = await gdalPromise; let input = file;
     if (isZip) { const entries = readZipEntries(buffer); if (!entries) throw new Error('Not a supported format. This zip archive could not be read as a shapefile bundle.'); ensureShapefileParts(entries); input = toFilesFromZipEntries(entries); }
+    const openStart = Date.now();
     const { datasets, errors } = await gdal.open(input);
+    debug(`GDAL open timing (${side}): ms=${Date.now() - openStart}, datasets=${datasets?.length || 0}`);
     if (!datasets?.length) throw new Error(errors?.[0] || 'Unable to open dataset');
     const conversionEstimateMs = Math.min(180000, Math.max(10000, Math.floor(((file.size || 0) / (1024 * 1024)) * 220)));
     const geojsonText = await withProgressPulse(
@@ -388,20 +399,40 @@ const loadAsFeatures = async (file, side, csvOptions = {}) => {
         tickMs: 600
       },
       async () => {
+        const convertStart = Date.now();
         const out = await gdal.ogr2ogr(datasets[0], ['-f','GeoJSON']);
+        const convertMs = Date.now() - convertStart;
+        const readBytesStart = Date.now();
         const bytes = await gdal.getFileBytes(out);
-        return textDecoder.decode(bytes);
+        const readBytesMs = Date.now() - readBytesStart;
+        const decodeStart = Date.now();
+        const text = textDecoder.decode(bytes);
+        const decodeMs = Date.now() - decodeStart;
+        debug(`GDAL conversion timing (${side}): ogr2ogrMs=${convertMs}, getFileBytesMs=${readBytesMs}, decodeTextMs=${decodeMs}, geojsonBytes=${bytes?.length || 0}`);
+        return text;
       }
     );
+    const jsonParseStart = Date.now();
     geojson = JSON.parse(geojsonText);
+    debug(`GeoJSON parse timing (${side}): ms=${Date.now() - jsonParseStart}`);
     sendProgress(side, 'gdal-convert', 75, 'Converted to GeoJSON');
   }
   const features = geojson.features || [];
+  const hadGeometryBeforeStrip = features.some((f)=>Boolean(f.geometry));
+  const sourceGeometryTypes = Array.from(new Set(features.map((f)=>f.geometry?.type).filter(Boolean)));
+  if (side === 'right') {
+    for (let i = 0; i < features.length; i += 1) {
+      if (features[i]?.geometry !== undefined) features[i].geometry = null;
+    }
+    debug(`RIGHT-side geometry stripped before record mapping: rows=${features.length}`);
+  }
+  const recordBuildStart = Date.now();
   const records = features.map((f,i)=>({ ...f.properties, __row:i, __geometry:f.geometry || null }));
+  debug(`Record materialization timing (${side}): ms=${Date.now() - recordBuildStart}, rows=${records.length}`);
   const fields = Array.from(new Set(records.flatMap((r)=>Object.keys(r).filter((k)=>!k.startsWith('__')))));
   debug(`Vector load summary for ${side}: features=${features.length}, records=${records.length}, fields=${fields.length}`);
   sendProgress(side, 'profile', 82, 'Profiling columns');
-  const info = { label:isZip?'ESRI Shapefile (.shp.zip)':isGeoJson?'GeoJSON (.geojson)':isGpkg?'GeoPackage (.gpkg)':'Dataset', hasGeometry:features.some((f)=>Boolean(f.geometry)), rowCount:records.length, fields, records, geometryTypes:Array.from(new Set(features.map((f)=>f.geometry?.type).filter(Boolean))), columnProfiles: buildColumnProfilesSafe(records, fields, `${side}/${isGpkg ? 'gpkg' : isZip ? 'shpzip' : isGeoJson ? 'geojson' : 'dataset'}`) };
+  const info = { label:isZip?'ESRI Shapefile (.shp.zip)':isGeoJson?'GeoJSON (.geojson)':isGpkg?'GeoPackage (.gpkg)':'Dataset', hasGeometry:hadGeometryBeforeStrip, rowCount:records.length, fields, records, geometryTypes:sourceGeometryTypes, columnProfiles: buildColumnProfilesSafe(records, fields, `${side}/${isGpkg ? 'gpkg' : isZip ? 'shpzip' : isGeoJson ? 'geojson' : 'dataset'}`) };
   enforceSideGeometryRules(side, info);
   sendProgress(side, 'done', 99, 'Load complete');
   return info;

--- a/util/src/apps/constructWorker.js
+++ b/util/src/apps/constructWorker.js
@@ -8,6 +8,35 @@ const send = (type, payload) => self.postMessage({ type, payload });
 const debug = (message) => send('log', { message: `[Construct inspect] ${message}` });
 const clampPercent = (value) => Math.max(0, Math.min(100, Math.round(value)));
 const sendProgress = (side, phase, percent, detail = '') => send('progress', { side, phase, percent: clampPercent(percent), detail });
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const withProgressPulse = async ({ side, phase, startPercent, endPercent, detail, estimatedMs = 30000, tickMs = 700 }, work) => {
+  let finished = false;
+  const startTs = Date.now();
+  sendProgress(side, phase, startPercent, detail);
+
+  const ticker = (async () => {
+    while (!finished) {
+      const elapsed = Date.now() - startTs;
+      const t = Math.min(0.97, elapsed / Math.max(estimatedMs, 1000));
+      const eased = 1 - ((1 - t) * (1 - t));
+      const pct = startPercent + ((endPercent - startPercent) * eased);
+      sendProgress(side, phase, pct, `${detail} (${Math.round(elapsed / 1000)}s)`);
+      await sleep(tickMs);
+    }
+  })();
+
+  try {
+    const result = await work();
+    finished = true;
+    await ticker;
+    sendProgress(side, phase, endPercent, `${detail} complete`);
+    return result;
+  } catch (err) {
+    finished = true;
+    await ticker;
+    throw err;
+  }
+};
 const slugify = (value) => String(value).normalize('NFKD').replace(/[^\w\s-]/g, '').trim().replace(/[\s_-]+/g, '-').replace(/^-+|-+$/g, '').toLowerCase();
 let parquetModulePromise = null;
 let parquetInitialized = false;
@@ -342,17 +371,36 @@ const loadAsFeatures = async (file, side, csvOptions = {}) => {
     sendProgress(side, 'geojson-parse', 45, 'Parsing GeoJSON');
     geojson = JSON.parse(textDecoder.decode(new Uint8Array(buffer)));
   } else {
-    sendProgress(side, 'gdal-open', 35, 'Opening dataset');
+    sendProgress(side, 'gdal-open', 15, 'Opening dataset');
     const gdal = await gdalPromise; let input = file;
     if (isZip) { const entries = readZipEntries(buffer); if (!entries) throw new Error('Not a supported format. This zip archive could not be read as a shapefile bundle.'); ensureShapefileParts(entries); input = toFilesFromZipEntries(entries); }
-    sendProgress(side, 'gdal-convert', 55, 'Converting to GeoJSON');
-    const { datasets, errors } = await gdal.open(input); if (!datasets?.length) throw new Error(errors?.[0] || 'Unable to open dataset'); const out = await gdal.ogr2ogr(datasets[0], ['-f','GeoJSON']); geojson = JSON.parse(textDecoder.decode(await gdal.getFileBytes(out)));
+    const { datasets, errors } = await gdal.open(input);
+    if (!datasets?.length) throw new Error(errors?.[0] || 'Unable to open dataset');
+    const conversionEstimateMs = Math.min(180000, Math.max(10000, Math.floor(((file.size || 0) / (1024 * 1024)) * 220)));
+    const geojsonText = await withProgressPulse(
+      {
+        side,
+        phase: 'gdal-convert',
+        startPercent: 25,
+        endPercent: 75,
+        detail: 'Converting to GeoJSON',
+        estimatedMs: conversionEstimateMs,
+        tickMs: 600
+      },
+      async () => {
+        const out = await gdal.ogr2ogr(datasets[0], ['-f','GeoJSON']);
+        const bytes = await gdal.getFileBytes(out);
+        return textDecoder.decode(bytes);
+      }
+    );
+    geojson = JSON.parse(geojsonText);
+    sendProgress(side, 'gdal-convert', 75, 'Converted to GeoJSON');
   }
   const features = geojson.features || [];
   const records = features.map((f,i)=>({ ...f.properties, __row:i, __geometry:f.geometry || null }));
   const fields = Array.from(new Set(records.flatMap((r)=>Object.keys(r).filter((k)=>!k.startsWith('__')))));
   debug(`Vector load summary for ${side}: features=${features.length}, records=${records.length}, fields=${fields.length}`);
-  sendProgress(side, 'profile', 75, 'Profiling columns');
+  sendProgress(side, 'profile', 82, 'Profiling columns');
   const info = { label:isZip?'ESRI Shapefile (.shp.zip)':isGeoJson?'GeoJSON (.geojson)':isGpkg?'GeoPackage (.gpkg)':'Dataset', hasGeometry:features.some((f)=>Boolean(f.geometry)), rowCount:records.length, fields, records, geometryTypes:Array.from(new Set(features.map((f)=>f.geometry?.type).filter(Boolean))), columnProfiles: buildColumnProfilesSafe(records, fields, `${side}/${isGpkg ? 'gpkg' : isZip ? 'shpzip' : isGeoJson ? 'geojson' : 'dataset'}`) };
   enforceSideGeometryRules(side, info);
   sendProgress(side, 'done', 100, 'Load complete');


### PR DESCRIPTION
### Motivation

- A very large GeoPackage/GeoParquet input triggered `Maximum call stack size exceeded` while loading/inspecting LEFT/RIGHT sources, so we need better diagnostics to locate the failure stage and to remove likely failure modes.
- The most plausible cause is use of spread-based min/max over very large arrays during column profiling, which can blow the stack for huge inputs.

### Description

- Added a worker-side debug logger that emits `[Construct inspect]` messages to the existing app log panel via `send('log', ...)` to trace file/size, format detection, buffer reads, GeoParquet metadata, table rows/fields, and geometry-type summaries.
- Instrumented `loadAsFeatures()` and `loadGeoParquetRows()` with debug messages showing file name/size, buffer bytes, detected format, GeoParquet primary geometry/encoding, table rows and field counts, and row extraction completion.
- Replaced the previous spread-based min/max computation in `buildColumnProfiles()` with an iterative scan that computes `min`/`max` without creating large intermediate arrays to avoid stack/heap issues on large datasets.
- Introduced `buildColumnProfilesSafe(rows, fields, label)` wrapper that logs start/finish/failure and calls `buildColumnProfiles()`, and replaced direct calls with this safe wrapper in CSV, GeoParquet, and vector paths.

### Testing

- Ran a quick syntax check with `node --check util/src/apps/constructWorker.js`, which completed successfully.
- No other automated tests exist for the in-browser worker here; runtime validation should be performed by reloading the app and reproducing the problematic LEFT/RIGHT load to capture the new `[Construct inspect]` log entries (these logs will show whether the failure occurs during read/parse/geometry decoding/profile phases).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699f469fe58c83268cd685830b144ef3)