### PR TITLE
Add Synthetic City Builder util app with worker-based generator and ZIP export

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -54,6 +54,12 @@
               <p>&nbsp;</p>
               <a class="button" href="/util/construct.html">Construct</a>
             </article>
+            <article class="card">
+              <h2>Synthetic City Builder</h2>
+              <p>Generate deterministic synthetic parcel universes and repeat-sales datasets for experimentation.</p>
+              <p>&nbsp;</p>
+              <a class="button" href="/util/synthetic/index.html">Synthetic</a>
+            </article>
           </div>
         </div>
       </section>

--- a/util/src/apps/syntheticApp.js
+++ b/util/src/apps/syntheticApp.js
@@ -1,0 +1,173 @@
+import { triggerDownload } from '../export/download.js';
+
+const MODEL_GROUPS = ['single_family', 'multi_family', 'commercial', 'industrial', 'mobile_home', 'agricultural'];
+
+export default function startSyntheticApp() {
+  const byId = (id) => document.getElementById(id);
+  const logEl = byId('log');
+  const statusEl = byId('status');
+  const mParcels = byId('mParcels');
+  const mSales = byId('mSales');
+  const mCrs = byId('mCrs');
+  const generateBtn = byId('generateBtn');
+  const cancelBtn = byId('cancelBtn');
+  const exportBtn = byId('exportBtn');
+
+  const state = { worker: null, result: null };
+
+  const map = new maplibregl.Map({
+    container: 'map',
+    style: 'https://demotiles.maplibre.org/style.json',
+    center: [-87.6298, 41.8781],
+    zoom: 10
+  });
+
+  map.addControl(new maplibregl.NavigationControl(), 'top-right');
+
+  map.on('load', () => {
+    map.addSource('parcels', { type: 'geojson', data: { type: 'FeatureCollection', features: [] } });
+    map.addLayer({
+      id: 'parcels-fill',
+      type: 'fill',
+      source: 'parcels',
+      paint: {
+        'fill-color': ['match', ['get', 'neighborhood'],
+          'CBD', '#f97316',
+          'inner ring', '#f59e0b',
+          'suburb', '#84cc16',
+          'exurb', '#22c55e',
+          'commercial corridors', '#0ea5e9',
+          'industrial sector', '#6b7280',
+          'rural outlying', '#a3a3a3',
+          '#8b5cf6'
+        ],
+        'fill-opacity': 0.55
+      }
+    });
+    map.addLayer({ id: 'parcels-line', type: 'line', source: 'parcels', paint: { 'line-color': '#334155', 'line-width': 0.4 } });
+  });
+
+  const log = (msg) => {
+    logEl.textContent += `${msg}\n`;
+    logEl.scrollTop = logEl.scrollHeight;
+  };
+
+  const readNumber = (id, fallback) => {
+    const v = Number(byId(id).value);
+    return Number.isFinite(v) ? v : fallback;
+  };
+
+  const buildConfig = () => {
+    const saleProbabilities = Object.fromEntries(MODEL_GROUPS.map((g) => [g, Math.max(0, Math.min(1, readNumber(`p_${g}`, 0.05)))]));
+    return {
+      cityName: byId('cityName').value.trim() || 'Unknown',
+      centerLat: readNumber('centerLat', 41.8781),
+      centerLon: readNumber('centerLon', -87.6298),
+      seed: byId('seed').value.trim() || 'synthetic-city',
+      parcelCount: Math.min(10000, Math.max(100, Math.round(readNumber('parcelCount', 5000)))),
+      repaintYears: Math.max(1, Math.round(readNumber('repaintYears', 5))),
+      invalidPct: Math.max(0, Math.min(100, readNumber('invalidPct', 8))),
+      saleProbabilities,
+      startYear: 1980,
+      endYear: new Date().getFullYear(),
+      nominalPriceList: [1, 5, 10, 50, 100, 500, 1000]
+    };
+  };
+
+  const setBusy = (busy) => {
+    generateBtn.disabled = busy;
+    cancelBtn.disabled = !busy;
+  };
+
+  const updateMap = (featureCollection) => {
+    const src = map.getSource('parcels');
+    if (src) src.setData(featureCollection);
+    const first = featureCollection?.features?.[0];
+    if (first?.geometry?.coordinates?.[0]?.[0]) {
+      const [lon, lat] = first.geometry.coordinates[0][0];
+      map.easeTo({ center: [lon, lat], zoom: 11, duration: 650 });
+    }
+  };
+
+  generateBtn.onclick = () => {
+    const config = buildConfig();
+    if (state.worker) state.worker.terminate();
+    state.result = null;
+    exportBtn.disabled = true;
+    logEl.textContent = '';
+    statusEl.textContent = 'Generating...';
+    setBusy(true);
+
+    const worker = new Worker(new URL('./syntheticWorker.js', import.meta.url), { type: 'module' });
+    state.worker = worker;
+
+    worker.onmessage = (event) => {
+      const { type, payload } = event.data || {};
+      if (type === 'log') log(payload.message);
+      if (type === 'progress') statusEl.textContent = payload.message;
+      if (type === 'milestone') updateMap(payload.featureCollection);
+      if (type === 'success') {
+        state.result = payload;
+        statusEl.textContent = 'Generation complete.';
+        mParcels.textContent = String(payload.universeCount || 0);
+        mSales.textContent = String(payload.salesCount || 0);
+        mCrs.textContent = payload.crs || 'EPSG:4326';
+        updateMap(payload.preview || { type: 'FeatureCollection', features: [] });
+        exportBtn.disabled = false;
+        setBusy(false);
+        worker.terminate();
+        state.worker = null;
+      }
+      if (type === 'error') {
+        statusEl.textContent = payload.message || 'Generation failed.';
+        setBusy(false);
+        worker.terminate();
+        state.worker = null;
+      }
+    };
+
+    worker.onerror = (err) => {
+      statusEl.textContent = err.message || 'Worker failure.';
+      setBusy(false);
+      worker.terminate();
+      state.worker = null;
+    };
+
+    worker.postMessage({ mode: 'generate', config });
+  };
+
+  cancelBtn.onclick = () => {
+    if (!state.worker) return;
+    state.worker.terminate();
+    state.worker = null;
+    setBusy(false);
+    statusEl.textContent = 'Canceled.';
+    log('Generation canceled by user.');
+  };
+
+  exportBtn.onclick = () => {
+    if (!state.result) return;
+    const worker = new Worker(new URL('./syntheticWorker.js', import.meta.url), { type: 'module' });
+    statusEl.textContent = 'Building export ZIP...';
+    exportBtn.disabled = true;
+
+    worker.onmessage = async (event) => {
+      const { type, payload } = event.data || {};
+      if (type === 'progress') statusEl.textContent = payload.message;
+      if (type === 'error') {
+        statusEl.textContent = payload.message || 'Export failed.';
+        exportBtn.disabled = false;
+        worker.terminate();
+      }
+      if (type === 'zip') {
+        const zipBlob = payload.zipBlob;
+        triggerDownload(zipBlob, payload.filename || 'synthetic_city.zip');
+        statusEl.textContent = 'Export complete.';
+        exportBtn.disabled = false;
+        worker.terminate();
+      }
+    };
+
+    worker.postMessage({ mode: 'export', payload: state.result });
+  };
+}

--- a/util/src/apps/syntheticApp.js
+++ b/util/src/apps/syntheticApp.js
@@ -9,6 +9,7 @@ export default function startSyntheticApp() {
   const mParcels = byId('mParcels');
   const mSales = byId('mSales');
   const mCrs = byId('mCrs');
+  const mRoads = byId('mRoads');
   const generateBtn = byId('generateBtn');
   const cancelBtn = byId('cancelBtn');
   const exportBtn = byId('exportBtn');
@@ -45,6 +46,8 @@ export default function startSyntheticApp() {
       }
     });
     map.addLayer({ id: 'parcels-line', type: 'line', source: 'parcels', paint: { 'line-color': '#334155', 'line-width': 0.4 } });
+    map.addSource('roads', { type: 'geojson', data: { type: 'FeatureCollection', features: [] } });
+    map.addLayer({ id: 'roads-line', type: 'line', source: 'roads', paint: { 'line-color': '#111827', 'line-width': ['interpolate', ['linear'], ['get','width_m'], 2.5, 0.5, 6, 1.5, 15, 2.8, 50, 5.5], 'line-opacity': 0.85 } });
   });
 
   const log = (msg) => {
@@ -112,6 +115,9 @@ export default function startSyntheticApp() {
         mParcels.textContent = String(payload.universeCount || 0);
         mSales.textContent = String(payload.salesCount || 0);
         mCrs.textContent = payload.crs || 'EPSG:4326';
+        mRoads.textContent = String(payload.roadsCount || 0);
+        const roadSrc = map.getSource('roads');
+        if (roadSrc) roadSrc.setData({ type: 'FeatureCollection', features: (payload.roads || []).slice(0, 5000).map((r) => ({ type:'Feature', geometry:r.geometry, properties:r })) });
         updateMap(payload.preview || { type: 'FeatureCollection', features: [] });
         exportBtn.disabled = false;
         setBusy(false);

--- a/util/src/apps/syntheticApp.js
+++ b/util/src/apps/syntheticApp.js
@@ -98,13 +98,13 @@ export default function startSyntheticApp() {
     statusEl.textContent = 'Generating...';
     setBusy(true);
 
-    const worker = new Worker(new URL('./syntheticWorker.js', import.meta.url), { type: 'module' });
+    const worker = new Worker(new URL('./syntheticWorker.js', import.meta.url));
     state.worker = worker;
 
     worker.onmessage = (event) => {
       const { type, payload } = event.data || {};
       if (type === 'log') log(payload.message);
-      if (type === 'progress') statusEl.textContent = payload.message;
+      if (type === 'progress') { statusEl.textContent = payload.message; log(payload.message); }
       if (type === 'milestone') updateMap(payload.featureCollection);
       if (type === 'success') {
         state.result = payload;
@@ -127,6 +127,7 @@ export default function startSyntheticApp() {
     };
 
     worker.onerror = (err) => {
+      console.error('Synthetic worker error', err);
       statusEl.textContent = err.message || 'Worker failure.';
       setBusy(false);
       worker.terminate();
@@ -147,14 +148,16 @@ export default function startSyntheticApp() {
 
   exportBtn.onclick = () => {
     if (!state.result) return;
-    const worker = new Worker(new URL('./syntheticWorker.js', import.meta.url), { type: 'module' });
+    const worker = new Worker(new URL('./syntheticWorker.js', import.meta.url));
     statusEl.textContent = 'Building export ZIP...';
     exportBtn.disabled = true;
 
     worker.onmessage = async (event) => {
       const { type, payload } = event.data || {};
-      if (type === 'progress') statusEl.textContent = payload.message;
+      if (type === 'progress') { statusEl.textContent = payload.message; log(payload.message); }
       if (type === 'error') {
+        console.error('Synthetic export error', payload);
+        if (payload?.stack) log(payload.stack);
         statusEl.textContent = payload.message || 'Export failed.';
         exportBtn.disabled = false;
         worker.terminate();

--- a/util/src/apps/syntheticWorker.js
+++ b/util/src/apps/syntheticWorker.js
@@ -1,0 +1,427 @@
+import { buildZipBlob } from '../export/zip.js';
+import { makeArrowTable, tableToIPC } from '../parquet/arrowSchema.js';
+import { createGeoMetadata } from '../geo/geoparquetMeta.js';
+import * as parquetModule from '../../vendor/parquet-wasm/esm/parquet_wasm.js';
+
+await parquetModule.default(new URL('../../vendor/parquet-wasm/esm/parquet_wasm_bg.wasm', import.meta.url));
+
+const MODEL_GROUPS = ['single_family', 'multi_family', 'commercial', 'industrial', 'mobile_home', 'agricultural'];
+
+const BLDG_TYPE_BY_GROUP = {
+  single_family: ['SF_RANCH', 'SF_TWO_STORY', 'SF_TOWNHOUSE'],
+  multi_family: ['MF_DUPLEX', 'MF_TRIPLEX', 'MF_GARDEN_APT', 'MF_MIDRISE_APT'],
+  commercial: ['COMM_RETAIL_SMALL', 'COMM_RETAIL_BIGBOX', 'COMM_OFFICE_LOWRISE', 'COMM_MIXED_USE'],
+  industrial: ['IND_WAREHOUSE', 'IND_LIGHT_MANUFACTURING', 'IND_FLEX'],
+  mobile_home: ['MH_SINGLE_WIDE', 'MH_DOUBLE_WIDE', 'MH_PARK_PAD'],
+  agricultural: ['AG_ROW_CROP', 'AG_PASTURE', 'AG_FARMSTEAD']
+};
+
+const NEIGHBORHOODS = ['CBD', 'inner ring', 'suburb', 'exurb', 'commercial corridors', 'industrial sector', 'rural outlying'];
+const ZONING_BY_GROUP = {
+  single_family: ['R1', 'R2'], multi_family: ['R3', 'R4'], commercial: ['C1', 'C2'], industrial: ['I1', 'I2'], mobile_home: ['R-MH'], agricultural: ['AG']
+};
+const LAND_TYPE_BY_GROUP = {
+  single_family: ['residential'], multi_family: ['residential'], commercial: ['commercial'], industrial: ['industrial'], mobile_home: ['residential'], agricultural: ['agricultural']
+};
+
+const textEncoder = new TextEncoder();
+
+const send = (type, payload) => self.postMessage({ type, payload });
+const log = (message) => send('log', { message });
+const progress = (message) => send('progress', { message });
+
+const randPick = (rng, items) => items[Math.floor(rng() * items.length)];
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+
+function metersToLonLat(centerLon, centerLat, dx, dy) {
+  const degLat = dy / 111320;
+  const degLon = dx / (111320 * Math.cos((centerLat * Math.PI) / 180));
+  return [centerLon + degLon, centerLat + degLat];
+}
+
+function polygonWkb(coords) {
+  const points = coords;
+  const pointCount = points.length;
+  const byteLength = 1 + 4 + 4 + 4 + pointCount * 16;
+  const buf = new ArrayBuffer(byteLength);
+  const v = new DataView(buf);
+  let o = 0;
+  v.setUint8(o, 1); o += 1;
+  v.setUint32(o, 3, true); o += 4;
+  v.setUint32(o, 1, true); o += 4;
+  v.setUint32(o, pointCount, true); o += 4;
+  for (const [x, y] of points) {
+    v.setFloat64(o, x, true); o += 8;
+    v.setFloat64(o, y, true); o += 8;
+  }
+  return new Uint8Array(buf);
+}
+
+function toDateStringUTC(d) {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function buildInflationSeries(startYear, endYear) {
+  const startDate = new Date(Date.UTC(startYear, 0, 1));
+  const endDate = new Date(Date.UTC(endYear, 0, 1));
+  const monthly = [];
+  let idx = 1;
+  for (let y = startYear; y <= endYear; y++) {
+    for (let m = 0; m < 12; m++) {
+      const d = new Date(Date.UTC(y, m, 1));
+      if (d > endDate) break;
+      const monthlyRate = 0.002 + ((m % 6) * 0.0001);
+      idx *= 1 + monthlyRate;
+      monthly.push({ date: d, idx });
+    }
+  }
+  const monthlyMap = new Map(monthly.map((m) => [toDateStringUTC(m.date), m.idx]));
+  const rows = [];
+  const oneDayMs = 86400000;
+  for (let t = startDate.getTime(); t <= endDate.getTime(); t += oneDayMs) {
+    const d = new Date(t);
+    const cur = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+    const next = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1));
+    const curIdx = monthlyMap.get(toDateStringUTC(cur)) ?? 1;
+    const nextIdx = monthlyMap.get(toDateStringUTC(next)) ?? curIdx;
+    const span = next.getTime() - cur.getTime() || oneDayMs;
+    const f = clamp((t - cur.getTime()) / span, 0, 1);
+    const startIndexed = curIdx + (nextIdx - curIdx) * f;
+    rows.push({ period: toDateStringUTC(d), start_indexed: startIndexed, end_indexed: 0, correction_factor: 0 });
+  }
+  const last = rows.length ? rows[rows.length - 1].start_indexed : 1;
+  rows.forEach((r) => {
+    r.end_indexed = r.start_indexed / last;
+    r.correction_factor = 1 / r.end_indexed;
+  });
+  return { rows, byDate: new Map(rows.map((r) => [r.period, r])) };
+}
+
+function chooseGroupByNeighborhood(rng, neighborhood) {
+  if (neighborhood === 'CBD') return rng() < 0.7 ? 'commercial' : 'multi_family';
+  if (neighborhood === 'inner ring') return randPick(rng, ['single_family', 'multi_family', 'commercial']);
+  if (neighborhood === 'commercial corridors') return randPick(rng, ['commercial', 'single_family']);
+  if (neighborhood === 'industrial sector') return randPick(rng, ['industrial', 'commercial']);
+  if (neighborhood === 'rural outlying') return randPick(rng, ['agricultural', 'single_family']);
+  if (neighborhood === 'exurb') return randPick(rng, ['single_family', 'mobile_home', 'agricultural']);
+  return randPick(rng, ['single_family', 'multi_family', 'mobile_home']);
+}
+
+function neighborhoodForOffset(dx, dy) {
+  const dist = Math.sqrt(dx * dx + dy * dy);
+  if (Math.abs(dy) < 120 && Math.abs(dx) < 1600) return 'commercial corridors';
+  if (dx > 800 && dy < -800) return 'industrial sector';
+  if (dist < 320) return 'CBD';
+  if (dist < 780) return 'inner ring';
+  if (dist < 1300) return 'suburb';
+  if (dist < 1900) return 'exurb';
+  return 'rural outlying';
+}
+
+function buildParcelRecord({ key, centerLon, centerLat, i, j, n, cellM, rng }) {
+  const half = (n - 1) / 2;
+  const dx = (i - half) * cellM;
+  const dy = (j - half) * cellM;
+  const beltFactor = 1 + 0.08 * Math.sin(Math.sqrt(dx * dx + dy * dy) / 350);
+  const width = cellM * (0.85 + rng() * 0.35) * beltFactor;
+  const height = cellM * (0.85 + rng() * 0.35) * (2 - beltFactor);
+  const x0 = dx - width / 2; const x1 = dx + width / 2;
+  const y0 = dy - height / 2; const y1 = dy + height / 2;
+  const p0 = metersToLonLat(centerLon, centerLat, x0, y0);
+  const p1 = metersToLonLat(centerLon, centerLat, x1, y0);
+  const p2 = metersToLonLat(centerLon, centerLat, x1, y1);
+  const p3 = metersToLonLat(centerLon, centerLat, x0, y1);
+  const ring = [p0, p1, p2, p3, p0];
+
+  const neighborhood = neighborhoodForOffset(dx, dy);
+  const model_group = chooseGroupByNeighborhood(rng, neighborhood);
+  const bldg_type = randPick(rng, BLDG_TYPE_BY_GROUP[model_group]);
+  const zoning = randPick(rng, ZONING_BY_GROUP[model_group]);
+  const land_type = randPick(rng, LAND_TYPE_BY_GROUP[model_group]);
+
+  const land_area_sqft = Math.max(1000, Math.round((width * height) * 10.7639));
+  const stories = model_group === 'commercial' ? (rng() < 0.35 ? 2 : 1) : model_group === 'multi_family' ? (rng() < 0.5 ? 2 : 3) : 1;
+  const footprint = model_group === 'agricultural' ? 0 : Math.round(land_area_sqft * (0.15 + rng() * 0.4));
+  const finished = Math.round(footprint * Math.max(1, stories) * (0.88 + rng() * 0.18));
+  const units = model_group === 'multi_family' ? (bldg_type === 'MF_DUPLEX' ? 2 : bldg_type === 'MF_TRIPLEX' ? 3 : 8 + Math.floor(rng() * 24)) : 0;
+  const beds = model_group === 'single_family' ? Math.max(1, Math.round(finished / 700)) : model_group === 'multi_family' ? Math.max(0, Math.round(units * 1.6)) : 0;
+  const baths = model_group === 'single_family' ? Math.max(1, Math.round(beds * 0.75)) : model_group === 'multi_family' ? Math.max(0, Math.round(units * 1.2)) : 0;
+  const yearBuilt = 1940 + Math.floor(rng() * 80);
+
+  return {
+    key,
+    geometry: { type: 'Polygon', coordinates: [ring] },
+    longitude: (p0[0] + p2[0]) / 2,
+    latitude: (p0[1] + p2[1]) / 2,
+    neighborhood,
+    model_group,
+    zoning,
+    land_type,
+    land_area_sqft,
+    bldg_type,
+    bldg_area_footprint_sqft: footprint,
+    bldg_area_finished_sqft: finished,
+    bldg_stories: footprint > 0 ? stories : 0,
+    bldg_units: footprint > 0 ? units : 0,
+    bldg_rooms_bed: footprint > 0 ? beds : 0,
+    bldg_rooms_bath: footprint > 0 ? baths : 0,
+    bldg_quality_num: footprint > 0 ? 2 + Math.floor(rng() * 4) : 0,
+    bldg_condition_num: footprint > 0 ? 45 + Math.floor(rng() * 45) : 0,
+    bldg_year_built: footprint > 0 ? yearBuilt : null,
+    bldg_year_renovated: null
+  };
+}
+
+function calcValues(parcel) {
+  const landBase = parcel.land_area_sqft * (parcel.neighborhood === 'CBD' ? 42 : parcel.neighborhood === 'inner ring' ? 21 : 9);
+  const imprBase = parcel.bldg_area_finished_sqft * (parcel.model_group === 'commercial' ? 180 : parcel.model_group === 'industrial' ? 115 : 140);
+  const qualityAdj = 1 + (parcel.bldg_quality_num || 0) * 0.07;
+  const conditionAdj = 0.2 + (parcel.bldg_condition_num || 0) / 125;
+  const platonic_land_value = Math.round(landBase);
+  const platonic_impr_value = Math.round(imprBase * qualityAdj * conditionAdj);
+  return { platonic_land_value, platonic_impr_value, platonic_market_value: platonic_land_value + platonic_impr_value };
+}
+
+function invalidateSalePrice(rng, nominalPriceList, platonic) {
+  if (rng() < 0.5) return randPick(rng, nominalPriceList);
+  const rounded = Math.round((rng() * 999) / 5) * 5;
+  return Math.max(1, rounded);
+}
+
+function makeGeoFeature(row, includeGeometry = true) {
+  const props = { ...row };
+  delete props.geometry;
+  return {
+    type: 'Feature',
+    geometry: includeGeometry ? row.geometry : null,
+    properties: props
+  };
+}
+
+function generateSimulation(config) {
+  const rng = self.Math.seedrandom(config.seed);
+  const parcelCount = config.parcelCount;
+  const n = Math.ceil(Math.sqrt(parcelCount));
+  const cellM = 70;
+  const universe = [];
+
+  progress('Generating parcel fabric...');
+  for (let idx = 0; idx < parcelCount; idx++) {
+    const i = idx % n;
+    const j = Math.floor(idx / n);
+    const key = String(idx + 1).padStart(5, '0');
+    const parcel = buildParcelRecord({ key, centerLon: config.centerLon, centerLat: config.centerLat, i, j, n, cellM, rng });
+    universe.push(parcel);
+  }
+  send('milestone', { featureCollection: { type: 'FeatureCollection', features: universe.slice(0, 4500).map((r) => makeGeoFeature(r)) } });
+
+  progress('Building inflation series...');
+  const inflation = buildInflationSeries(config.startYear, config.endYear);
+
+  progress('Simulating yearly events and sales...');
+  const salesPlatonic = [];
+  const salesObserved = [];
+
+  for (let year = config.startYear; year <= config.endYear; year++) {
+    for (const p of universe) {
+      if (p.bldg_area_finished_sqft > 0) {
+        p.bldg_condition_num = clamp(p.bldg_condition_num - (0.5 + rng() * 1.4), 0, 100);
+      }
+      if (p.bldg_area_finished_sqft > 0 && rng() < 0.008) {
+        p.bldg_area_finished_sqft = 0; p.bldg_area_footprint_sqft = 0; p.bldg_quality_num = 0; p.bldg_condition_num = 0;
+        p.bldg_type = 'NONE'; p.bldg_stories = 0; p.bldg_units = 0; p.bldg_rooms_bed = 0; p.bldg_rooms_bath = 0; p.bldg_year_built = null; p.bldg_year_renovated = null;
+      } else if (p.bldg_area_finished_sqft === 0 && rng() < 0.015) {
+        p.bldg_type = randPick(rng, BLDG_TYPE_BY_GROUP[p.model_group]);
+        p.bldg_stories = p.model_group === 'multi_family' ? 2 : 1;
+        p.bldg_area_footprint_sqft = Math.max(450, Math.round(p.land_area_sqft * (0.12 + rng() * 0.25)));
+        p.bldg_area_finished_sqft = Math.round(p.bldg_area_footprint_sqft * p.bldg_stories * (0.9 + rng() * 0.2));
+        p.bldg_quality_num = 2 + Math.floor(rng() * 3);
+        p.bldg_condition_num = 65 + Math.floor(rng() * 30);
+        p.bldg_year_built = year;
+      } else if (p.bldg_area_finished_sqft > 0 && rng() < 0.02) {
+        p.bldg_condition_num = clamp(p.bldg_condition_num + 8 + rng() * 20, 0, 100);
+        p.bldg_year_renovated = year;
+      }
+
+      const saleProb = config.saleProbabilities[p.model_group] ?? 0.05;
+      if (rng() > saleProb) continue;
+      const month = Math.floor(rng() * 12);
+      const day = 1 + Math.floor(rng() * 28);
+      const saleDate = toDateStringUTC(new Date(Date.UTC(year, month, day)));
+      const infl = inflation.byDate.get(saleDate) || inflation.rows[inflation.rows.length - 1];
+      const values = calcValues(p);
+      const trendAdj = infl.start_indexed;
+      const platonicSale = Math.max(1, Math.round(values.platonic_market_value * trendAdj));
+      const noise = Math.round((rng() - 0.5) * 0.06 * platonicSale);
+      const truePrice = Math.max(1, platonicSale + noise);
+
+      const key_sale = `${p.key}---${saleDate}`;
+      const platonicRow = {
+        ...p,
+        key_sale,
+        sale_date: saleDate,
+        sale_type: 'VALID',
+        valid_sale: true,
+        sale_noise: noise,
+        sale_price: truePrice,
+        vacant_sale: p.bldg_area_finished_sqft === 0,
+        inflation_index: infl.start_indexed,
+        ...values
+      };
+
+      const observedRow = { ...platonicRow };
+      if (rng() < config.invalidPct / 100) {
+        observedRow.sale_type = 'NOT_ARMS_LENGTH';
+        observedRow.sale_price = invalidateSalePrice(rng, config.nominalPriceList, truePrice);
+        observedRow.valid_sale = true;
+        platonicRow.sale_type = 'NOT_ARMS_LENGTH';
+        platonicRow.valid_sale = false;
+      }
+
+      salesPlatonic.push(platonicRow);
+      salesObserved.push(observedRow);
+    }
+
+    if ((year - config.startYear) % config.repaintYears === 0 || year === config.endYear) {
+      send('milestone', { featureCollection: { type: 'FeatureCollection', features: universe.slice(0, 4500).map((r) => makeGeoFeature(r)) } });
+      log(`Milestone repaint: year ${year}.`);
+    }
+  }
+
+  const preview = { type: 'FeatureCollection', features: universe.slice(0, 4500).map((r) => makeGeoFeature(r)) };
+  return {
+    config,
+    crs: 'EPSG:4326',
+    universeCount: universe.length,
+    salesCount: salesObserved.length,
+    preview,
+    universe,
+    sales: salesObserved,
+    sales_platonic: salesPlatonic,
+    inflation: inflation.rows
+  };
+}
+
+function inferType(v) {
+  if (v == null) return 'string';
+  if (typeof v === 'boolean') return 'bool';
+  if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float';
+  return 'string';
+}
+
+function arrowType(Arrow, kind) {
+  if (kind === 'bool') return new Arrow.Bool();
+  if (kind === 'int') return new Arrow.Int32();
+  if (kind === 'float') return new Arrow.Float64();
+  return new Arrow.Utf8();
+}
+
+function rowToFields(rows) {
+  const keys = new Set();
+  rows.forEach((r) => Object.keys(r).forEach((k) => { if (k !== 'geometry') keys.add(k); }));
+  return Array.from(keys).map((name) => {
+    const sample = rows.find((r) => r[name] != null)?.[name] ?? null;
+    return { name, kind: inferType(sample) };
+  });
+}
+
+async function toGeoParquetBytes(rows) {
+  const Arrow = await import('../../vendor/apache-arrow.js');
+  const fields = rowToFields(rows);
+  const spatialRef = { wkid: 4326, latestWkid: 4326, wkt: null };
+  const geoMetadata = await createGeoMetadata(spatialRef, 'Polygon');
+  const schema = new Arrow.Schema([
+    new Arrow.Field('geometry', new Arrow.Binary(), true),
+    ...fields.map((f) => new Arrow.Field(f.name, arrowType(Arrow, f.kind), true))
+  ], new Map([['geo', JSON.stringify(geoMetadata)]]));
+
+  const geomBuilder = Arrow.makeBuilder({ type: new Arrow.Binary(), nullValues: [null, undefined] });
+  const fieldBuilders = new Map(fields.map((f) => [f.name, Arrow.makeBuilder({ type: arrowType(Arrow, f.kind), nullValues: [null, undefined] })]));
+
+  for (const row of rows) {
+    const ring = row.geometry.coordinates[0];
+    geomBuilder.append(polygonWkb(ring));
+    for (const f of fields) {
+      const v = row[f.name] == null ? null : row[f.name];
+      fieldBuilders.get(f.name).append(v);
+    }
+  }
+
+  geomBuilder.finish();
+  const geomVector = geomBuilder.toVector();
+  const vectors = [geomVector];
+  for (const f of fields) {
+    const b = fieldBuilders.get(f.name);
+    b.finish();
+    vectors.push(b.toVector());
+  }
+
+  const table = makeArrowTable(Arrow, schema, vectors);
+  const ipc = tableToIPC(Arrow, table, 'stream');
+  const wasmTable = parquetModule.Table.fromIPCStream(ipc);
+  const writerProps = new parquetModule.WriterPropertiesBuilder()
+    .setCompression(parquetModule.Compression.ZSTD)
+    .setKeyValueMetadata(new Map([['geo', JSON.stringify(geoMetadata)]]))
+    .build();
+  const bytes = parquetModule.writeParquet(wasmTable, writerProps);
+  return bytes;
+}
+
+async function buildExportZip(payload) {
+  progress('Encoding universe.geoparquet...');
+  const universeBytes = await toGeoParquetBytes(payload.universe);
+  progress('Encoding sales.geoparquet...');
+  const salesBytes = await toGeoParquetBytes(payload.sales);
+  progress('Encoding sales_platonic.geoparquet...');
+  const platBytes = await toGeoParquetBytes(payload.sales_platonic);
+  progress('Encoding inflation.csv...');
+
+  const csvHeader = 'period,start_indexed,end_indexed,correction_factor';
+  const csvBody = payload.inflation.map((r) => `${r.period},${r.start_indexed},${r.end_indexed},${r.correction_factor}`).join('\n');
+  const inflationBytes = textEncoder.encode(`${csvHeader}\n${csvBody}`);
+
+  const metadata = {
+    seed: payload.config.seed,
+    app_version: 'mvp-0.1',
+    crs: 'EPSG:4326',
+    center: { city_name: payload.config.cityName, latitude: payload.config.centerLat, longitude: payload.config.centerLon },
+    start_year: payload.config.startYear,
+    end_year: payload.config.endYear,
+    parcel_count: payload.config.parcelCount,
+    repaint_interval_years: payload.config.repaintYears,
+    invalid_pct: payload.config.invalidPct,
+    sale_probabilities: payload.config.saleProbabilities,
+    nominal_price_list: payload.config.nominalPriceList
+  };
+  const metaBytes = textEncoder.encode(JSON.stringify(metadata, null, 2));
+
+  const zipBlob = buildZipBlob([
+    { name: 'universe.geoparquet', data: universeBytes },
+    { name: 'sales.geoparquet', data: salesBytes },
+    { name: 'sales_platonic.geoparquet', data: platBytes },
+    { name: 'inflation.csv', data: inflationBytes },
+    { name: 'metadata.json', data: metaBytes }
+  ]);
+
+  return zipBlob;
+}
+
+self.onmessage = async (event) => {
+  const { mode, config, payload } = event.data || {};
+  try {
+    if (mode === 'generate') {
+      const result = generateSimulation(config);
+      send('success', result);
+      return;
+    }
+    if (mode === 'export') {
+      const zipBlob = await buildExportZip(payload);
+      send('zip', { zipBlob, filename: `synthetic_city_${new Date().toISOString().slice(0, 10)}.zip` });
+    }
+  } catch (err) {
+    send('error', { message: err?.message || String(err) });
+  }
+};

--- a/util/src/apps/syntheticWorker.js
+++ b/util/src/apps/syntheticWorker.js
@@ -1,12 +1,7 @@
-import { buildZipBlob } from '../export/zip.js';
-import { makeArrowTable, tableToIPC } from '../parquet/arrowSchema.js';
-import { createGeoMetadata } from '../geo/geoparquetMeta.js';
-import * as parquetModule from '../../vendor/parquet-wasm/esm/parquet_wasm.js';
-
-let parquetReady = false;
+/* global self */
+importScripts('../../vendor/apache-arrow.js');
 
 const MODEL_GROUPS = ['single_family', 'multi_family', 'commercial', 'industrial', 'mobile_home', 'agricultural'];
-
 const BLDG_TYPE_BY_GROUP = {
   single_family: ['SF_RANCH', 'SF_TWO_STORY', 'SF_TOWNHOUSE'],
   multi_family: ['MF_DUPLEX', 'MF_TRIPLEX', 'MF_GARDEN_APT', 'MF_MIDRISE_APT'],
@@ -15,8 +10,6 @@ const BLDG_TYPE_BY_GROUP = {
   mobile_home: ['MH_SINGLE_WIDE', 'MH_DOUBLE_WIDE', 'MH_PARK_PAD'],
   agricultural: ['AG_ROW_CROP', 'AG_PASTURE', 'AG_FARMSTEAD']
 };
-
-const NEIGHBORHOODS = ['CBD', 'inner ring', 'suburb', 'exurb', 'commercial corridors', 'industrial sector', 'rural outlying'];
 const ZONING_BY_GROUP = {
   single_family: ['R1', 'R2'], multi_family: ['R3', 'R4'], commercial: ['C1', 'C2'], industrial: ['I1', 'I2'], mobile_home: ['R-MH'], agricultural: ['AG']
 };
@@ -25,377 +18,268 @@ const LAND_TYPE_BY_GROUP = {
 };
 
 const textEncoder = new TextEncoder();
-
 const send = (type, payload) => self.postMessage({ type, payload });
 const log = (message) => send('log', { message });
 const progress = (message) => send('progress', { message });
+const randPick = (rng, items) => items[Math.floor(rng() * items.length)];
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
 
-async function ensureParquetReady() {
-  if (parquetReady) return;
-  progress('Loading parquet encoder...');
-  await parquetModule.default(new URL('../../vendor/parquet-wasm/esm/parquet_wasm_bg.wasm', import.meta.url));
-  parquetReady = true;
+let parquetModulePromise = null;
+let parquetInitialized = false;
+let arrowHelpersPromise = null;
+
+async function ensureParquetModule() {
+  if (!parquetModulePromise) {
+    parquetModulePromise = import('../../vendor/parquet-wasm/esm/parquet_wasm.js').then(async (mod) => {
+      if (!parquetInitialized) {
+        progress('Loading parquet encoder...');
+        const wasmUrl = new URL('../../vendor/parquet-wasm/esm/parquet_wasm_bg.wasm', self.location.href);
+        await mod.default(wasmUrl);
+        parquetInitialized = true;
+      }
+      return mod;
+    });
+  }
+  return parquetModulePromise;
+}
+
+async function ensureArrowHelpers() {
+  if (!arrowHelpersPromise) {
+    arrowHelpersPromise = Promise.all([
+      import('../parquet/arrowSchema.js'),
+      import('../geo/geoparquetMeta.js')
+    ]).then(([arrowSchema, geoMeta]) => ({ arrowSchema, geoMeta }));
+  }
+  return arrowHelpersPromise;
+}
+
+function crc32(bytes) {
+  const table = crc32.table || (crc32.table = (() => {
+    const tbl = new Uint32Array(256);
+    for (let i = 0; i < 256; i++) {
+      let c = i;
+      for (let k = 0; k < 8; k++) c = c & 1 ? 0xEDB88320 ^ (c >>> 1) : (c >>> 1);
+      tbl[i] = c >>> 0;
+    }
+    return tbl;
+  })());
+  let crc = 0xFFFFFFFF;
+  bytes.forEach((b) => { crc = table[(crc ^ b) & 0xFF] ^ (crc >>> 8); });
+  return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
+function buildZipBlob(files) {
+  const local = []; const central = []; let offset = 0;
+  files.forEach((file) => {
+    const nameBytes = new TextEncoder().encode(file.name);
+    const data = new Uint8Array(file.data);
+    const crc = crc32(data);
+
+    const lh = new Uint8Array(30 + nameBytes.length);
+    const lv = new DataView(lh.buffer);
+    lv.setUint32(0, 0x04034b50, true); lv.setUint16(4, 20, true); lv.setUint32(14, crc, true);
+    lv.setUint32(18, data.length, true); lv.setUint32(22, data.length, true); lv.setUint16(26, nameBytes.length, true);
+    lh.set(nameBytes, 30);
+    local.push(lh, data);
+
+    const ch = new Uint8Array(46 + nameBytes.length);
+    const cv = new DataView(ch.buffer);
+    cv.setUint32(0, 0x02014b50, true); cv.setUint16(4, 20, true); cv.setUint16(6, 20, true);
+    cv.setUint32(16, crc, true); cv.setUint32(20, data.length, true); cv.setUint32(24, data.length, true);
+    cv.setUint16(28, nameBytes.length, true); cv.setUint32(42, offset, true);
+    ch.set(nameBytes, 46);
+    central.push(ch);
+    offset += lh.length + data.length;
+  });
+  const centralSize = central.reduce((s, p) => s + p.length, 0);
+  const end = new Uint8Array(22);
+  const ev = new DataView(end.buffer);
+  ev.setUint32(0, 0x06054b50, true); ev.setUint16(8, files.length, true); ev.setUint16(10, files.length, true);
+  ev.setUint32(12, centralSize, true); ev.setUint32(16, offset, true);
+  return new Blob([...local, ...central, end], { type: 'application/zip' });
 }
 
 function makeSeededRng(seedText) {
   let h = 2166136261 >>> 0;
   const src = String(seedText || 'synthetic-city');
-  for (let i = 0; i < src.length; i++) {
-    h ^= src.charCodeAt(i);
-    h = Math.imul(h, 16777619);
-  }
+  for (let i = 0; i < src.length; i++) { h ^= src.charCodeAt(i); h = Math.imul(h, 16777619); }
   let state = h >>> 0;
-  return () => {
-    state ^= state << 13;
-    state ^= state >>> 17;
-    state ^= state << 5;
-    state >>>= 0;
-    return state / 4294967296;
-  };
+  return () => { state ^= state << 13; state ^= state >>> 17; state ^= state << 5; state >>>= 0; return state / 4294967296; };
 }
-
-const randPick = (rng, items) => items[Math.floor(rng() * items.length)];
-const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
 
 function metersToLonLat(centerLon, centerLat, dx, dy) {
   const degLat = dy / 111320;
   const degLon = dx / (111320 * Math.cos((centerLat * Math.PI) / 180));
   return [centerLon + degLon, centerLat + degLat];
 }
+function toDateStringUTC(d) { return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`; }
 
 function polygonWkb(coords) {
-  const points = coords;
-  const pointCount = points.length;
-  const byteLength = 1 + 4 + 4 + 4 + pointCount * 16;
-  const buf = new ArrayBuffer(byteLength);
-  const v = new DataView(buf);
-  let o = 0;
-  v.setUint8(o, 1); o += 1;
-  v.setUint32(o, 3, true); o += 4;
-  v.setUint32(o, 1, true); o += 4;
-  v.setUint32(o, pointCount, true); o += 4;
-  for (const [x, y] of points) {
-    v.setFloat64(o, x, true); o += 8;
-    v.setFloat64(o, y, true); o += 8;
-  }
+  const count = coords.length; const buf = new ArrayBuffer(1 + 4 + 4 + 4 + count * 16); const v = new DataView(buf); let o = 0;
+  v.setUint8(o, 1); o += 1; v.setUint32(o, 3, true); o += 4; v.setUint32(o, 1, true); o += 4; v.setUint32(o, count, true); o += 4;
+  for (const [x, y] of coords) { v.setFloat64(o, x, true); o += 8; v.setFloat64(o, y, true); o += 8; }
   return new Uint8Array(buf);
 }
 
-function toDateStringUTC(d) {
-  const y = d.getUTCFullYear();
-  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
-  const day = String(d.getUTCDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
-
 function buildInflationSeries(startYear, endYear) {
-  const startDate = new Date(Date.UTC(startYear, 0, 1));
-  const endDate = new Date(Date.UTC(endYear, 0, 1));
-  const monthly = [];
-  let idx = 1;
-  for (let y = startYear; y <= endYear; y++) {
-    for (let m = 0; m < 12; m++) {
-      const d = new Date(Date.UTC(y, m, 1));
-      if (d > endDate) break;
-      const monthlyRate = 0.002 + ((m % 6) * 0.0001);
-      idx *= 1 + monthlyRate;
-      monthly.push({ date: d, idx });
-    }
+  const start = new Date(Date.UTC(startYear, 0, 1));
+  const end = new Date(Date.UTC(endYear, 0, 1));
+  const monthly = []; let idx = 1;
+  for (let y = startYear; y <= endYear; y++) for (let m = 0; m < 12; m++) {
+    const d = new Date(Date.UTC(y, m, 1)); if (d > end) break; const r = 0.002 + ((m % 6) * 0.0001); idx *= (1 + r); monthly.push({ date: d, idx });
   }
-  const monthlyMap = new Map(monthly.map((m) => [toDateStringUTC(m.date), m.idx]));
-  const rows = [];
-  const oneDayMs = 86400000;
-  for (let t = startDate.getTime(); t <= endDate.getTime(); t += oneDayMs) {
-    const d = new Date(t);
-    const cur = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
-    const next = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1));
-    const curIdx = monthlyMap.get(toDateStringUTC(cur)) ?? 1;
-    const nextIdx = monthlyMap.get(toDateStringUTC(next)) ?? curIdx;
-    const span = next.getTime() - cur.getTime() || oneDayMs;
-    const f = clamp((t - cur.getTime()) / span, 0, 1);
-    const startIndexed = curIdx + (nextIdx - curIdx) * f;
-    rows.push({ period: toDateStringUTC(d), start_indexed: startIndexed, end_indexed: 0, correction_factor: 0 });
+  const mMap = new Map(monthly.map((m) => [toDateStringUTC(m.date), m.idx]));
+  const rows = []; const dayMs = 86400000;
+  for (let t = start.getTime(); t <= end.getTime(); t += dayMs) {
+    const d = new Date(t); const cur = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1)); const nxt = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1));
+    const a = mMap.get(toDateStringUTC(cur)) ?? 1; const b = mMap.get(toDateStringUTC(nxt)) ?? a;
+    const f = clamp((t - cur.getTime()) / (nxt.getTime() - cur.getTime() || dayMs), 0, 1);
+    rows.push({ period: toDateStringUTC(d), start_indexed: a + (b - a) * f, end_indexed: 0, correction_factor: 0 });
   }
   const last = rows.length ? rows[rows.length - 1].start_indexed : 1;
-  rows.forEach((r) => {
-    r.end_indexed = r.start_indexed / last;
-    r.correction_factor = 1 / r.end_indexed;
-  });
+  rows.forEach((r) => { r.end_indexed = r.start_indexed / last; r.correction_factor = 1 / r.end_indexed; });
   return { rows, byDate: new Map(rows.map((r) => [r.period, r])) };
-}
-
-function chooseGroupByNeighborhood(rng, neighborhood) {
-  if (neighborhood === 'CBD') return rng() < 0.7 ? 'commercial' : 'multi_family';
-  if (neighborhood === 'inner ring') return randPick(rng, ['single_family', 'multi_family', 'commercial']);
-  if (neighborhood === 'commercial corridors') return randPick(rng, ['commercial', 'single_family']);
-  if (neighborhood === 'industrial sector') return randPick(rng, ['industrial', 'commercial']);
-  if (neighborhood === 'rural outlying') return randPick(rng, ['agricultural', 'single_family']);
-  if (neighborhood === 'exurb') return randPick(rng, ['single_family', 'mobile_home', 'agricultural']);
-  return randPick(rng, ['single_family', 'multi_family', 'mobile_home']);
 }
 
 function neighborhoodForOffset(dx, dy) {
   const dist = Math.sqrt(dx * dx + dy * dy);
   if (Math.abs(dy) < 120 && Math.abs(dx) < 1600) return 'commercial corridors';
   if (dx > 800 && dy < -800) return 'industrial sector';
-  if (dist < 320) return 'CBD';
-  if (dist < 780) return 'inner ring';
-  if (dist < 1300) return 'suburb';
-  if (dist < 1900) return 'exurb';
-  return 'rural outlying';
+  if (dist < 320) return 'CBD'; if (dist < 780) return 'inner ring'; if (dist < 1300) return 'suburb'; if (dist < 1900) return 'exurb'; return 'rural outlying';
+}
+function chooseGroupByNeighborhood(rng, n) {
+  if (n === 'CBD') return rng() < 0.7 ? 'commercial' : 'multi_family';
+  if (n === 'inner ring') return randPick(rng, ['single_family', 'multi_family', 'commercial']);
+  if (n === 'commercial corridors') return randPick(rng, ['commercial', 'single_family']);
+  if (n === 'industrial sector') return randPick(rng, ['industrial', 'commercial']);
+  if (n === 'rural outlying') return randPick(rng, ['agricultural', 'single_family']);
+  if (n === 'exurb') return randPick(rng, ['single_family', 'mobile_home', 'agricultural']);
+  return randPick(rng, ['single_family', 'multi_family', 'mobile_home']);
 }
 
 function buildParcelRecord({ key, centerLon, centerLat, i, j, n, cellM, rng }) {
-  const half = (n - 1) / 2;
-  const dx = (i - half) * cellM;
-  const dy = (j - half) * cellM;
-  const beltFactor = 1 + 0.08 * Math.sin(Math.sqrt(dx * dx + dy * dy) / 350);
-  const width = cellM * (0.85 + rng() * 0.35) * beltFactor;
-  const height = cellM * (0.85 + rng() * 0.35) * (2 - beltFactor);
-  const x0 = dx - width / 2; const x1 = dx + width / 2;
-  const y0 = dy - height / 2; const y1 = dy + height / 2;
-  const p0 = metersToLonLat(centerLon, centerLat, x0, y0);
-  const p1 = metersToLonLat(centerLon, centerLat, x1, y0);
-  const p2 = metersToLonLat(centerLon, centerLat, x1, y1);
-  const p3 = metersToLonLat(centerLon, centerLat, x0, y1);
-  const ring = [p0, p1, p2, p3, p0];
-
+  const half = (n - 1) / 2; const dx = (i - half) * cellM; const dy = (j - half) * cellM;
+  const width = cellM * (0.85 + rng() * 0.35); const height = cellM * (0.85 + rng() * 0.35);
+  const x0 = dx - width / 2; const x1 = dx + width / 2; const y0 = dy - height / 2; const y1 = dy + height / 2;
+  const p0 = metersToLonLat(centerLon, centerLat, x0, y0), p1 = metersToLonLat(centerLon, centerLat, x1, y0), p2 = metersToLonLat(centerLon, centerLat, x1, y1), p3 = metersToLonLat(centerLon, centerLat, x0, y1);
   const neighborhood = neighborhoodForOffset(dx, dy);
   const model_group = chooseGroupByNeighborhood(rng, neighborhood);
   const bldg_type = randPick(rng, BLDG_TYPE_BY_GROUP[model_group]);
   const zoning = randPick(rng, ZONING_BY_GROUP[model_group]);
   const land_type = randPick(rng, LAND_TYPE_BY_GROUP[model_group]);
-
   const land_area_sqft = Math.max(1000, Math.round((width * height) * 10.7639));
-  const stories = model_group === 'commercial' ? (rng() < 0.35 ? 2 : 1) : model_group === 'multi_family' ? (rng() < 0.5 ? 2 : 3) : 1;
+  const stories = model_group === 'multi_family' ? 2 : 1;
   const footprint = model_group === 'agricultural' ? 0 : Math.round(land_area_sqft * (0.15 + rng() * 0.4));
-  const finished = Math.round(footprint * Math.max(1, stories) * (0.88 + rng() * 0.18));
-  const units = model_group === 'multi_family' ? (bldg_type === 'MF_DUPLEX' ? 2 : bldg_type === 'MF_TRIPLEX' ? 3 : 8 + Math.floor(rng() * 24)) : 0;
-  const beds = model_group === 'single_family' ? Math.max(1, Math.round(finished / 700)) : model_group === 'multi_family' ? Math.max(0, Math.round(units * 1.6)) : 0;
-  const baths = model_group === 'single_family' ? Math.max(1, Math.round(beds * 0.75)) : model_group === 'multi_family' ? Math.max(0, Math.round(units * 1.2)) : 0;
-  const yearBuilt = 1940 + Math.floor(rng() * 80);
-
+  const finished = Math.round(footprint * stories * (0.9 + rng() * 0.2));
   return {
-    key,
-    geometry: { type: 'Polygon', coordinates: [ring] },
-    longitude: (p0[0] + p2[0]) / 2,
-    latitude: (p0[1] + p2[1]) / 2,
-    neighborhood,
-    model_group,
-    zoning,
-    land_type,
-    land_area_sqft,
-    bldg_type,
-    bldg_area_footprint_sqft: footprint,
-    bldg_area_finished_sqft: finished,
-    bldg_stories: footprint > 0 ? stories : 0,
-    bldg_units: footprint > 0 ? units : 0,
-    bldg_rooms_bed: footprint > 0 ? beds : 0,
-    bldg_rooms_bath: footprint > 0 ? baths : 0,
-    bldg_quality_num: footprint > 0 ? 2 + Math.floor(rng() * 4) : 0,
-    bldg_condition_num: footprint > 0 ? 45 + Math.floor(rng() * 45) : 0,
-    bldg_year_built: footprint > 0 ? yearBuilt : null,
-    bldg_year_renovated: null
+    key, geometry: { type: 'Polygon', coordinates: [[p0, p1, p2, p3, p0]] }, longitude: (p0[0] + p2[0]) / 2, latitude: (p0[1] + p2[1]) / 2,
+    neighborhood, model_group, zoning, land_type, land_area_sqft, bldg_type,
+    bldg_area_footprint_sqft: footprint, bldg_area_finished_sqft: finished, bldg_stories: footprint > 0 ? stories : 0,
+    bldg_units: model_group === 'multi_family' ? 2 + Math.floor(rng() * 12) : 0, bldg_rooms_bed: footprint > 0 ? Math.max(0, Math.round(finished / 700)) : 0,
+    bldg_rooms_bath: footprint > 0 ? Math.max(0, Math.round(finished / 1200)) : 0,
+    bldg_quality_num: footprint > 0 ? 2 + Math.floor(rng() * 4) : 0, bldg_condition_num: footprint > 0 ? 45 + Math.floor(rng() * 45) : 0,
+    bldg_year_built: footprint > 0 ? 1940 + Math.floor(rng() * 80) : null, bldg_year_renovated: null
   };
 }
 
-function calcValues(parcel) {
-  const landBase = parcel.land_area_sqft * (parcel.neighborhood === 'CBD' ? 42 : parcel.neighborhood === 'inner ring' ? 21 : 9);
-  const imprBase = parcel.bldg_area_finished_sqft * (parcel.model_group === 'commercial' ? 180 : parcel.model_group === 'industrial' ? 115 : 140);
-  const qualityAdj = 1 + (parcel.bldg_quality_num || 0) * 0.07;
-  const conditionAdj = 0.2 + (parcel.bldg_condition_num || 0) / 125;
-  const platonic_land_value = Math.round(landBase);
-  const platonic_impr_value = Math.round(imprBase * qualityAdj * conditionAdj);
-  return { platonic_land_value, platonic_impr_value, platonic_market_value: platonic_land_value + platonic_impr_value };
-}
+const makeFeature = (row) => ({ type: 'Feature', geometry: row.geometry, properties: Object.fromEntries(Object.entries(row).filter(([k]) => k !== 'geometry')) });
 
-function invalidateSalePrice(rng, nominalPriceList, platonic) {
-  if (rng() < 0.5) return randPick(rng, nominalPriceList);
-  const rounded = Math.round((rng() * 999) / 5) * 5;
-  return Math.max(1, rounded);
-}
-
-function makeGeoFeature(row, includeGeometry = true) {
-  const props = { ...row };
-  delete props.geometry;
-  return {
-    type: 'Feature',
-    geometry: includeGeometry ? row.geometry : null,
-    properties: props
-  };
+function calcValues(p) {
+  const land = Math.round(p.land_area_sqft * (p.neighborhood === 'CBD' ? 42 : p.neighborhood === 'inner ring' ? 21 : 9));
+  const impr = Math.round(p.bldg_area_finished_sqft * (p.model_group === 'commercial' ? 180 : p.model_group === 'industrial' ? 115 : 140) * (1 + (p.bldg_quality_num || 0) * 0.07) * (0.2 + (p.bldg_condition_num || 0) / 125));
+  return { platonic_land_value: land, platonic_impr_value: impr, platonic_market_value: land + impr };
 }
 
 function generateSimulation(config) {
   const rng = makeSeededRng(config.seed);
-  const parcelCount = config.parcelCount;
-  const n = Math.ceil(Math.sqrt(parcelCount));
-  const cellM = 70;
-  const universe = [];
-
+  const universe = []; const n = Math.ceil(Math.sqrt(config.parcelCount)); const cellM = 70;
   progress('Generating parcel fabric...');
-  for (let idx = 0; idx < parcelCount; idx++) {
-    const i = idx % n;
-    const j = Math.floor(idx / n);
-    const key = String(idx + 1).padStart(5, '0');
-    const parcel = buildParcelRecord({ key, centerLon: config.centerLon, centerLat: config.centerLat, i, j, n, cellM, rng });
-    universe.push(parcel);
+  for (let idx = 0; idx < config.parcelCount; idx++) {
+    const i = idx % n, j = Math.floor(idx / n), key = String(idx + 1).padStart(5, '0');
+    universe.push(buildParcelRecord({ key, centerLon: config.centerLon, centerLat: config.centerLat, i, j, n, cellM, rng }));
   }
-  send('milestone', { featureCollection: { type: 'FeatureCollection', features: universe.slice(0, 4500).map((r) => makeGeoFeature(r)) } });
+  send('milestone', { featureCollection: { type: 'FeatureCollection', features: universe.slice(0, 4500).map(makeFeature) } });
 
   progress('Building inflation series...');
   const inflation = buildInflationSeries(config.startYear, config.endYear);
-
   progress('Simulating yearly events and sales...');
-  const salesPlatonic = [];
-  const salesObserved = [];
 
+  const sales = []; const sales_platonic = [];
   for (let year = config.startYear; year <= config.endYear; year++) {
     for (const p of universe) {
-      if (p.bldg_area_finished_sqft > 0) {
-        p.bldg_condition_num = clamp(p.bldg_condition_num - (0.5 + rng() * 1.4), 0, 100);
-      }
-      if (p.bldg_area_finished_sqft > 0 && rng() < 0.008) {
-        p.bldg_area_finished_sqft = 0; p.bldg_area_footprint_sqft = 0; p.bldg_quality_num = 0; p.bldg_condition_num = 0;
-        p.bldg_type = 'NONE'; p.bldg_stories = 0; p.bldg_units = 0; p.bldg_rooms_bed = 0; p.bldg_rooms_bath = 0; p.bldg_year_built = null; p.bldg_year_renovated = null;
-      } else if (p.bldg_area_finished_sqft === 0 && rng() < 0.015) {
-        p.bldg_type = randPick(rng, BLDG_TYPE_BY_GROUP[p.model_group]);
-        p.bldg_stories = p.model_group === 'multi_family' ? 2 : 1;
-        p.bldg_area_footprint_sqft = Math.max(450, Math.round(p.land_area_sqft * (0.12 + rng() * 0.25)));
-        p.bldg_area_finished_sqft = Math.round(p.bldg_area_footprint_sqft * p.bldg_stories * (0.9 + rng() * 0.2));
-        p.bldg_quality_num = 2 + Math.floor(rng() * 3);
-        p.bldg_condition_num = 65 + Math.floor(rng() * 30);
-        p.bldg_year_built = year;
-      } else if (p.bldg_area_finished_sqft > 0 && rng() < 0.02) {
-        p.bldg_condition_num = clamp(p.bldg_condition_num + 8 + rng() * 20, 0, 100);
-        p.bldg_year_renovated = year;
-      }
-
-      const saleProb = config.saleProbabilities[p.model_group] ?? 0.05;
-      if (rng() > saleProb) continue;
-      const month = Math.floor(rng() * 12);
-      const day = 1 + Math.floor(rng() * 28);
-      const saleDate = toDateStringUTC(new Date(Date.UTC(year, month, day)));
+      if (p.bldg_area_finished_sqft > 0) p.bldg_condition_num = clamp(p.bldg_condition_num - (0.5 + rng() * 1.4), 0, 100);
+      const prob = config.saleProbabilities[p.model_group] ?? 0.05;
+      if (rng() > prob) continue;
+      const saleDate = toDateStringUTC(new Date(Date.UTC(year, Math.floor(rng() * 12), 1 + Math.floor(rng() * 28))));
       const infl = inflation.byDate.get(saleDate) || inflation.rows[inflation.rows.length - 1];
-      const values = calcValues(p);
-      const trendAdj = infl.start_indexed;
-      const platonicSale = Math.max(1, Math.round(values.platonic_market_value * trendAdj));
-      const noise = Math.round((rng() - 0.5) * 0.06 * platonicSale);
-      const truePrice = Math.max(1, platonicSale + noise);
-
+      const vals = calcValues(p);
+      const platonicPrice = Math.max(1, Math.round(vals.platonic_market_value * infl.start_indexed));
+      const noise = Math.round((rng() - 0.5) * 0.06 * platonicPrice);
+      const truePrice = Math.max(1, platonicPrice + noise);
       const key_sale = `${p.key}---${saleDate}`;
-      const platonicRow = {
-        ...p,
-        key_sale,
-        sale_date: saleDate,
-        sale_type: 'VALID',
-        valid_sale: true,
-        sale_noise: noise,
-        sale_price: truePrice,
-        vacant_sale: p.bldg_area_finished_sqft === 0,
-        inflation_index: infl.start_indexed,
-        ...values
-      };
-
-      const observedRow = { ...platonicRow };
+      const base = { ...p, key_sale, sale_date: saleDate, sale_type: 'VALID', valid_sale: true, sale_noise: noise, sale_price: truePrice, vacant_sale: p.bldg_area_finished_sqft === 0, inflation_index: infl.start_indexed, ...vals };
+      const obs = { ...base };
       if (rng() < config.invalidPct / 100) {
-        observedRow.sale_type = 'NOT_ARMS_LENGTH';
-        observedRow.sale_price = invalidateSalePrice(rng, config.nominalPriceList, truePrice);
-        observedRow.valid_sale = true;
-        platonicRow.sale_type = 'NOT_ARMS_LENGTH';
-        platonicRow.valid_sale = false;
+        obs.sale_type = 'NOT_ARMS_LENGTH';
+        obs.sale_price = rng() < 0.5 ? randPick(rng, config.nominalPriceList) : Math.max(1, Math.round((rng() * 999) / 5) * 5);
+        obs.valid_sale = true;
+        base.sale_type = 'NOT_ARMS_LENGTH';
+        base.valid_sale = false;
       }
-
-      salesPlatonic.push(platonicRow);
-      salesObserved.push(observedRow);
+      sales_platonic.push(base); sales.push(obs);
     }
-
     if ((year - config.startYear) % config.repaintYears === 0 || year === config.endYear) {
-      send('milestone', { featureCollection: { type: 'FeatureCollection', features: universe.slice(0, 4500).map((r) => makeGeoFeature(r)) } });
+      send('milestone', { featureCollection: { type: 'FeatureCollection', features: universe.slice(0, 4500).map(makeFeature) } });
       log(`Milestone repaint: year ${year}.`);
     }
   }
-
-  const preview = { type: 'FeatureCollection', features: universe.slice(0, 4500).map((r) => makeGeoFeature(r)) };
-  return {
-    config,
-    crs: 'EPSG:4326',
-    universeCount: universe.length,
-    salesCount: salesObserved.length,
-    preview,
-    universe,
-    sales: salesObserved,
-    sales_platonic: salesPlatonic,
-    inflation: inflation.rows
-  };
+  return { config, crs: 'EPSG:4326', universeCount: universe.length, salesCount: sales.length, preview: { type: 'FeatureCollection', features: universe.slice(0, 4500).map(makeFeature) }, universe, sales, sales_platonic, inflation: inflation.rows };
 }
 
-function inferType(v) {
-  if (v == null) return 'string';
-  if (typeof v === 'boolean') return 'bool';
-  if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float';
-  return 'string';
-}
-
-function arrowType(Arrow, kind) {
-  if (kind === 'bool') return new Arrow.Bool();
-  if (kind === 'int') return new Arrow.Int32();
-  if (kind === 'float') return new Arrow.Float64();
-  return new Arrow.Utf8();
-}
-
+function inferType(v) { if (v == null) return 'string'; if (typeof v === 'boolean') return 'bool'; if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float'; return 'string'; }
+function arrowType(Arrow, k) { if (k === 'bool') return new Arrow.Bool(); if (k === 'int') return new Arrow.Int32(); if (k === 'float') return new Arrow.Float64(); return new Arrow.Utf8(); }
 function rowToFields(rows) {
-  const keys = new Set();
-  rows.forEach((r) => Object.keys(r).forEach((k) => { if (k !== 'geometry') keys.add(k); }));
-  return Array.from(keys).map((name) => {
-    const sample = rows.find((r) => r[name] != null)?.[name] ?? null;
-    return { name, kind: inferType(sample) };
-  });
+  const keys = new Set(); rows.forEach((r) => Object.keys(r).forEach((k) => { if (k !== 'geometry') keys.add(k); }));
+  return Array.from(keys).map((name) => ({ name, kind: inferType(rows.find((r) => r[name] != null)?.[name] ?? null) }));
 }
 
 async function toGeoParquetBytes(rows) {
-  const Arrow = await import('../../vendor/apache-arrow.js');
+  const Arrow = self.Arrow;
+  if (!Arrow) throw new Error('Arrow library failed to load.');
+  const { arrowSchema, geoMeta } = await ensureArrowHelpers();
+  const { makeArrowTable, tableToIPC } = arrowSchema;
+  const { createGeoMetadata } = geoMeta;
+
   const fields = rowToFields(rows);
-  const spatialRef = { wkid: 4326, latestWkid: 4326, wkt: null };
-  const geoMetadata = await createGeoMetadata(spatialRef, 'Polygon');
+  const geoMetadata = await createGeoMetadata({ wkid: 4326, latestWkid: 4326, wkt: null }, 'Polygon');
   const schema = new Arrow.Schema([
     new Arrow.Field('geometry', new Arrow.Binary(), true),
     ...fields.map((f) => new Arrow.Field(f.name, arrowType(Arrow, f.kind), true))
   ], new Map([['geo', JSON.stringify(geoMetadata)]]));
 
   const geomBuilder = Arrow.makeBuilder({ type: new Arrow.Binary(), nullValues: [null, undefined] });
-  const fieldBuilders = new Map(fields.map((f) => [f.name, Arrow.makeBuilder({ type: arrowType(Arrow, f.kind), nullValues: [null, undefined] })]));
+  const builders = new Map(fields.map((f) => [f.name, Arrow.makeBuilder({ type: arrowType(Arrow, f.kind), nullValues: [null, undefined] })]));
 
-  for (const row of rows) {
-    const ring = row.geometry.coordinates[0];
-    geomBuilder.append(polygonWkb(ring));
-    for (const f of fields) {
-      const v = row[f.name] == null ? null : row[f.name];
-      fieldBuilders.get(f.name).append(v);
-    }
-  }
-
+  rows.forEach((row) => {
+    geomBuilder.append(polygonWkb(row.geometry.coordinates[0]));
+    fields.forEach((f) => builders.get(f.name).append(row[f.name] == null ? null : row[f.name]));
+  });
   geomBuilder.finish();
-  const geomVector = geomBuilder.toVector();
-  const vectors = [geomVector];
-  for (const f of fields) {
-    const b = fieldBuilders.get(f.name);
-    b.finish();
-    vectors.push(b.toVector());
-  }
+  const vectors = [geomBuilder.toVector()];
+  fields.forEach((f) => { const b = builders.get(f.name); b.finish(); vectors.push(b.toVector()); });
 
   const table = makeArrowTable(Arrow, schema, vectors);
   const ipc = tableToIPC(Arrow, table, 'stream');
+  const parquetModule = await ensureParquetModule();
   const wasmTable = parquetModule.Table.fromIPCStream(ipc);
   const writerProps = new parquetModule.WriterPropertiesBuilder()
     .setCompression(parquetModule.Compression.ZSTD)
     .setKeyValueMetadata(new Map([['geo', JSON.stringify(geoMetadata)]]))
     .build();
-  const bytes = parquetModule.writeParquet(wasmTable, writerProps);
-  return bytes;
+  return parquetModule.writeParquet(wasmTable, writerProps);
 }
 
 async function buildExportZip(payload) {
-  await ensureParquetReady();
   progress('Encoding universe.geoparquet...');
   const universeBytes = await toGeoParquetBytes(payload.universe);
   progress('Encoding sales.geoparquet...');
@@ -403,50 +287,34 @@ async function buildExportZip(payload) {
   progress('Encoding sales_platonic.geoparquet...');
   const platBytes = await toGeoParquetBytes(payload.sales_platonic);
   progress('Encoding inflation.csv...');
-
-  const csvHeader = 'period,start_indexed,end_indexed,correction_factor';
-  const csvBody = payload.inflation.map((r) => `${r.period},${r.start_indexed},${r.end_indexed},${r.correction_factor}`).join('\n');
-  const inflationBytes = textEncoder.encode(`${csvHeader}\n${csvBody}`);
-
+  const csv = ['period,start_indexed,end_indexed,correction_factor', ...payload.inflation.map((r) => `${r.period},${r.start_indexed},${r.end_indexed},${r.correction_factor}`)].join('\n');
+  const inflationBytes = textEncoder.encode(csv);
   const metadata = {
-    seed: payload.config.seed,
-    app_version: 'mvp-0.1',
-    crs: 'EPSG:4326',
+    seed: payload.config.seed, app_version: 'mvp-0.1', crs: 'EPSG:4326',
     center: { city_name: payload.config.cityName, latitude: payload.config.centerLat, longitude: payload.config.centerLon },
-    start_year: payload.config.startYear,
-    end_year: payload.config.endYear,
-    parcel_count: payload.config.parcelCount,
-    repaint_interval_years: payload.config.repaintYears,
-    invalid_pct: payload.config.invalidPct,
-    sale_probabilities: payload.config.saleProbabilities,
-    nominal_price_list: payload.config.nominalPriceList
+    start_year: payload.config.startYear, end_year: payload.config.endYear, parcel_count: payload.config.parcelCount,
+    repaint_interval_years: payload.config.repaintYears, invalid_pct: payload.config.invalidPct,
+    sale_probabilities: payload.config.saleProbabilities, nominal_price_list: payload.config.nominalPriceList
   };
   const metaBytes = textEncoder.encode(JSON.stringify(metadata, null, 2));
-
-  const zipBlob = buildZipBlob([
+  return buildZipBlob([
     { name: 'universe.geoparquet', data: universeBytes },
     { name: 'sales.geoparquet', data: salesBytes },
     { name: 'sales_platonic.geoparquet', data: platBytes },
     { name: 'inflation.csv', data: inflationBytes },
     { name: 'metadata.json', data: metaBytes }
   ]);
-
-  return zipBlob;
 }
 
 self.onmessage = async (event) => {
   const { mode, config, payload } = event.data || {};
   try {
-    if (mode === 'generate') {
-      const result = generateSimulation(config);
-      send('success', result);
-      return;
-    }
+    if (mode === 'generate') return send('success', generateSimulation(config));
     if (mode === 'export') {
       const zipBlob = await buildExportZip(payload);
-      send('zip', { zipBlob, filename: `synthetic_city_${new Date().toISOString().slice(0, 10)}.zip` });
+      return send('zip', { zipBlob, filename: `synthetic_city_${new Date().toISOString().slice(0, 10)}.zip` });
     }
   } catch (err) {
-    send('error', { message: err?.message || String(err) });
+    send('error', { message: err?.message || String(err), stack: err?.stack || null });
   }
 };

--- a/util/src/apps/syntheticWorker.js
+++ b/util/src/apps/syntheticWorker.js
@@ -3,7 +3,7 @@ import { makeArrowTable, tableToIPC } from '../parquet/arrowSchema.js';
 import { createGeoMetadata } from '../geo/geoparquetMeta.js';
 import * as parquetModule from '../../vendor/parquet-wasm/esm/parquet_wasm.js';
 
-await parquetModule.default(new URL('../../vendor/parquet-wasm/esm/parquet_wasm_bg.wasm', import.meta.url));
+let parquetReady = false;
 
 const MODEL_GROUPS = ['single_family', 'multi_family', 'commercial', 'industrial', 'mobile_home', 'agricultural'];
 
@@ -29,6 +29,30 @@ const textEncoder = new TextEncoder();
 const send = (type, payload) => self.postMessage({ type, payload });
 const log = (message) => send('log', { message });
 const progress = (message) => send('progress', { message });
+
+async function ensureParquetReady() {
+  if (parquetReady) return;
+  progress('Loading parquet encoder...');
+  await parquetModule.default(new URL('../../vendor/parquet-wasm/esm/parquet_wasm_bg.wasm', import.meta.url));
+  parquetReady = true;
+}
+
+function makeSeededRng(seedText) {
+  let h = 2166136261 >>> 0;
+  const src = String(seedText || 'synthetic-city');
+  for (let i = 0; i < src.length; i++) {
+    h ^= src.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  let state = h >>> 0;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    return state / 4294967296;
+  };
+}
 
 const randPick = (rng, items) => items[Math.floor(rng() * items.length)];
 const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
@@ -202,7 +226,7 @@ function makeGeoFeature(row, includeGeometry = true) {
 }
 
 function generateSimulation(config) {
-  const rng = self.Math.seedrandom(config.seed);
+  const rng = makeSeededRng(config.seed);
   const parcelCount = config.parcelCount;
   const n = Math.ceil(Math.sqrt(parcelCount));
   const cellM = 70;
@@ -371,6 +395,7 @@ async function toGeoParquetBytes(rows) {
 }
 
 async function buildExportZip(payload) {
+  await ensureParquetReady();
   progress('Encoding universe.geoparquet...');
   const universeBytes = await toGeoParquetBytes(payload.universe);
   progress('Encoding sales.geoparquet...');

--- a/util/src/apps/syntheticWorker.js
+++ b/util/src/apps/syntheticWorker.js
@@ -259,11 +259,20 @@ function buildRoadsAndBlocks(config, rng) {
   addRoad(roads, { orientation: 'v', fixed: beltMin.xMin - ROAD_BUFFER_M / 2, start: beltMin.yMin - ROAD_BUFFER_M / 2, end: beltMax.yMax + ROAD_BUFFER_M / 2, road_class: 'beltway', width_m: BELTWAY_WIDTH_M, year_paved: 1940, name: 'West Beltway' });
   addRoad(roads, { orientation: 'v', fixed: beltMax.xMax + ROAD_BUFFER_M / 2, start: beltMin.yMin - ROAD_BUFFER_M / 2, end: beltMax.yMax + ROAD_BUFFER_M / 2, road_class: 'beltway', width_m: BELTWAY_WIDTH_M, year_paved: 1940, name: 'East Beltway' });
 
-  const highwayOffset = beltMax.xMax + ROAD_BUFFER_M / 2;
-  const highwayOffsetY = beltMax.yMax + ROAD_BUFFER_M / 2;
+  // Highways connect at beltway side midpoints and do not pass through the city core.
+  const beltTopY = beltMax.yMax + ROAD_BUFFER_M / 2;
+  const beltBottomY = beltMin.yMin - ROAD_BUFFER_M / 2;
+  const beltLeftX = beltMin.xMin - ROAD_BUFFER_M / 2;
+  const beltRightX = beltMax.xMax + ROAD_BUFFER_M / 2;
   const ext = 80 * GRID_PITCH_M;
-  addRoad(roads, { orientation: 'v', fixed: highwayOffset, start: -ext, end: ext, road_class: 'highway', width_m: HIGHWAY_WIDTH_M, year_paved: 1940, name: 'N/S Highway' });
-  addRoad(roads, { orientation: 'h', fixed: highwayOffsetY, start: -ext, end: ext, road_class: 'highway', width_m: HIGHWAY_WIDTH_M, year_paved: 1940, name: 'E/W Highway' });
+
+  // N/S highway: two segments touching top and bottom beltway midpoints.
+  addRoad(roads, { orientation: 'v', fixed: 0, start: beltTopY, end: ext, road_class: 'highway', width_m: HIGHWAY_WIDTH_M, year_paved: 1940, name: 'N/S Highway' });
+  addRoad(roads, { orientation: 'v', fixed: 0, start: -ext, end: beltBottomY, road_class: 'highway', width_m: HIGHWAY_WIDTH_M, year_paved: 1940, name: 'N/S Highway' });
+
+  // E/W highway: two segments touching west and east beltway midpoints.
+  addRoad(roads, { orientation: 'h', fixed: 0, start: -ext, end: beltLeftX, road_class: 'highway', width_m: HIGHWAY_WIDTH_M, year_paved: 1940, name: 'E/W Highway' });
+  addRoad(roads, { orientation: 'h', fixed: 0, start: beltRightX, end: ext, road_class: 'highway', width_m: HIGHWAY_WIDTH_M, year_paved: 1940, name: 'E/W Highway' });
 
   for (let year = 1941; year <= endYear; year++) {
     const budget = Math.max(0, Math.round(FRONTIER_BUDGET_INITIAL * Math.pow(1 + FRONTIER_BUDGET_GROWTH, year - 1940)));

--- a/util/src/apps/syntheticWorker.js
+++ b/util/src/apps/syntheticWorker.js
@@ -1,6 +1,20 @@
 /* global self */
 importScripts('../../vendor/apache-arrow.js');
 
+const BLOCK_SIZE_M = 100;
+const ROAD_BUFFER_M = 10;
+const GRID_PITCH_M = BLOCK_SIZE_M + ROAD_BUFFER_M;
+const LOCAL_ROAD_WIDTH_M = 2.5;
+const ARTERIAL_WIDTH_M = 6;
+const BELTWAY_WIDTH_M = 15;
+const HIGHWAY_WIDTH_M = 50;
+const INITIAL_HALF_BLOCKS = 10; // 20x20 blocks
+const CBD_HALF_BLOCKS = 3; // 6x6
+const ARTERIAL_CADENCE = 4;
+const FRONTIER_BUDGET_INITIAL = 18;
+const FRONTIER_BUDGET_GROWTH = 0.015;
+const SF_ARTERIAL_PENALTY = 0.8;
+
 const MODEL_GROUPS = ['single_family', 'multi_family', 'commercial', 'industrial', 'mobile_home', 'agricultural'];
 const BLDG_TYPE_BY_GROUP = {
   single_family: ['SF_RANCH', 'SF_TWO_STORY', 'SF_TOWNHOUSE'],
@@ -10,18 +24,45 @@ const BLDG_TYPE_BY_GROUP = {
   mobile_home: ['MH_SINGLE_WIDE', 'MH_DOUBLE_WIDE', 'MH_PARK_PAD'],
   agricultural: ['AG_ROW_CROP', 'AG_PASTURE', 'AG_FARMSTEAD']
 };
-const ZONING_BY_GROUP = {
-  single_family: ['R1', 'R2'], multi_family: ['R3', 'R4'], commercial: ['C1', 'C2'], industrial: ['I1', 'I2'], mobile_home: ['R-MH'], agricultural: ['AG']
+const ZONING_ALLOWED = {
+  R1: ['single_family', 'mobile_home'],
+  R2: ['single_family', 'mobile_home'],
+  R3: ['single_family', 'multi_family', 'mobile_home'],
+  R4: ['single_family', 'multi_family', 'mobile_home'],
+  C1: ['commercial', 'multi_family'],
+  C2: ['commercial', 'multi_family'],
+  I1: ['industrial', 'commercial'],
+  I2: ['industrial', 'commercial'],
+  MX: ['commercial', 'multi_family'],
+  AG: ['agricultural', 'single_family']
+};
+const ZONING_WEIGHTS = {
+  R1: { single_family: 0.85, mobile_home: 0.15 },
+  R2: { single_family: 0.8, mobile_home: 0.2 },
+  R3: { multi_family: 0.45, single_family: 0.45, mobile_home: 0.1 },
+  R4: { multi_family: 0.65, single_family: 0.25, mobile_home: 0.1 },
+  C1: { commercial: 0.7, multi_family: 0.3 },
+  C2: { commercial: 0.8, multi_family: 0.2 },
+  I1: { industrial: 0.75, commercial: 0.25 },
+  I2: { industrial: 0.85, commercial: 0.15 },
+  MX: { commercial: 0.55, multi_family: 0.45 },
+  AG: { agricultural: 0.85, single_family: 0.15 }
 };
 const LAND_TYPE_BY_GROUP = {
-  single_family: ['residential'], multi_family: ['residential'], commercial: ['commercial'], industrial: ['industrial'], mobile_home: ['residential'], agricultural: ['agricultural']
+  single_family: 'residential', multi_family: 'residential', commercial: 'commercial', industrial: 'industrial', mobile_home: 'residential', agricultural: 'agricultural'
 };
+const MIN_PARCEL_ACRES = {
+  single_family: 0.03, multi_family: 0.10, commercial: 0.25, industrial: 1, mobile_home: 0.03, agricultural: 2
+};
+const MAX_PARCEL_ACRES = {
+  single_family: 20, multi_family: 50, commercial: 100, industrial: 500, mobile_home: 20, agricultural: 100000
+};
+const FRUIT_VEG_NAMES = ['Apple', 'Plum', 'Pear', 'Peach', 'Lemon', 'Lime', 'Onion', 'Carrot', 'Turnip', 'Celery', 'Pepper', 'Tomato', 'Potato', 'Grape', 'Berry', 'Kiwi'];
 
 const textEncoder = new TextEncoder();
 const send = (type, payload) => self.postMessage({ type, payload });
 const log = (message) => send('log', { message });
 const progress = (message) => send('progress', { message });
-const randPick = (rng, items) => items[Math.floor(rng() * items.length)];
 const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
 
 let parquetModulePromise = null;
@@ -33,8 +74,7 @@ async function ensureParquetModule() {
     parquetModulePromise = import('../../vendor/parquet-wasm/esm/parquet_wasm.js').then(async (mod) => {
       if (!parquetInitialized) {
         progress('Loading parquet encoder...');
-        const wasmUrl = new URL('../../vendor/parquet-wasm/esm/parquet_wasm_bg.wasm', self.location.href);
-        await mod.default(wasmUrl);
+        await mod.default(new URL('../../vendor/parquet-wasm/esm/parquet_wasm_bg.wasm', self.location.href));
         parquetInitialized = true;
       }
       return mod;
@@ -45,12 +85,476 @@ async function ensureParquetModule() {
 
 async function ensureArrowHelpers() {
   if (!arrowHelpersPromise) {
-    arrowHelpersPromise = Promise.all([
-      import('../parquet/arrowSchema.js'),
-      import('../geo/geoparquetMeta.js')
-    ]).then(([arrowSchema, geoMeta]) => ({ arrowSchema, geoMeta }));
+    arrowHelpersPromise = Promise.all([import('../parquet/arrowSchema.js'), import('../geo/geoparquetMeta.js')]).then(([arrowSchema, geoMeta]) => ({ arrowSchema, geoMeta }));
   }
   return arrowHelpersPromise;
+}
+
+function makeSeededRng(seedText) {
+  let h = 2166136261 >>> 0;
+  const src = String(seedText || 'synthetic-city');
+  for (let i = 0; i < src.length; i++) { h ^= src.charCodeAt(i); h = Math.imul(h, 16777619); }
+  let state = h >>> 0;
+  return () => { state ^= state << 13; state ^= state >>> 17; state ^= state << 5; state >>>= 0; return state / 4294967296; };
+}
+
+const randPick = (rng, items) => items[Math.floor(rng() * items.length)];
+function weightedPick(rng, weightsObj) {
+  const entries = Object.entries(weightsObj);
+  let total = 0; entries.forEach(([, w]) => { total += w; });
+  let t = rng() * total;
+  for (const [k, w] of entries) { t -= w; if (t <= 0) return k; }
+  return entries[0][0];
+}
+
+function metersToLonLat(centerLon, centerLat, dx, dy) {
+  const degLat = dy / 111320;
+  const degLon = dx / (111320 * Math.cos((centerLat * Math.PI) / 180));
+  return [centerLon + degLon, centerLat + degLat];
+}
+const toDateStringUTC = (d) => `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+
+function polygonWkb(coords) {
+  const count = coords.length;
+  const buf = new ArrayBuffer(1 + 4 + 4 + 4 + count * 16);
+  const v = new DataView(buf);
+  let o = 0;
+  v.setUint8(o, 1); o += 1;
+  v.setUint32(o, 3, true); o += 4;
+  v.setUint32(o, 1, true); o += 4;
+  v.setUint32(o, count, true); o += 4;
+  for (const [x, y] of coords) { v.setFloat64(o, x, true); o += 8; v.setFloat64(o, y, true); o += 8; }
+  return new Uint8Array(buf);
+}
+function lineWkb(coords) {
+  const count = coords.length;
+  const buf = new ArrayBuffer(1 + 4 + 4 + count * 16);
+  const v = new DataView(buf);
+  let o = 0;
+  v.setUint8(o, 1); o += 1;
+  v.setUint32(o, 2, true); o += 4;
+  v.setUint32(o, count, true); o += 4;
+  for (const [x, y] of coords) { v.setFloat64(o, x, true); o += 8; v.setFloat64(o, y, true); o += 8; }
+  return new Uint8Array(buf);
+}
+
+function blockBounds(i, j) {
+  const xMin = i * GRID_PITCH_M - BLOCK_SIZE_M / 2;
+  const xMax = i * GRID_PITCH_M + BLOCK_SIZE_M / 2;
+  const yMin = j * GRID_PITCH_M - BLOCK_SIZE_M / 2;
+  const yMax = j * GRID_PITCH_M + BLOCK_SIZE_M / 2;
+  return { xMin, xMax, yMin, yMax };
+}
+
+function roadKey(orientation, fixed, min, max) {
+  return `${orientation}|${fixed}|${Math.min(min, max)}|${Math.max(min, max)}`;
+}
+
+function addRoad(roadsMap, r) {
+  const k = roadKey(r.orientation, r.fixed, r.start, r.end);
+  const existing = roadsMap.get(k);
+  if (!existing || r.width_m > existing.width_m) roadsMap.set(k, r);
+}
+
+function paveBlock(roadsMap, i, j, year, roadClass = 'local') {
+  const b = blockBounds(i, j);
+  const width = roadClass === 'arterial' ? ARTERIAL_WIDTH_M : LOCAL_ROAD_WIDTH_M;
+  addRoad(roadsMap, { orientation: 'h', fixed: b.yMin - ROAD_BUFFER_M / 2, start: b.xMin - ROAD_BUFFER_M / 2, end: b.xMax + ROAD_BUFFER_M / 2, road_class: roadClass, width_m: width, year_paved: year });
+  addRoad(roadsMap, { orientation: 'h', fixed: b.yMax + ROAD_BUFFER_M / 2, start: b.xMin - ROAD_BUFFER_M / 2, end: b.xMax + ROAD_BUFFER_M / 2, road_class: roadClass, width_m: width, year_paved: year });
+  addRoad(roadsMap, { orientation: 'v', fixed: b.xMin - ROAD_BUFFER_M / 2, start: b.yMin - ROAD_BUFFER_M / 2, end: b.yMax + ROAD_BUFFER_M / 2, road_class: roadClass, width_m: width, year_paved: year });
+  addRoad(roadsMap, { orientation: 'v', fixed: b.xMax + ROAD_BUFFER_M / 2, start: b.yMin - ROAD_BUFFER_M / 2, end: b.yMax + ROAD_BUFFER_M / 2, road_class: roadClass, width_m: width, year_paved: year });
+}
+
+function buildInflationSeries(startYear, endYear) {
+  const start = new Date(Date.UTC(startYear, 0, 1));
+  const end = new Date(Date.UTC(endYear, 0, 1));
+  const monthly = [];
+  let idx = 1;
+  for (let y = startYear; y <= endYear; y++) {
+    for (let m = 0; m < 12; m++) {
+      const d = new Date(Date.UTC(y, m, 1));
+      if (d > end) break;
+      const macro = 0.0018 + ((m % 6) * 0.0001);
+      const local = 0.0004;
+      idx *= 1 + macro + local;
+      monthly.push({ date: d, idx });
+    }
+  }
+  const mMap = new Map(monthly.map((m) => [toDateStringUTC(m.date), m.idx]));
+  const rows = [];
+  const dayMs = 86400000;
+  for (let t = start.getTime(); t <= end.getTime(); t += dayMs) {
+    const d = new Date(t);
+    const cur = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+    const nxt = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1));
+    const a = mMap.get(toDateStringUTC(cur)) ?? 1;
+    const b = mMap.get(toDateStringUTC(nxt)) ?? a;
+    const f = clamp((t - cur.getTime()) / (nxt.getTime() - cur.getTime() || dayMs), 0, 1);
+    rows.push({ period: toDateStringUTC(d), start_indexed: a + (b - a) * f, end_indexed: 0, correction_factor: 0 });
+  }
+  const last = rows.length ? rows[rows.length - 1].start_indexed : 1;
+  rows.forEach((r) => { r.end_indexed = r.start_indexed / last; r.correction_factor = 1 / r.end_indexed; });
+  return { rows, byDate: new Map(rows.map((r) => [r.period, r])) };
+}
+
+function assignNeighborhoods(blocks, rng) {
+  const unassigned = new Set(blocks.map((b) => `${b.i},${b.j}`));
+  const neigh = [];
+  let nIndex = 1;
+  while (unassigned.size) {
+    const seedKey = randPick(rng, Array.from(unassigned));
+    const target = 2 + Math.floor(rng() * 7);
+    const queue = [seedKey];
+    const members = [];
+    while (queue.length && members.length < target) {
+      const k = queue.shift();
+      if (!unassigned.has(k)) continue;
+      unassigned.delete(k);
+      members.push(k);
+      const [i, j] = k.split(',').map(Number);
+      [[i+1,j],[i-1,j],[i,j+1],[i,j-1]].forEach(([ni,nj]) => {
+        const nk = `${ni},${nj}`;
+        if (unassigned.has(nk) && rng() < 0.8) queue.push(nk);
+      });
+    }
+    neigh.push({ name: `Neighborhood ${nIndex++}`, blocks: new Set(members) });
+  }
+  return neigh;
+}
+
+function pickZoningForBlock(i, j, arterialNearby) {
+  const cbd = Math.abs(i) < CBD_HALF_BLOCKS && Math.abs(j) < CBD_HALF_BLOCKS;
+  if (cbd) return 'MX';
+  if (arterialNearby) {
+    // 45/35/20
+    const r = ((i * 13 + j * 17) % 100 + 100) % 100;
+    if (r < 45) return 'C1';
+    if (r < 80) return 'R4';
+    return 'MX';
+  }
+  const d = Math.sqrt(i * i + j * j);
+  if (d > 15) return 'AG';
+  if (d > 10) return 'R2';
+  if (d > 7) return 'R3';
+  return 'R4';
+}
+
+function buildRoadsAndBlocks(config, rng) {
+  const roads = new Map();
+  const paved = new Map();
+  const endYear = config.endYear;
+
+  for (let i = -INITIAL_HALF_BLOCKS; i < INITIAL_HALF_BLOCKS; i++) {
+    for (let j = -INITIAL_HALF_BLOCKS; j < INITIAL_HALF_BLOCKS; j++) {
+      paved.set(`${i},${j}`, { i, j, year_paved: 1940 });
+      const isArterial = i % ARTERIAL_CADENCE === 0 || j % ARTERIAL_CADENCE === 0;
+      paveBlock(roads, i, j, 1940, isArterial ? 'arterial' : 'local');
+    }
+  }
+
+  const beltMin = blockBounds(-INITIAL_HALF_BLOCKS, -INITIAL_HALF_BLOCKS);
+  const beltMax = blockBounds(INITIAL_HALF_BLOCKS - 1, INITIAL_HALF_BLOCKS - 1);
+  addRoad(roads, { orientation: 'h', fixed: beltMin.yMin - ROAD_BUFFER_M / 2, start: beltMin.xMin - ROAD_BUFFER_M / 2, end: beltMax.xMax + ROAD_BUFFER_M / 2, road_class: 'beltway', width_m: BELTWAY_WIDTH_M, year_paved: 1940, name: 'North Beltway' });
+  addRoad(roads, { orientation: 'h', fixed: beltMax.yMax + ROAD_BUFFER_M / 2, start: beltMin.xMin - ROAD_BUFFER_M / 2, end: beltMax.xMax + ROAD_BUFFER_M / 2, road_class: 'beltway', width_m: BELTWAY_WIDTH_M, year_paved: 1940, name: 'South Beltway' });
+  addRoad(roads, { orientation: 'v', fixed: beltMin.xMin - ROAD_BUFFER_M / 2, start: beltMin.yMin - ROAD_BUFFER_M / 2, end: beltMax.yMax + ROAD_BUFFER_M / 2, road_class: 'beltway', width_m: BELTWAY_WIDTH_M, year_paved: 1940, name: 'West Beltway' });
+  addRoad(roads, { orientation: 'v', fixed: beltMax.xMax + ROAD_BUFFER_M / 2, start: beltMin.yMin - ROAD_BUFFER_M / 2, end: beltMax.yMax + ROAD_BUFFER_M / 2, road_class: 'beltway', width_m: BELTWAY_WIDTH_M, year_paved: 1940, name: 'East Beltway' });
+
+  const highwayOffset = beltMax.xMax + ROAD_BUFFER_M / 2;
+  const highwayOffsetY = beltMax.yMax + ROAD_BUFFER_M / 2;
+  const ext = 80 * GRID_PITCH_M;
+  addRoad(roads, { orientation: 'v', fixed: highwayOffset, start: -ext, end: ext, road_class: 'highway', width_m: HIGHWAY_WIDTH_M, year_paved: 1940, name: 'N/S Highway' });
+  addRoad(roads, { orientation: 'h', fixed: highwayOffsetY, start: -ext, end: ext, road_class: 'highway', width_m: HIGHWAY_WIDTH_M, year_paved: 1940, name: 'E/W Highway' });
+
+  for (let year = 1941; year <= endYear; year++) {
+    const budget = Math.max(0, Math.round(FRONTIER_BUDGET_INITIAL * Math.pow(1 + FRONTIER_BUDGET_GROWTH, year - 1940)));
+    const frontier = new Set();
+    for (const b of paved.values()) {
+      [[b.i+1,b.j],[b.i-1,b.j],[b.i,b.j+1],[b.i,b.j-1]].forEach(([ni,nj]) => {
+        const k = `${ni},${nj}`;
+        if (!paved.has(k)) frontier.add(k);
+      });
+    }
+    const candidates = Array.from(frontier);
+    let used = 0;
+    while (used < budget && candidates.length) {
+      const idx = Math.floor(rng() * candidates.length);
+      const k = candidates.splice(idx, 1)[0];
+      const [i,j] = k.split(',').map(Number);
+      paved.set(k, { i, j, year_paved: year });
+      const arterial = i % ARTERIAL_CADENCE === 0 || j % ARTERIAL_CADENCE === 0;
+      paveBlock(roads, i, j, year, arterial ? 'arterial' : 'local');
+      used++;
+    }
+  }
+
+  // naming
+  const uniqueX = Array.from(new Set(Array.from(roads.values()).filter((r) => r.orientation === 'v').map((r) => r.fixed))).sort((a,b)=>a-b);
+  const uniqueY = Array.from(new Set(Array.from(roads.values()).filter((r) => r.orientation === 'h').map((r) => r.fixed))).sort((a,b)=>a-b);
+  let serviceIdx = 0;
+  roads.forEach((r) => {
+    if (r.name) return;
+    if (r.road_class === 'highway' || r.road_class === 'beltway') return;
+    const onGrid = Math.abs(((r.fixed + BLOCK_SIZE_M / 2) / GRID_PITCH_M) - Math.round((r.fixed + BLOCK_SIZE_M / 2) / GRID_PITCH_M)) < 0.0001;
+    if (onGrid && r.road_class !== 'local_service') {
+      if (r.orientation === 'v') r.name = `${uniqueX.indexOf(r.fixed) + 1}th Avenue`;
+      else r.name = `${uniqueY.indexOf(r.fixed) + 1}th Street`;
+    } else {
+      const base = FRUIT_VEG_NAMES[serviceIdx % FRUIT_VEG_NAMES.length];
+      r.name = `${base} ${r.orientation === 'v' ? 'Avenue' : 'Street'}`;
+      serviceIdx += 1;
+    }
+  });
+
+  const blocks = Array.from(paved.values());
+  const neighborhoods = assignNeighborhoods(blocks, rng);
+  const nbByBlock = new Map();
+  neighborhoods.forEach((n) => n.blocks.forEach((k) => nbByBlock.set(k, n.name)));
+
+  return { roads: Array.from(roads.values()), blocks, nbByBlock };
+}
+
+function metersToAcres(m2) { return m2 * 0.000247105; }
+
+function createParcelsFromBlock(block, roads, nbByBlock, centerLon, centerLat, rng, keyBase) {
+  const { i, j } = block;
+  const b = blockBounds(i, j);
+  const blockKey = `${i},${j}`;
+  const arterialNearby = roads.some((r) => r.road_class === 'arterial' && ((r.orientation === 'v' && Math.abs(r.fixed - (b.xMin - ROAD_BUFFER_M/2)) <= GRID_PITCH_M/2) || (r.orientation === 'h' && Math.abs(r.fixed - (b.yMin - ROAD_BUFFER_M/2)) <= GRID_PITCH_M/2)));
+  const zoning = pickZoningForBlock(i, j, arterialNearby);
+  const allowed = ZONING_ALLOWED[zoning];
+  const weights = ZONING_WEIGHTS[zoning];
+
+  const parcels = [];
+  let parcelIndex = 0;
+  const split = 2 + Math.floor(rng() * 3);
+  const laneNeeded = split >= 4;
+  const laneWidth = laneNeeded ? 4 : 0;
+  const width = (b.xMax - b.xMin - laneWidth) / split;
+
+  for (let s = 0; s < split; s++) {
+    const x0 = b.xMin + s * width;
+    const x1 = x0 + width;
+    const poly = [[x0, b.yMin], [x1, b.yMin], [x1, b.yMax], [x0, b.yMax], [x0, b.yMin]];
+    const model_group = weightedPick(rng, weights);
+    if (!allowed.includes(model_group)) continue;
+    const areaSqft = Math.round((width * (b.yMax - b.yMin)) * 10.7639);
+    const areaAc = metersToAcres(width * (b.yMax - b.yMin));
+    if (areaAc < MIN_PARCEL_ACRES[model_group]) continue;
+    const boundedArea = Math.min(areaAc, MAX_PARCEL_ACRES[model_group]);
+    const lotFactor = boundedArea / Math.max(0.01, areaAc);
+    const adjWidth = width * lotFactor;
+    const adjPoly = [[x0, b.yMin], [x0 + adjWidth, b.yMin], [x0 + adjWidth, b.yMax], [x0, b.yMax], [x0, b.yMin]];
+
+    parcelIndex += 1;
+    const key = `${String(keyBase).padStart(5, '0')}-${String(parcelIndex).padStart(2, '0')}`;
+    const ll = adjPoly.map(([x, y]) => metersToLonLat(centerLon, centerLat, x, y));
+    const modelType = randPick(rng, BLDG_TYPE_BY_GROUP[model_group]);
+    const neighborhood = nbByBlock.get(blockKey) || 'Neighborhood 0';
+    const dCenter = Math.sqrt(i*i + j*j);
+    const baseStory = model_group === 'multi_family' ? 2 : model_group === 'commercial' ? 2 : 1;
+    const footprint = model_group === 'agricultural' ? 0 : Math.max(250, Math.round(areaSqft * (0.12 + rng() * 0.35)));
+    const finished = Math.round(footprint * baseStory * (0.9 + rng() * 0.25));
+    parcels.push({
+      key,
+      geometry: { type: 'Polygon', coordinates: [ll] },
+      block_i: i,
+      block_j: j,
+      year_paved: block.year_paved,
+      neighborhood,
+      zoning,
+      model_group,
+      land_type: LAND_TYPE_BY_GROUP[model_group],
+      land_area_sqft: Math.round(adjWidth * (b.yMax - b.yMin) * 10.7639),
+      longitude: ll.reduce((s, p) => s + p[0], 0) / ll.length,
+      latitude: ll.reduce((s, p) => s + p[1], 0) / ll.length,
+      bldg_type: footprint > 0 ? modelType : 'NONE',
+      bldg_area_footprint_sqft: footprint,
+      bldg_area_finished_sqft: finished,
+      bldg_stories: footprint > 0 ? baseStory : 0,
+      bldg_units: model_group === 'multi_family' ? 2 + Math.floor(rng() * 16) : 0,
+      bldg_rooms_bed: model_group === 'single_family' ? Math.max(1, Math.round(finished / 700)) : 0,
+      bldg_rooms_bath: model_group === 'single_family' ? Math.max(1, Math.round(finished / 1200)) : 0,
+      bldg_quality_num: footprint > 0 ? 2 + Math.floor(rng() * 4) : 0,
+      bldg_condition_num: footprint > 0 ? 45 + Math.floor(rng() * 45) : 0,
+      bldg_year_built: footprint > 0 ? block.year_paved : null,
+      bldg_year_renovated: null,
+      distance_to_center_blocks: dCenter,
+      arterial_frontage: arterialNearby
+    });
+  }
+  return parcels;
+}
+
+function calcValues(p, inflationIndex) {
+  const centerPremium = Math.max(0.6, 2.4 - p.distance_to_center_blocks * 0.08);
+  const zoningPremium = p.zoning.startsWith('C') || p.zoning === 'MX' ? 1.35 : p.zoning.startsWith('I') ? 1.15 : p.zoning === 'AG' ? 0.75 : 1;
+  const arterialAdj = p.model_group === 'single_family' && p.arterial_frontage ? SF_ARTERIAL_PENALTY : (p.arterial_frontage ? 1.12 : 1);
+  const land = Math.round(p.land_area_sqft * 3.8 * centerPremium * zoningPremium * arterialAdj * Math.pow(inflationIndex, 0.55));
+  const impro = Math.round(p.bldg_area_finished_sqft * 85 * (0.2 + p.bldg_condition_num / 120) * (1 + p.bldg_quality_num * 0.06));
+  return { platonic_land_value: land, platonic_impr_value: impro, platonic_market_value: land + impro };
+}
+
+function maybeRedevelop(p, rng) {
+  if (p.bldg_area_finished_sqft <= 0) return;
+  const ratio = p.platonic_land_value / Math.max(1, p.platonic_impr_value);
+  if (ratio > 2.2 && rng() < clamp((ratio - 2.2) * 0.07, 0, 0.35)) {
+    p.bldg_condition_num = 70 + Math.floor(rng() * 25);
+    p.bldg_year_built = p.current_year;
+    p.bldg_area_footprint_sqft = Math.round(p.land_area_sqft * (0.2 + rng() * 0.35));
+    p.bldg_area_finished_sqft = Math.round(p.bldg_area_footprint_sqft * (1 + Math.floor(rng() * 2)));
+  }
+}
+
+function roadsToFeatures(roads, centerLon, centerLat) {
+  return roads.map((r, idx) => {
+    const c1 = r.orientation === 'h' ? [r.start, r.fixed] : [r.fixed, r.start];
+    const c2 = r.orientation === 'h' ? [r.end, r.fixed] : [r.fixed, r.end];
+    const p1 = metersToLonLat(centerLon, centerLat, c1[0], c1[1]);
+    const p2 = metersToLonLat(centerLon, centerLat, c2[0], c2[1]);
+    return {
+      road_id: `r${idx + 1}`,
+      road_class: r.road_class,
+      width_m: r.width_m,
+      year_paved: r.year_paved,
+      road_name: r.name || 'Unnamed Road',
+      geometry: { type: 'LineString', coordinates: [p1, p2] }
+    };
+  });
+}
+
+function generateSimulation(config) {
+  const rng = makeSeededRng(config.seed);
+  progress('Laying out roads and blocks...');
+  const infra = buildRoadsAndBlocks(config, rng);
+  const roadFeatures = roadsToFeatures(infra.roads, config.centerLon, config.centerLat);
+
+  progress('Carving parcels from paved blocks...');
+  let keyBase = 1;
+  let universe = [];
+  infra.blocks.forEach((b) => {
+    const rows = createParcelsFromBlock(b, infra.roads, infra.nbByBlock, config.centerLon, config.centerLat, rng, keyBase);
+    keyBase += 1;
+    universe = universe.concat(rows);
+  });
+
+  progress('Building inflation series...');
+  const inflation = buildInflationSeries(1940, config.endYear);
+  progress('Simulating yearly sales and redevelopment...');
+
+  const sales = [];
+  const sales_platonic = [];
+  const currentByKey = new Map(universe.map((p) => [p.key, p]));
+
+  for (let year = 1940; year <= config.endYear; year++) {
+    for (const p of universe) {
+      p.current_year = year;
+      p.bldg_condition_num = clamp(p.bldg_condition_num - (0.35 + rng() * 1.2), 0, 100);
+      const yearInfl = inflation.byDate.get(`${year}-01-01`)?.start_indexed || 1;
+      Object.assign(p, calcValues(p, yearInfl));
+      maybeRedevelop(p, rng);
+
+      const threshold = 120000 * Math.pow(yearInfl, 0.65);
+      const developScore = clamp((p.platonic_land_value - threshold) / Math.max(1, threshold), 0, 2);
+      const saleProb = clamp((config.saleProbabilities[p.model_group] || 0.05) + developScore * 0.02, 0.01, 0.45);
+      if (rng() > saleProb) continue;
+
+      const saleDate = toDateStringUTC(new Date(Date.UTC(year, Math.floor(rng() * 12), 1 + Math.floor(rng() * 28))));
+      const infl = inflation.byDate.get(saleDate) || inflation.rows[inflation.rows.length - 1];
+      const base = calcValues(p, infl.start_indexed);
+      const platonicSale = Math.max(1, Math.round(base.platonic_market_value));
+      const noise = Math.round((rng() - 0.5) * 0.05 * platonicSale);
+      const truePrice = Math.max(1, platonicSale + noise);
+      const key_sale = `${p.key}---${saleDate}`;
+      const plat = {
+        ...p,
+        key_sale,
+        sale_date: saleDate,
+        sale_type: 'VALID',
+        valid_sale: true,
+        sale_noise: noise,
+        sale_price: truePrice,
+        vacant_sale: p.bldg_area_finished_sqft === 0,
+        inflation_index: infl.start_indexed,
+        ...base
+      };
+      const obs = { ...plat };
+      if (rng() < config.invalidPct / 100) {
+        obs.sale_type = 'NOT_ARMS_LENGTH';
+        obs.sale_price = rng() < 0.5 ? randPick(rng, config.nominalPriceList) : Math.max(1, Math.round((rng() * 999) / 5) * 5);
+        obs.valid_sale = true;
+        plat.sale_type = 'NOT_ARMS_LENGTH';
+        plat.valid_sale = false;
+      }
+      sales_platonic.push(plat);
+      sales.push(obs);
+      currentByKey.set(p.key, p);
+    }
+
+    if ((year - 1940) % config.repaintYears === 0 || year === config.endYear) {
+      send('milestone', { featureCollection: { type: 'FeatureCollection', features: Array.from(currentByKey.values()).slice(0, 3500).map((r) => ({ type: 'Feature', geometry: r.geometry, properties: { neighborhood: r.neighborhood } })) } });
+      log(`Milestone repaint: year ${year}.`);
+    }
+  }
+
+  return {
+    config,
+    crs: 'EPSG:4326',
+    universeCount: universe.length,
+    salesCount: sales.length,
+    roadsCount: roadFeatures.length,
+    preview: { type: 'FeatureCollection', features: universe.slice(0, 3500).map((r) => ({ type: 'Feature', geometry: r.geometry, properties: { neighborhood: r.neighborhood } })) },
+    universe,
+    sales,
+    sales_platonic,
+    roads: roadFeatures,
+    inflation: inflation.rows
+  };
+}
+
+function inferType(v) { if (v == null) return 'string'; if (typeof v === 'boolean') return 'bool'; if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float'; return 'string'; }
+function arrowType(Arrow, k) { if (k === 'bool') return new Arrow.Bool(); if (k === 'int') return new Arrow.Int32(); if (k === 'float') return new Arrow.Float64(); return new Arrow.Utf8(); }
+
+function rowToFields(rows) {
+  const keys = new Set();
+  rows.forEach((r) => Object.keys(r).forEach((k) => { if (k !== 'geometry') keys.add(k); }));
+  return Array.from(keys).map((name) => ({ name, kind: inferType(rows.find((r) => r[name] != null)?.[name] ?? null) }));
+}
+
+async function toGeoParquetBytes(rows) {
+  if (!rows.length) throw new Error('No rows to export.');
+  const Arrow = self.Arrow;
+  if (!Arrow) throw new Error('Arrow library failed to load.');
+  const { arrowSchema, geoMeta } = await ensureArrowHelpers();
+  const { makeArrowTable, tableToIPC } = arrowSchema;
+  const { createGeoMetadata } = geoMeta;
+
+  const geomType = rows[0]?.geometry?.type === 'LineString' ? 'LineString' : 'Polygon';
+  const fields = rowToFields(rows);
+  const geoMetadata = await createGeoMetadata({ wkid: 4326, latestWkid: 4326, wkt: null }, geomType);
+  const schema = new Arrow.Schema([
+    new Arrow.Field('geometry', new Arrow.Binary(), true),
+    ...fields.map((f) => new Arrow.Field(f.name, arrowType(Arrow, f.kind), true))
+  ], new Map([['geo', JSON.stringify(geoMetadata)]]));
+
+  const geomBuilder = Arrow.makeBuilder({ type: new Arrow.Binary(), nullValues: [null, undefined] });
+  const builders = new Map(fields.map((f) => [f.name, Arrow.makeBuilder({ type: arrowType(Arrow, f.kind), nullValues: [null, undefined] })]));
+
+  rows.forEach((row) => {
+    const coords = row.geometry.coordinates;
+    const wkb = row.geometry.type === 'LineString' ? lineWkb(coords) : polygonWkb(coords[0]);
+    geomBuilder.append(wkb);
+    fields.forEach((f) => builders.get(f.name).append(row[f.name] == null ? null : row[f.name]));
+  });
+  geomBuilder.finish();
+  const vectors = [geomBuilder.toVector()];
+  fields.forEach((f) => { const b = builders.get(f.name); b.finish(); vectors.push(b.toVector()); });
+
+  const table = makeArrowTable(Arrow, schema, vectors);
+  const ipc = tableToIPC(Arrow, table, 'stream');
+  const parquetModule = await ensureParquetModule();
+  const wasmTable = parquetModule.Table.fromIPCStream(ipc);
+  const writerProps = new parquetModule.WriterPropertiesBuilder().setCompression(parquetModule.Compression.ZSTD).setKeyValueMetadata(new Map([['geo', JSON.stringify(geoMetadata)]])).build();
+  return parquetModule.writeParquet(wasmTable, writerProps);
 }
 
 function crc32(bytes) {
@@ -74,209 +578,19 @@ function buildZipBlob(files) {
     const nameBytes = new TextEncoder().encode(file.name);
     const data = new Uint8Array(file.data);
     const crc = crc32(data);
-
-    const lh = new Uint8Array(30 + nameBytes.length);
-    const lv = new DataView(lh.buffer);
+    const lh = new Uint8Array(30 + nameBytes.length); const lv = new DataView(lh.buffer);
     lv.setUint32(0, 0x04034b50, true); lv.setUint16(4, 20, true); lv.setUint32(14, crc, true);
-    lv.setUint32(18, data.length, true); lv.setUint32(22, data.length, true); lv.setUint16(26, nameBytes.length, true);
-    lh.set(nameBytes, 30);
+    lv.setUint32(18, data.length, true); lv.setUint32(22, data.length, true); lv.setUint16(26, nameBytes.length, true); lh.set(nameBytes, 30);
     local.push(lh, data);
-
-    const ch = new Uint8Array(46 + nameBytes.length);
-    const cv = new DataView(ch.buffer);
+    const ch = new Uint8Array(46 + nameBytes.length); const cv = new DataView(ch.buffer);
     cv.setUint32(0, 0x02014b50, true); cv.setUint16(4, 20, true); cv.setUint16(6, 20, true);
-    cv.setUint32(16, crc, true); cv.setUint32(20, data.length, true); cv.setUint32(24, data.length, true);
-    cv.setUint16(28, nameBytes.length, true); cv.setUint32(42, offset, true);
-    ch.set(nameBytes, 46);
-    central.push(ch);
-    offset += lh.length + data.length;
+    cv.setUint32(16, crc, true); cv.setUint32(20, data.length, true); cv.setUint32(24, data.length, true); cv.setUint16(28, nameBytes.length, true); cv.setUint32(42, offset, true); ch.set(nameBytes, 46);
+    central.push(ch); offset += lh.length + data.length;
   });
   const centralSize = central.reduce((s, p) => s + p.length, 0);
-  const end = new Uint8Array(22);
-  const ev = new DataView(end.buffer);
-  ev.setUint32(0, 0x06054b50, true); ev.setUint16(8, files.length, true); ev.setUint16(10, files.length, true);
-  ev.setUint32(12, centralSize, true); ev.setUint32(16, offset, true);
+  const end = new Uint8Array(22); const ev = new DataView(end.buffer);
+  ev.setUint32(0, 0x06054b50, true); ev.setUint16(8, files.length, true); ev.setUint16(10, files.length, true); ev.setUint32(12, centralSize, true); ev.setUint32(16, offset, true);
   return new Blob([...local, ...central, end], { type: 'application/zip' });
-}
-
-function makeSeededRng(seedText) {
-  let h = 2166136261 >>> 0;
-  const src = String(seedText || 'synthetic-city');
-  for (let i = 0; i < src.length; i++) { h ^= src.charCodeAt(i); h = Math.imul(h, 16777619); }
-  let state = h >>> 0;
-  return () => { state ^= state << 13; state ^= state >>> 17; state ^= state << 5; state >>>= 0; return state / 4294967296; };
-}
-
-function metersToLonLat(centerLon, centerLat, dx, dy) {
-  const degLat = dy / 111320;
-  const degLon = dx / (111320 * Math.cos((centerLat * Math.PI) / 180));
-  return [centerLon + degLon, centerLat + degLat];
-}
-function toDateStringUTC(d) { return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`; }
-
-function polygonWkb(coords) {
-  const count = coords.length; const buf = new ArrayBuffer(1 + 4 + 4 + 4 + count * 16); const v = new DataView(buf); let o = 0;
-  v.setUint8(o, 1); o += 1; v.setUint32(o, 3, true); o += 4; v.setUint32(o, 1, true); o += 4; v.setUint32(o, count, true); o += 4;
-  for (const [x, y] of coords) { v.setFloat64(o, x, true); o += 8; v.setFloat64(o, y, true); o += 8; }
-  return new Uint8Array(buf);
-}
-
-function buildInflationSeries(startYear, endYear) {
-  const start = new Date(Date.UTC(startYear, 0, 1));
-  const end = new Date(Date.UTC(endYear, 0, 1));
-  const monthly = []; let idx = 1;
-  for (let y = startYear; y <= endYear; y++) for (let m = 0; m < 12; m++) {
-    const d = new Date(Date.UTC(y, m, 1)); if (d > end) break; const r = 0.002 + ((m % 6) * 0.0001); idx *= (1 + r); monthly.push({ date: d, idx });
-  }
-  const mMap = new Map(monthly.map((m) => [toDateStringUTC(m.date), m.idx]));
-  const rows = []; const dayMs = 86400000;
-  for (let t = start.getTime(); t <= end.getTime(); t += dayMs) {
-    const d = new Date(t); const cur = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1)); const nxt = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1));
-    const a = mMap.get(toDateStringUTC(cur)) ?? 1; const b = mMap.get(toDateStringUTC(nxt)) ?? a;
-    const f = clamp((t - cur.getTime()) / (nxt.getTime() - cur.getTime() || dayMs), 0, 1);
-    rows.push({ period: toDateStringUTC(d), start_indexed: a + (b - a) * f, end_indexed: 0, correction_factor: 0 });
-  }
-  const last = rows.length ? rows[rows.length - 1].start_indexed : 1;
-  rows.forEach((r) => { r.end_indexed = r.start_indexed / last; r.correction_factor = 1 / r.end_indexed; });
-  return { rows, byDate: new Map(rows.map((r) => [r.period, r])) };
-}
-
-function neighborhoodForOffset(dx, dy) {
-  const dist = Math.sqrt(dx * dx + dy * dy);
-  if (Math.abs(dy) < 120 && Math.abs(dx) < 1600) return 'commercial corridors';
-  if (dx > 800 && dy < -800) return 'industrial sector';
-  if (dist < 320) return 'CBD'; if (dist < 780) return 'inner ring'; if (dist < 1300) return 'suburb'; if (dist < 1900) return 'exurb'; return 'rural outlying';
-}
-function chooseGroupByNeighborhood(rng, n) {
-  if (n === 'CBD') return rng() < 0.7 ? 'commercial' : 'multi_family';
-  if (n === 'inner ring') return randPick(rng, ['single_family', 'multi_family', 'commercial']);
-  if (n === 'commercial corridors') return randPick(rng, ['commercial', 'single_family']);
-  if (n === 'industrial sector') return randPick(rng, ['industrial', 'commercial']);
-  if (n === 'rural outlying') return randPick(rng, ['agricultural', 'single_family']);
-  if (n === 'exurb') return randPick(rng, ['single_family', 'mobile_home', 'agricultural']);
-  return randPick(rng, ['single_family', 'multi_family', 'mobile_home']);
-}
-
-function buildParcelRecord({ key, centerLon, centerLat, i, j, n, cellM, rng }) {
-  const half = (n - 1) / 2; const dx = (i - half) * cellM; const dy = (j - half) * cellM;
-  const width = cellM * (0.85 + rng() * 0.35); const height = cellM * (0.85 + rng() * 0.35);
-  const x0 = dx - width / 2; const x1 = dx + width / 2; const y0 = dy - height / 2; const y1 = dy + height / 2;
-  const p0 = metersToLonLat(centerLon, centerLat, x0, y0), p1 = metersToLonLat(centerLon, centerLat, x1, y0), p2 = metersToLonLat(centerLon, centerLat, x1, y1), p3 = metersToLonLat(centerLon, centerLat, x0, y1);
-  const neighborhood = neighborhoodForOffset(dx, dy);
-  const model_group = chooseGroupByNeighborhood(rng, neighborhood);
-  const bldg_type = randPick(rng, BLDG_TYPE_BY_GROUP[model_group]);
-  const zoning = randPick(rng, ZONING_BY_GROUP[model_group]);
-  const land_type = randPick(rng, LAND_TYPE_BY_GROUP[model_group]);
-  const land_area_sqft = Math.max(1000, Math.round((width * height) * 10.7639));
-  const stories = model_group === 'multi_family' ? 2 : 1;
-  const footprint = model_group === 'agricultural' ? 0 : Math.round(land_area_sqft * (0.15 + rng() * 0.4));
-  const finished = Math.round(footprint * stories * (0.9 + rng() * 0.2));
-  return {
-    key, geometry: { type: 'Polygon', coordinates: [[p0, p1, p2, p3, p0]] }, longitude: (p0[0] + p2[0]) / 2, latitude: (p0[1] + p2[1]) / 2,
-    neighborhood, model_group, zoning, land_type, land_area_sqft, bldg_type,
-    bldg_area_footprint_sqft: footprint, bldg_area_finished_sqft: finished, bldg_stories: footprint > 0 ? stories : 0,
-    bldg_units: model_group === 'multi_family' ? 2 + Math.floor(rng() * 12) : 0, bldg_rooms_bed: footprint > 0 ? Math.max(0, Math.round(finished / 700)) : 0,
-    bldg_rooms_bath: footprint > 0 ? Math.max(0, Math.round(finished / 1200)) : 0,
-    bldg_quality_num: footprint > 0 ? 2 + Math.floor(rng() * 4) : 0, bldg_condition_num: footprint > 0 ? 45 + Math.floor(rng() * 45) : 0,
-    bldg_year_built: footprint > 0 ? 1940 + Math.floor(rng() * 80) : null, bldg_year_renovated: null
-  };
-}
-
-const makeFeature = (row) => ({ type: 'Feature', geometry: row.geometry, properties: Object.fromEntries(Object.entries(row).filter(([k]) => k !== 'geometry')) });
-
-function calcValues(p) {
-  const land = Math.round(p.land_area_sqft * (p.neighborhood === 'CBD' ? 42 : p.neighborhood === 'inner ring' ? 21 : 9));
-  const impr = Math.round(p.bldg_area_finished_sqft * (p.model_group === 'commercial' ? 180 : p.model_group === 'industrial' ? 115 : 140) * (1 + (p.bldg_quality_num || 0) * 0.07) * (0.2 + (p.bldg_condition_num || 0) / 125));
-  return { platonic_land_value: land, platonic_impr_value: impr, platonic_market_value: land + impr };
-}
-
-function generateSimulation(config) {
-  const rng = makeSeededRng(config.seed);
-  const universe = []; const n = Math.ceil(Math.sqrt(config.parcelCount)); const cellM = 70;
-  progress('Generating parcel fabric...');
-  for (let idx = 0; idx < config.parcelCount; idx++) {
-    const i = idx % n, j = Math.floor(idx / n), key = String(idx + 1).padStart(5, '0');
-    universe.push(buildParcelRecord({ key, centerLon: config.centerLon, centerLat: config.centerLat, i, j, n, cellM, rng }));
-  }
-  send('milestone', { featureCollection: { type: 'FeatureCollection', features: universe.slice(0, 4500).map(makeFeature) } });
-
-  progress('Building inflation series...');
-  const inflation = buildInflationSeries(config.startYear, config.endYear);
-  progress('Simulating yearly events and sales...');
-
-  const sales = []; const sales_platonic = [];
-  for (let year = config.startYear; year <= config.endYear; year++) {
-    for (const p of universe) {
-      if (p.bldg_area_finished_sqft > 0) p.bldg_condition_num = clamp(p.bldg_condition_num - (0.5 + rng() * 1.4), 0, 100);
-      const prob = config.saleProbabilities[p.model_group] ?? 0.05;
-      if (rng() > prob) continue;
-      const saleDate = toDateStringUTC(new Date(Date.UTC(year, Math.floor(rng() * 12), 1 + Math.floor(rng() * 28))));
-      const infl = inflation.byDate.get(saleDate) || inflation.rows[inflation.rows.length - 1];
-      const vals = calcValues(p);
-      const platonicPrice = Math.max(1, Math.round(vals.platonic_market_value * infl.start_indexed));
-      const noise = Math.round((rng() - 0.5) * 0.06 * platonicPrice);
-      const truePrice = Math.max(1, platonicPrice + noise);
-      const key_sale = `${p.key}---${saleDate}`;
-      const base = { ...p, key_sale, sale_date: saleDate, sale_type: 'VALID', valid_sale: true, sale_noise: noise, sale_price: truePrice, vacant_sale: p.bldg_area_finished_sqft === 0, inflation_index: infl.start_indexed, ...vals };
-      const obs = { ...base };
-      if (rng() < config.invalidPct / 100) {
-        obs.sale_type = 'NOT_ARMS_LENGTH';
-        obs.sale_price = rng() < 0.5 ? randPick(rng, config.nominalPriceList) : Math.max(1, Math.round((rng() * 999) / 5) * 5);
-        obs.valid_sale = true;
-        base.sale_type = 'NOT_ARMS_LENGTH';
-        base.valid_sale = false;
-      }
-      sales_platonic.push(base); sales.push(obs);
-    }
-    if ((year - config.startYear) % config.repaintYears === 0 || year === config.endYear) {
-      send('milestone', { featureCollection: { type: 'FeatureCollection', features: universe.slice(0, 4500).map(makeFeature) } });
-      log(`Milestone repaint: year ${year}.`);
-    }
-  }
-  return { config, crs: 'EPSG:4326', universeCount: universe.length, salesCount: sales.length, preview: { type: 'FeatureCollection', features: universe.slice(0, 4500).map(makeFeature) }, universe, sales, sales_platonic, inflation: inflation.rows };
-}
-
-function inferType(v) { if (v == null) return 'string'; if (typeof v === 'boolean') return 'bool'; if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float'; return 'string'; }
-function arrowType(Arrow, k) { if (k === 'bool') return new Arrow.Bool(); if (k === 'int') return new Arrow.Int32(); if (k === 'float') return new Arrow.Float64(); return new Arrow.Utf8(); }
-function rowToFields(rows) {
-  const keys = new Set(); rows.forEach((r) => Object.keys(r).forEach((k) => { if (k !== 'geometry') keys.add(k); }));
-  return Array.from(keys).map((name) => ({ name, kind: inferType(rows.find((r) => r[name] != null)?.[name] ?? null) }));
-}
-
-async function toGeoParquetBytes(rows) {
-  const Arrow = self.Arrow;
-  if (!Arrow) throw new Error('Arrow library failed to load.');
-  const { arrowSchema, geoMeta } = await ensureArrowHelpers();
-  const { makeArrowTable, tableToIPC } = arrowSchema;
-  const { createGeoMetadata } = geoMeta;
-
-  const fields = rowToFields(rows);
-  const geoMetadata = await createGeoMetadata({ wkid: 4326, latestWkid: 4326, wkt: null }, 'Polygon');
-  const schema = new Arrow.Schema([
-    new Arrow.Field('geometry', new Arrow.Binary(), true),
-    ...fields.map((f) => new Arrow.Field(f.name, arrowType(Arrow, f.kind), true))
-  ], new Map([['geo', JSON.stringify(geoMetadata)]]));
-
-  const geomBuilder = Arrow.makeBuilder({ type: new Arrow.Binary(), nullValues: [null, undefined] });
-  const builders = new Map(fields.map((f) => [f.name, Arrow.makeBuilder({ type: arrowType(Arrow, f.kind), nullValues: [null, undefined] })]));
-
-  rows.forEach((row) => {
-    geomBuilder.append(polygonWkb(row.geometry.coordinates[0]));
-    fields.forEach((f) => builders.get(f.name).append(row[f.name] == null ? null : row[f.name]));
-  });
-  geomBuilder.finish();
-  const vectors = [geomBuilder.toVector()];
-  fields.forEach((f) => { const b = builders.get(f.name); b.finish(); vectors.push(b.toVector()); });
-
-  const table = makeArrowTable(Arrow, schema, vectors);
-  const ipc = tableToIPC(Arrow, table, 'stream');
-  const parquetModule = await ensureParquetModule();
-  const wasmTable = parquetModule.Table.fromIPCStream(ipc);
-  const writerProps = new parquetModule.WriterPropertiesBuilder()
-    .setCompression(parquetModule.Compression.ZSTD)
-    .setKeyValueMetadata(new Map([['geo', JSON.stringify(geoMetadata)]]))
-    .build();
-  return parquetModule.writeParquet(wasmTable, writerProps);
 }
 
 async function buildExportZip(payload) {
@@ -286,21 +600,32 @@ async function buildExportZip(payload) {
   const salesBytes = await toGeoParquetBytes(payload.sales);
   progress('Encoding sales_platonic.geoparquet...');
   const platBytes = await toGeoParquetBytes(payload.sales_platonic);
+  progress('Encoding roads.geoparquet...');
+  const roadsBytes = await toGeoParquetBytes(payload.roads);
   progress('Encoding inflation.csv...');
   const csv = ['period,start_indexed,end_indexed,correction_factor', ...payload.inflation.map((r) => `${r.period},${r.start_indexed},${r.end_indexed},${r.correction_factor}`)].join('\n');
   const inflationBytes = textEncoder.encode(csv);
   const metadata = {
-    seed: payload.config.seed, app_version: 'mvp-0.1', crs: 'EPSG:4326',
+    seed: payload.config.seed,
+    app_version: 'mvp-0.2-network',
+    crs: 'EPSG:4326',
     center: { city_name: payload.config.cityName, latitude: payload.config.centerLat, longitude: payload.config.centerLon },
-    start_year: payload.config.startYear, end_year: payload.config.endYear, parcel_count: payload.config.parcelCount,
-    repaint_interval_years: payload.config.repaintYears, invalid_pct: payload.config.invalidPct,
-    sale_probabilities: payload.config.saleProbabilities, nominal_price_list: payload.config.nominalPriceList
+    start_year: 1940,
+    end_year: payload.config.endYear,
+    parcel_count: payload.universeCount,
+    road_count: payload.roadsCount,
+    repaint_interval_years: payload.config.repaintYears,
+    invalid_pct: payload.config.invalidPct,
+    sale_probabilities: payload.config.saleProbabilities,
+    nominal_price_list: payload.config.nominalPriceList
   };
   const metaBytes = textEncoder.encode(JSON.stringify(metadata, null, 2));
+
   return buildZipBlob([
     { name: 'universe.geoparquet', data: universeBytes },
     { name: 'sales.geoparquet', data: salesBytes },
     { name: 'sales_platonic.geoparquet', data: platBytes },
+    { name: 'roads.geoparquet', data: roadsBytes },
     { name: 'inflation.csv', data: inflationBytes },
     { name: 'metadata.json', data: metaBytes }
   ]);
@@ -309,10 +634,14 @@ async function buildExportZip(payload) {
 self.onmessage = async (event) => {
   const { mode, config, payload } = event.data || {};
   try {
-    if (mode === 'generate') return send('success', generateSimulation(config));
+    if (mode === 'generate') {
+      const effective = { ...config, startYear: 1940 };
+      send('success', generateSimulation(effective));
+      return;
+    }
     if (mode === 'export') {
       const zipBlob = await buildExportZip(payload);
-      return send('zip', { zipBlob, filename: `synthetic_city_${new Date().toISOString().slice(0, 10)}.zip` });
+      send('zip', { zipBlob, filename: `synthetic_city_${new Date().toISOString().slice(0, 10)}.zip` });
     }
   } catch (err) {
     send('error', { message: err?.message || String(err), stack: err?.stack || null });

--- a/util/synthetic/AGENTS.md
+++ b/util/synthetic/AGENTS.md
@@ -1,0 +1,300 @@
+# Synthetic City Builder (`util/synthetic`) — Working Plan
+
+This file captures confirmed decisions, MVP boundaries, and remaining open questions for the **Synthetic City Builder** util app.
+
+## App paradigm
+- Build as a **`util/` style app** (vanilla JS + HTML + local vendored deps).
+- Keep processing local/in-browser.
+- Use existing util wizard/progress/cancel/export patterns.
+- New app root and planning scope: `util/synthetic/`.
+
+## MVP target (simple + shippable)
+A deterministic, local-only synthetic city simulator that:
+1. generates a valid polygon parcel universe (up to ~10k parcels),
+2. simulates yearly evolution from 1980 to Jan 1 of present year,
+3. creates repeat-sales transactions,
+4. computes platonic vs observed sale values,
+5. exports a single ZIP containing geometry-bearing datasets.
+
+MVP intentionally excludes hybrid upload mode and advanced invalid-sale variants.
+
+## Core outputs
+Always export **one ZIP delivery package**.
+
+ZIP contents for MVP:
+1. `universe.geoparquet` (geometry-bearing)
+2. `sales.geoparquet` (geometry-bearing observed/dirtied sales)
+3. `sales_platonic.geoparquet` (geometry-bearing ground-truth sales)
+4. `inflation.csv` (daily index time series)
+5. `metadata.json` (seed + params + model settings + CRS + run timestamps)
+
+## Key contracts
+### Universe dataset
+- One row per parcel with polygon geometry.
+- Primary key: `key` (globally unique per parcel).
+- Represents parcel/building characteristics as-of the final simulation date.
+
+### Sales dataset
+- One row per sale event (repeat sales allowed).
+- Primary key: `key_sale`.
+- Foreign key: `key` to universe parcel.
+- `key_sale` MUST be strictly zero-padded date format: `key---YYYY-MM-DD`.
+- Sales exports include parcel geometry for user delivery.
+
+### Inflation dataset
+- Daily series (derived via interpolation between monthly anchors).
+- Schema is exactly:
+  - `period` (`YYYY-MM-DD`)
+  - `start_indexed` (index beginning at `1.0`)
+  - `end_indexed` (index ending at `1.0` on final date)
+  - `correction_factor` (`1 / end_indexed`)
+- Each sales row stores `inflation_index` for its sale date (taken from `start_indexed` for that day).
+
+## Required schema
+
+### Land characteristics
+- `land_area_sqft`
+- `longitude`
+- `latitude`
+- `land_type` (categorical)
+- `zoning` (categorical)
+- `neighborhood` (categorical)
+
+### Building characteristics
+### Proposed MVP `bldg_type` vocab by `model_group`
+Proposed starter mapping (designed for internal consistency + easy extension):
+- `single_family`:
+  - `SF_RANCH`
+  - `SF_TWO_STORY`
+  - `SF_TOWNHOUSE`
+- `multi_family`:
+  - `MF_DUPLEX`
+  - `MF_TRIPLEX`
+  - `MF_GARDEN_APT`
+  - `MF_MIDRISE_APT`
+- `commercial`:
+  - `COMM_RETAIL_SMALL`
+  - `COMM_RETAIL_BIGBOX`
+  - `COMM_OFFICE_LOWRISE`
+  - `COMM_MIXED_USE`
+- `industrial`:
+  - `IND_WAREHOUSE`
+  - `IND_LIGHT_MANUFACTURING`
+  - `IND_FLEX`
+- `mobile_home`:
+  - `MH_SINGLE_WIDE`
+  - `MH_DOUBLE_WIDE`
+  - `MH_PARK_PAD`
+- `agricultural`:
+  - `AG_ROW_CROP`
+  - `AG_PASTURE`
+  - `AG_FARMSTEAD`
+
+(If approved, this becomes the exact allowed set for MVP generation and UI filters.)
+
+- `bldg_area_finished_sqft`
+- `bldg_area_footprint_sqft`
+- `bldg_quality_num` (0 for vacant lot; otherwise tiers >=1)
+- `bldg_condition_num` (0..100)
+- `model_group` (categorical: `single_family`, `multi_family`, `commercial`, `industrial`, `mobile_home`, `agricultural`)
+- `bldg_type` (categorical; must be consistent with `model_group`)
+- `bldg_year_built`
+- `bldg_stories`
+- `bldg_units` (multifamily only)
+- `bldg_rooms_bed`
+- `bldg_rooms_bath`
+- `bldg_year_renovated`
+
+### Dataset-wide export note
+- `model_group` is exported in all three primary datasets: `universe`, `sales`, and `sales_platonic`.
+
+### Sales characteristics (by file)
+Common core fields in both sales files:
+- `sale_date` (`YYYY-MM-DD`)
+- `sale_type` (`VALID` or `NOT_ARMS_LENGTH` for MVP)
+- `valid_sale` (boolean)
+- `sale_price`
+- `sale_noise`
+- `vacant_sale`
+- `inflation_index`
+
+Notes:
+- In `sales_platonic`, these fields store ground truth values.
+- In `sales`, these fields store observed/dirtied values after error simulation.
+
+### Value decomposition characteristics
+- `platonic_land_value`
+- `platonic_impr_value`
+- `platonic_market_value` (= land + improvement)
+- `sale_noise` (signed)
+
+Sales price handling:
+- `sales_platonic.sale_price` = true/latent transaction value.
+- `sales.sale_price` = observed transaction value after dirtied/error transform.
+
+## Vacant-lot encoding rules
+When parcel is vacant at a given state snapshot:
+- Numeric building fields should be `0` where naturally expected:
+  - `bldg_area_finished_sqft=0`
+  - `bldg_area_footprint_sqft=0`
+  - `bldg_quality_num=0`
+  - `bldg_condition_num=0`
+  - `bldg_stories=0`
+  - `bldg_units=0`
+  - `bldg_rooms_bed=0`
+  - `bldg_rooms_bath=0`
+- Categorical building fields should be `"NONE"` where applicable:
+  - `bldg_type="NONE"`
+- Required null edge cases:
+  - `bldg_year_built=NULL` (never built)
+  - `bldg_year_renovated=NULL` (never renovated)
+
+## Geometry & generation model
+- User chooses a real-world center location.
+- Geometry constraints are strict:
+  - no overlaps,
+  - no slivers,
+  - valid polygon geometry only.
+- Initial fabric: rectilinear/grid + simple beltway influence.
+- Neighborhood archetypes in MVP:
+  - CBD
+  - inner ring
+  - suburb
+  - exurb
+  - commercial corridors
+  - industrial sector
+  - rural outlying
+- Neighborhood and zoning quotas are user-controlled and interpreted by **parcel counts**.
+
+## CRS strategy (recommended default)
+- Internal generation CRS: derived **UTM zone** from user-selected center (projected meters).
+- Map display CRS: web map standard rendering (MapLibre).
+- Export CRS: generation UTM CRS (clean projected CRS metadata).
+
+Rationale: robust distance/area calculations for parcel geometry and pricing-distance effects, while preserving clean GIS metadata for exports.
+
+## Temporal simulation
+- Default start year: `1980`.
+- End date: `YYYY-01-01` for the current present year (as-of date).
+- Yearly simulation events:
+  - sale transaction,
+  - teardown,
+  - new construction,
+  - renovation.
+
+## Pricing model (MVP)
+- Hidden hedonic model with simple user sliders/steppers.
+- Strong location effects (CBD distance decay + neighborhood premiums).
+- Zoning premiums/penalties.
+- Land and improvement values modeled separately, then combined.
+- Depreciation curve presets:
+  - linear,
+  - concave exponential,
+  - S-curve.
+- Inflation for MVP: monthly indexed keyframes with linear interpolation to daily values.
+- Noise model: simplest baseline (homoskedastic).
+
+
+## Platonic vs observed modeling approach
+Recommendation: keep **one internal platonic model** and derive observed/dirtied outputs from it at export/build-finalization time.
+
+### Why this is simpler and safer
+- Prevents drift: one authoritative state transition model (teardown/build/reno/sale) drives everything.
+- Easier debugging: if a value looks wrong, check platonic first, then dirtied transformation rules.
+- Cleaner determinism: same seed + params always regenerates identical platonic truth before noise/error injection.
+- Lower maintenance: avoids duplicating lifecycle logic across two parallel mutable datasets.
+
+### Practical data-shape choice for MVP
+Use two sales outputs in the ZIP:
+1. `sales.geoparquet` = observed/dirtied user-facing transactions.
+2. `sales_platonic.geoparquet` = ground-truth transactions (same row/key structure, no recording errors).
+
+And keep only one simulation state machine internally (platonic).
+Observed rows are produced by a deterministic post-process transform from the platonic sales rows.
+
+### Field strategy with dual-file outputs
+- Keep shared structural IDs in both files: `key`, `key_sale`, `sale_date`, geometry, etc.
+- In `sales_platonic` keep truth fields (e.g., `vacant_sale`, `sale_price`) as truth, without prefixing.
+- In `sales` keep observed equivalents (same column names) after applying error rules.
+- Optional: include lightweight lineage fields in observed sales, e.g. `dirty_rule_applied`, `dirty_from_key_sale`.
+
+This removes most `platonic_*` suffix clutter while preserving clean experimental ground truth.
+
+## Invalid sale modeling
+- User-configurable controls in MVP:
+  - `% invalid sales`
+  - checkboxes for invalid-sale types are hidden in MVP until additional types ship.
+- `sale_type` must be encoded per record.
+- Invalid nominal-price generator for `NOT_ARMS_LENGTH`: 50% fixed pick-list + 50% rounded-random `<1000`.
+- Ground truth is preserved in `sales_platonic`; observed errors are reflected in `sales`.
+
+### MVP implemented invalid type
+- **Not arm's length** only:
+  - `sales`: `valid_sale=True`, nominal round-number price (< $1000).
+  - `sales_platonic`: `valid_sale=False`, nominal round-number price (< $1000).
+
+### Validity semantics (authoritative)
+- `sales_platonic` captures the best-known true state for each parcel-sale record.
+- `sales_platonic.sale_price` always represents true individual-parcel transacted price (no data-entry mistakes).
+- `valid_sale=False` means "exclude from modeling" (not "did not happen").
+- `sales` may include observational/data-entry errors; `sales_platonic` does not.
+
+### Deferred invalid-type behavior rules (locked now for future implementation)
+- Distressed sale:
+  - `sales`: `valid_sale=True`, `sale_price≈25%` below baseline.
+  - `sales_platonic`: `valid_sale=False`, `sale_price≈25%` below baseline (true but non-modelable).
+- Vacant-at-sale mislabeled improved:
+  - `sales`: `valid_sale=True`, `vacant_sale=False`.
+  - `sales_platonic`: `valid_sale=False`, `vacant_sale=True`.
+- Improved-at-sale mislabeled vacant:
+  - `sales`: `valid_sale=True`, `vacant_sale=True`.
+  - `sales_platonic`: `valid_sale=False`, `vacant_sale=False`.
+- Multi-parcel sale (correct discounted per-parcel):
+  - `sales`: `valid_sale=True`.
+  - `sales_platonic`: `valid_sale=False` (true but not representative of single-parcel market value).
+- Multi-parcel mislabeled with total package price:
+  - `sales`: `valid_sale=True`, `sale_price=<total package price>`.
+  - `sales_platonic`: `valid_sale=False`, `sale_price=<true individual parcel price>`.
+- Multi-parcel mislabeled with first parcel price:
+  - `sales`: `valid_sale=True`, `sale_price=<first parcel price>`.
+  - `sales_platonic`: `valid_sale=False`, `sale_price=<true individual parcel price>`.
+- Pre-developed lot mislabeled vacant:
+  - `sales`: `valid_sale=True`, `vacant_sale=True`.
+  - `sales_platonic`: `valid_sale=False`, `vacant_sale=False`.
+
+## Internal consistency rule (critical)
+Never draw disconnected random attributes. Derive features in coherent dependency order, e.g.:
+1. choose neighborhood + zoning + land type context,
+2. choose building presence/type and stories,
+3. derive footprint and finished area,
+4. derive units/rooms from type + area,
+5. derive quality/condition from age + depreciation + renovations,
+6. derive land/improvement platonic values,
+7. derive sale events and observed sale fields.
+
+## UI/UX baseline
+- Wizard-style util UI + MapLibre preview.
+- Center-point selector supports either:
+  - city-name combobox backed by a pre-generated top-cities list, or
+  - direct latitude/longitude input.
+- Milestone repaint only (not continuous animation).
+- Repaint interval `N` (user configurable) for yearly evolution milestones.
+- Long operations in Web Worker with progress + cancel.
+- Single scenario only for MVP.
+
+## Non-MVP / deferred
+- Hybrid real/synthetic upload mode implementation.
+- Multi-scenario batch runner.
+- Full invalid-sale taxonomy implementation.
+- Advanced inflation seasonality + slow random process.
+- Rich custom formula builder beyond sliders.
+
+## Resolved implementation decisions
+1. Proposed `bldg_type` lists per `model_group` are approved for MVP.
+2. `model_group` will be exported in `universe`, `sales`, and `sales_platonic`.
+3. Metadata minimum fields are approved: seed, app_version, CRS (EPSG/WKT), center point source+coords, start/end dates, parcel count, repaint interval, slider settings, and quotas.
+4. Persist both `city_name` (when selected) and raw center coordinates in metadata.
+5. Fixed nominal-price pick list for `NOT_ARMS_LENGTH` is approved: `1, 5, 10, 50, 100, 500, 1000`.
+
+## MVP readiness
+Planning scope is now sufficiently unambiguous to begin implementation of the `util/synthetic` app skeleton and simulation pipeline.

--- a/util/synthetic/AGENTS.md
+++ b/util/synthetic/AGENTS.md
@@ -298,3 +298,24 @@ Never draw disconnected random attributes. Derive features in coherent dependenc
 
 ## MVP readiness
 Planning scope is now sufficiently unambiguous to begin implementation of the `util/synthetic` app skeleton and simulation pipeline.
+
+
+## Network-first generation update (approved)
+- Internal city mechanics now use a 100m x 100m buildable block envelope with 10m road buffers between blocks.
+- Road widths:
+  - local: 2.5m
+  - arterial: 6m
+  - beltway: 15m
+  - highway: 50m
+- Initial paved city is 20x20 blocks centered on origin.
+- CBD is a fixed 6x6 core centered in the city.
+- Arterials occur every 4 grid lines.
+- Neighborhoods are dynamically filled as contiguous 2-8 block regions and may split blocks when needed.
+- Strict zoning-to-model-group allowed sets are enforced, with weighted probabilities inside each allowed set.
+- Growth uses probabilistic frontier paving under a yearly budget that grows over time.
+- Development threshold is absolute but grows slower than inflation.
+- Roads are exported as `roads.geoparquet` with fields including class, width, and paving year.
+- Naming:
+  - grid-aligned non-major roads: numbered avenues/streets
+  - highways/beltways: generic major-road names
+  - interior/service roads: deterministic fruit/vegetable names

--- a/util/synthetic/index.html
+++ b/util/synthetic/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Synthetic City Builder</title>
+  <link rel="stylesheet" href="/shared.css" />
+  <link rel="stylesheet" href="/util/vendor/maplibre/maplibre-gl.css" />
+  <style>
+    main { padding: 28px 20px 48px; }
+    .layout { display:grid; grid-template-columns: 360px 1fr; gap:1rem; }
+    .panel, .map-panel { background:var(--card); border:1px solid var(--border); border-radius:14px; padding:1rem; }
+    .map-panel { min-height: 640px; display:flex; flex-direction:column; }
+    .map { height: 520px; border:1px solid var(--border); border-radius: 10px; }
+    .row { display:flex; gap:.55rem; align-items:center; margin:.45rem 0; }
+    .row label { min-width: 145px; font-size:.92rem; }
+    input, select { width:100%; padding:.45rem; border:1px solid var(--border); border-radius:8px; }
+    .actions { margin-top:.8rem; display:flex; flex-wrap:wrap; gap:.5rem; }
+    button { padding:.58rem .86rem; border-radius:8px; border:none; background:var(--accent); color:#fff; font-weight:600; cursor:pointer; }
+    button[disabled] { opacity:.6; cursor:not-allowed; }
+    .button-secondary { background:#fff; color:var(--accent); border:1px solid var(--border); }
+    .muted { color:var(--muted); font-size:.9rem; }
+    .log { margin-top:.8rem; max-height:150px; overflow:auto; background:#0d1a2b; color:#dce6ff; border-radius:8px; padding:.65rem; font-family: ui-monospace, monospace; font-size:.82rem; white-space:pre-wrap; }
+    .metrics { display:grid; grid-template-columns: repeat(3, minmax(130px,1fr)); gap:.5rem; margin-top:.65rem; }
+    .metric { border:1px solid var(--border); border-radius:8px; padding:.45rem; background:#fff; }
+    .metric strong { display:block; font-size:1rem; }
+    @media (max-width: 980px) { .layout { grid-template-columns: 1fr; } .map-panel { min-height:unset; } }
+  </style>
+</head>
+<body>
+<header>
+  <div class="container header-row">
+    <a class="brand" href="/" aria-label="Put It On A Map home">
+      <img src="/images/logo.svg" alt="putitonamap logo" />
+      <div>PutItOnAMap.com</div>
+    </a>
+  </div>
+</header>
+<main class="container">
+  <h1>Synthetic City Builder (MVP)</h1>
+  <p class="muted">Generate a deterministic parcel universe + repeat sales, inspect on map, and export ZIP with universe/sales/sales_platonic/inflation/metadata.</p>
+  <div class="layout">
+    <section class="panel">
+      <h2>Scenario</h2>
+      <div class="row"><label>City name</label><input id="cityName" value="Chicago" /></div>
+      <div class="row"><label>Center latitude</label><input id="centerLat" type="number" step="0.0001" value="41.8781" /></div>
+      <div class="row"><label>Center longitude</label><input id="centerLon" type="number" step="0.0001" value="-87.6298" /></div>
+      <div class="row"><label>Seed</label><input id="seed" value="synthetic-city-001" /></div>
+      <div class="row"><label>Parcels</label><input id="parcelCount" type="number" min="100" max="10000" step="100" value="5000" /></div>
+      <div class="row"><label>Repaint interval</label><input id="repaintYears" type="number" min="1" max="10" value="5" /></div>
+      <div class="row"><label>Invalid sales %</label><input id="invalidPct" type="number" min="0" max="100" step="1" value="8" /></div>
+
+      <h3>Annual sale probability by model_group</h3>
+      <div class="row"><label>Single family</label><input id="p_single_family" type="number" min="0" max="1" step="0.01" value="0.06" /></div>
+      <div class="row"><label>Multi family</label><input id="p_multi_family" type="number" min="0" max="1" step="0.01" value="0.08" /></div>
+      <div class="row"><label>Commercial</label><input id="p_commercial" type="number" min="0" max="1" step="0.01" value="0.05" /></div>
+      <div class="row"><label>Industrial</label><input id="p_industrial" type="number" min="0" max="1" step="0.01" value="0.04" /></div>
+      <div class="row"><label>Mobile home</label><input id="p_mobile_home" type="number" min="0" max="1" step="0.01" value="0.07" /></div>
+      <div class="row"><label>Agricultural</label><input id="p_agricultural" type="number" min="0" max="1" step="0.01" value="0.03" /></div>
+
+      <div class="actions">
+        <button id="generateBtn" type="button">Generate city</button>
+        <button id="cancelBtn" class="button-secondary" type="button" disabled>Cancel</button>
+        <button id="exportBtn" type="button" disabled>Export ZIP</button>
+      </div>
+      <div id="status" class="muted" style="margin-top:.55rem;">Ready.</div>
+      <div id="log" class="log"></div>
+    </section>
+
+    <section class="map-panel">
+      <h2>Map preview</h2>
+      <div id="map" class="map"></div>
+      <div class="metrics">
+        <div class="metric"><span class="muted">Parcels</span><strong id="mParcels">0</strong></div>
+        <div class="metric"><span class="muted">Sales</span><strong id="mSales">0</strong></div>
+        <div class="metric"><span class="muted">CRS</span><strong id="mCrs">—</strong></div>
+      </div>
+    </section>
+  </div>
+</main>
+<script src="/util/vendor/maplibre/maplibre-gl.js"></script>
+<script src="/util/vendor/seedrandom/seedrandom.min.js"></script>
+<script type="module">
+  import startSyntheticApp from '/util/src/apps/syntheticApp.js';
+  startSyntheticApp();
+</script>
+</body>
+</html>

--- a/util/synthetic/index.html
+++ b/util/synthetic/index.html
@@ -21,7 +21,7 @@
     .button-secondary { background:#fff; color:var(--accent); border:1px solid var(--border); }
     .muted { color:var(--muted); font-size:.9rem; }
     .log { margin-top:.8rem; max-height:150px; overflow:auto; background:#0d1a2b; color:#dce6ff; border-radius:8px; padding:.65rem; font-family: ui-monospace, monospace; font-size:.82rem; white-space:pre-wrap; }
-    .metrics { display:grid; grid-template-columns: repeat(3, minmax(130px,1fr)); gap:.5rem; margin-top:.65rem; }
+    .metrics { display:grid; grid-template-columns: repeat(4, minmax(120px,1fr)); gap:.5rem; margin-top:.65rem; }
     .metric { border:1px solid var(--border); border-radius:8px; padding:.45rem; background:#fff; }
     .metric strong { display:block; font-size:1rem; }
     @media (max-width: 980px) { .layout { grid-template-columns: 1fr; } .map-panel { min-height:unset; } }
@@ -73,6 +73,7 @@
       <div class="metrics">
         <div class="metric"><span class="muted">Parcels</span><strong id="mParcels">0</strong></div>
         <div class="metric"><span class="muted">Sales</span><strong id="mSales">0</strong></div>
+        <div class="metric"><span class="muted">Roads</span><strong id="mRoads">0</strong></div>
         <div class="metric"><span class="muted">CRS</span><strong id="mCrs">—</strong></div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Provide a deterministic, in-browser synthetic city simulator to generate parcel geometry and repeat-sales for testing and demos, and to export packaged datasets. 
- Enable interactive scenario configuration and map preview with progress/cancel semantics while heavy work runs inside a Web Worker. 
- Deliver a single ZIP containing geometry-bearing GeoParquet files plus inflation CSV and metadata for downstream analysis and reproducibility. 

### Description
- Add `util/synthetic/index.html` which implements the wizard-style UI, loads vendor libs (`maplibre`, `seedrandom`) and starts the app. 
- Add `util/src/apps/syntheticApp.js` which wires the UI, manages a MapLibre preview, handles user controls (generate/cancel/export), and coordinates a generation/export `Worker`. 
- Add `util/src/apps/syntheticWorker.js` which implements deterministic parcel fabric generation, an inflation time series, yearly events (teardowns, new construction, renovations), platonic vs observed sale creation, and export encoding using Arrow + `parquet-wasm` and `buildZipBlob` into the final ZIP. 
- Add `util/synthetic/AGENTS.md` documenting the MVP design, data contracts, schema choices, export contents, and implementation decisions for the synthetic generator. 

### Testing
- No automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699f625638d88326b1709fcec3882bfc)